### PR TITLE
fix: Android Unity host callback release keep rule

### DIFF
--- a/engines/unity/flutter_plugin/android/consumer-rules.pro
+++ b/engines/unity/flutter_plugin/android/consumer-rules.pro
@@ -1,1 +1,7 @@
 # Unity/IL2CPP symbols are preserved by the Unity AAR artifacts.
+
+# Unity calls this exact JVM class and method from C# via AndroidJavaClass:
+# org.cytoid.gamecore.UnityHostCallback.onMessage(String).
+# Keep the name stable in release builds so game.ready, game.pong, game.logs.batch,
+# and game.play.result can be delivered back to Flutter after R8/ProGuard runs.
+-keep class org.cytoid.gamecore.UnityHostCallback { *; }


### PR DESCRIPTION
## Summary

Adds a consumer ProGuard keep rule for `org.cytoid.gamecore.UnityHostCallback`, the JVM callback Unity calls from C# via `AndroidJavaClass` to deliver envelopes back to Flutter.

## Root Cause

Release builds can run R8/ProGuard over the Flutter plugin classes. Without keeping this callback class name stable, Unity can still receive `bridge.play.start`, but outbound messages such as `game.ready`, `game.pong`, `game.logs.batch`, and `game.play.result` fail to reach Flutter. The host then reports `CytoidGameLostException` during gameplay, hides the Unity surface, and the Unity activity can remain paused mid-song.

## Validation

- `flutter test` in `engines/unity/flutter_plugin`
- `flutter build apk --release` in `engines/unity/flutter_plugin/example`
- Installed and launched the release APK on Pixel 7 before publishing the branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced Android app stability with improved internal message delivery reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->