### PR TITLE
Update Unity version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A community-driven touchscreen music game available on [App Store](https://itune
 
 ## Getting Started
 
-Cytoid is built in C# with [Unity 2019.4.10f1 (Personal)](https://unity3d.com).
+Cytoid is built in C# with [Unity 6000.0.58f2 (Personal)](https://unity3d.com).
 
 Because of license restrictions, some plugins/assets used in the project are not included in this repository. View [.gitignore](https://github.com/TigerHix/Cytoid/blob/main/.gitignore) for more information.
 


### PR DESCRIPTION
Although the project was upgraded to Unity 6 some time ago, the README still references Unity 2019.4.