### PR TITLE
feat(gameplay): record play events for result telemetry

### DIFF
--- a/docs/2026-06-20-play-events-anti-cheat-followup.md
+++ b/docs/2026-06-20-play-events-anti-cheat-followup.md
@@ -1,0 +1,127 @@
+# Play Events & Anti-Cheat Follow-up
+
+Status: **informational / roadmap**. No code changes scheduled. Written after the
+`feat/play-event-recorder` work landed `GamePlayEventRecorder` + the `playEvents`
+field on the game result payload.
+
+## Threat model context
+
+Cytoid Core Unity is an **open-source** client. Any secret embedded in the
+binary (HMAC key, private key, salt) can be extracted from the distributed AAR.
+Two consequences follow:
+
+1. A client-side signature proves only "Unity signed this payload", **not**
+   "this play was genuinely human-played". Memory edits or injected synthetic
+   touch events produce a mathematically valid signature.
+2. The only integrity that scales in an open-source client is **server-side
+   replay re-verification**: server replays `playEvents` against the chart and
+   recomputes the score. Client never holds a meaningful secret.
+
+Current threats under consideration:
+
+| Threat | Client signature | Server replay |
+|--------|:----------------:|:-------------:|
+| Flutter-side JSON tampering (hook the bridge, bump `score`) | partial — defeated by key extraction | — |
+| Unity memory edit of `GameState.Score` before emit | no | yes |
+| Auto-play not flagged by `usedAutoMod` (external bot) | no | yes (with human-likeness analysis) |
+| Fabricated / replayed `playEvents` | no | yes (recompute + consistency) |
+
+## Decision (this round)
+
+**Do not add client-side cryptographic signing of results now.** Server
+capabilities are still being planned; building a key-holding client before the
+server contract exists is premature. The `feat/play-event-recorder` work is the
+*foundation* for server-side replay, and that is the valuable part.
+
+This document records what the client must guarantee for `playEvents` to be a
+**reproducible replay input**, so future work does not regress it silently.
+
+## Replay reproducibility gaps in current `playEvents`
+
+The recorder (`engines/unity/Assets/Scripts/Game/GamePlayEvent.cs`) writes
+`{t, f, p, x, y}` per sampled touch. Three areas need attention before a server
+can deterministically replay a submitted score. **None are blockers for the
+telemetry use case that just shipped** — they only matter once the server
+actually re-judges.
+
+### 1. Coordinate normalization is screen-relative, not canvas-relative
+
+`x`/`y` are normalized against `Screen.width`/`Screen.height` (raw pixels):
+
+```csharp
+x = Normalize(finger.ScreenPosition.x, UnityEngine.Screen.width);
+y = Normalize(finger.ScreenPosition.y, UnityEngine.Screen.height);
+```
+
+But the judgment field is laid out in a Canvas Scaler
+`referenceResolution` space, and the active region is shifted by
+`Screen.safeArea` (notch / punch-hole, see `Game/Screens/Overlay/OverlayScreen.cs`).
+Two devices with the same aspect ratio but different notch geometry will record
+different `x`/`y` for a tap on the *same* note.
+
+**For replay:** the server needs the inverse map. Either
+(a) record the normalization basis (screen w/h, safe area, reference resolution)
+alongside the events, or (b) normalize in canvas space on the client instead of
+screen space. Option (b) is cleaner but changes the wire format and breaks the
+data already captured — prefer attaching the basis metadata and keeping the
+current encoding.
+
+### 2. Move sampling is lossy
+
+`ShouldSampleMove` keeps a move event only when ≥1/60 s elapsed **and** ≥96 px
+traveled since the last sample for that finger:
+
+```csharp
+private const float MoveSampleIntervalSeconds = 1f / 60f;
+private const int MoveSampleDistance = 96;
+```
+
+For tap notes this is fine (down/up are forced). For drag / flick notes whose
+judgment depends on the full trajectory, this can drop intermediate points the
+server would need to re-judge accurately. **Investigate** whether the down +
+sampled moves + up triple is sufficient for the server's drag judge, or whether
+drag-class notes need denser sampling (separate `MoveSampleDistance` for
+continuous note types, or unconditional sampling while a drag note is active).
+
+### 3. Time base and drift tolerance undefined
+
+`t` is `Mathf.RoundToInt(game.Time * 1000f)` — song time in ms. This is the right
+base (deterministic, independent of wall clock). But:
+
+- The real input moment and the recorded `t` differ by touch → frame → audio DSP
+  latency. The client applies calibration offsets; the server replay must apply
+  the *same* offsets or define an explicit tolerance window.
+- `t` is rounded to integer ms. Sub-ms timing is lost. Confirm this matches the
+  judgment-window granularity the server will re-apply.
+
+**For replay:** the launch payload already carries calibration offsets; ensure
+they travel with the result payload (or are re-asserted server-side) so replay
+judgment uses identical timing.
+
+## Cheap transport integrity (optional, low effort)
+
+Independent of server replay, a low-cost mitigation for the "Flutter hook bumps
+`score`" script-kiddie threat: have Unity emit a digest of selected result
+fields computed via an obfuscated rule, so a Flutter-side patch that only edits
+the JSON produces a mismatch. This is **obfuscation, not cryptography** — it
+raises the bar from "trivial `frida` script" to "must reverse the digest rule",
+which is enough to deter casual tampering. Do not treat it as a real integrity
+guarantee; the server-replay path is the guarantee.
+
+Defer until there is evidence of casual tampering, or until the server contract
+lands — whichever is first.
+
+## Acceptance criteria for a future anti-cheat PR
+
+When server-side replay is built, the client side must, at minimum:
+
+- [ ] Include normalization basis (screen w/h, safe area, reference resolution)
+      in the result payload, OR switch to canvas-space normalization.
+- [ ] Confirm drag/flick replay fidelity with the actual sampling rate; densify
+      sampling for continuous note types if needed.
+- [ ] Ensure calibration offsets accompany the result so replay timing matches.
+- [ ] Decide and document the `t` rounding vs. judgment-window relationship.
+
+Until then, `playEvents` is **telemetry and replay raw material only**, not an
+anti-cheat input. Do not wire anything that treats its presence as proof of
+legitimacy.

--- a/engines/unity/Assets/Scripts/Game/Game.cs
+++ b/engines/unity/Assets/Scripts/Game/Game.cs
@@ -342,6 +342,7 @@ public class Game : MonoBehaviour
         GameStartedOrResumedTimestamp = UnityEngine.Time.realtimeSinceStartup;
         State.IsStarted = true;
         State.IsPlaying = true;
+        GamePlayEventRecorder.Begin(this);
         LayoutStaticizer.Staticize(levelInfoParent.transform);
         LayoutStaticizer.Staticize(modHolderParent.transform);
         onGameStarted.Invoke(this);
@@ -512,6 +513,7 @@ public class Game : MonoBehaviour
         UnpauseCountdown = 0;
         State.IsPlaying = false;
         AudioListener.pause = true;
+        GamePlayEventRecorder.Suspend();
 
         if (State.Mode == GameMode.Tier)
         {
@@ -572,6 +574,7 @@ public class Game : MonoBehaviour
         GameStartedOrResumedTimestamp = UnityEngine.Time.realtimeSinceStartup;
         AudioListener.pause = false;
         State.IsPlaying = true;
+        GamePlayEventRecorder.Resume();
 
         onGameUnpaused.Invoke(this);
     }

--- a/engines/unity/Assets/Scripts/Game/GamePlayEvent.cs
+++ b/engines/unity/Assets/Scripts/Game/GamePlayEvent.cs
@@ -63,6 +63,7 @@ public static class GamePlayEventRecorder
     {
         isRecording = false;
         game = null;
+        events.Clear();
         lastEventsByFinger.Clear();
         Unsubscribe();
     }

--- a/engines/unity/Assets/Scripts/Game/GamePlayEvent.cs
+++ b/engines/unity/Assets/Scripts/Game/GamePlayEvent.cs
@@ -1,0 +1,138 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+[Serializable]
+public class GamePlayEvent
+{
+    public int t;
+    public int f;
+    public string p;
+    public int x;
+    public int y;
+}
+
+public static class GamePlayEventRecorder
+{
+    private const float MoveSampleIntervalSeconds = 1f / 60f;
+    private const int MoveSampleDistance = 96;
+
+    private static readonly List<GamePlayEvent> events = new List<GamePlayEvent>(4096);
+    private static readonly Dictionary<int, GamePlayEvent> lastEventsByFinger = new Dictionary<int, GamePlayEvent>();
+
+    private static Game game;
+    private static bool isSubscribed;
+    private static bool isRecording;
+
+    public static void Begin(Game currentGame)
+    {
+        game = currentGame;
+        events.Clear();
+        lastEventsByFinger.Clear();
+        isRecording = true;
+        Subscribe();
+    }
+
+    /// <summary>
+    /// Temporarily stops sampling events (e.g. while the game is paused)
+    /// without releasing the recorder. Finger tracking state is cleared so
+    /// the next down/move after resume is not compared against a stale
+    /// sample taken before the pause.
+    /// </summary>
+    public static void Suspend()
+    {
+        if (!isRecording) return;
+        isRecording = false;
+        lastEventsByFinger.Clear();
+    }
+
+    /// <summary>Resumes sampling after <see cref="Suspend"/>.</summary>
+    public static void Resume()
+    {
+        if (game == null) return;
+        lastEventsByFinger.Clear();
+        isRecording = true;
+    }
+
+    public static GamePlayEvent[] Snapshot()
+    {
+        return events.ToArray();
+    }
+
+    public static void End()
+    {
+        isRecording = false;
+        game = null;
+        lastEventsByFinger.Clear();
+        Unsubscribe();
+    }
+
+    private static void Subscribe()
+    {
+        if (isSubscribed) return;
+        GameTouchInput.FingerDown += OnFingerDown;
+        GameTouchInput.FingerUpdate += OnFingerUpdate;
+        GameTouchInput.FingerUp += OnFingerUp;
+        isSubscribed = true;
+    }
+
+    private static void Unsubscribe()
+    {
+        if (!isSubscribed) return;
+        GameTouchInput.FingerDown -= OnFingerDown;
+        GameTouchInput.FingerUpdate -= OnFingerUpdate;
+        GameTouchInput.FingerUp -= OnFingerUp;
+        isSubscribed = false;
+    }
+
+    private static void OnFingerDown(GameFinger finger)
+    {
+        Record(finger, "down", true);
+    }
+
+    private static void OnFingerUpdate(GameFinger finger)
+    {
+        Record(finger, "move", false);
+    }
+
+    private static void OnFingerUp(GameFinger finger)
+    {
+        Record(finger, "up", true);
+        lastEventsByFinger.Remove(finger.Index);
+    }
+
+    private static void Record(GameFinger finger, string phase, bool force)
+    {
+        if (!isRecording || game == null || game.State == null || !game.State.IsStarted) return;
+
+        var next = new GamePlayEvent
+        {
+            t = Mathf.Max(0, Mathf.RoundToInt(game.Time * 1000f)),
+            f = finger.Index,
+            p = phase,
+            x = Normalize(finger.ScreenPosition.x, UnityEngine.Screen.width),
+            y = Normalize(finger.ScreenPosition.y, UnityEngine.Screen.height)
+        };
+
+        if (!force && !ShouldSampleMove(next)) return;
+
+        events.Add(next);
+        lastEventsByFinger[finger.Index] = next;
+    }
+
+    private static bool ShouldSampleMove(GamePlayEvent next)
+    {
+        if (!lastEventsByFinger.TryGetValue(next.f, out var last)) return true;
+        if (next.t - last.t >= MoveSampleIntervalSeconds * 1000f) return true;
+
+        var dx = next.x - last.x;
+        var dy = next.y - last.y;
+        return dx * dx + dy * dy >= MoveSampleDistance * MoveSampleDistance;
+    }
+
+    private static int Normalize(float value, int max)
+    {
+        if (max <= 0) return 0;
+        return Mathf.Clamp(Mathf.RoundToInt(value / max * 65535f), 0, 65535);
+    }
+}

--- a/engines/unity/Assets/Scripts/Game/GamePlayEvent.cs.meta
+++ b/engines/unity/Assets/Scripts/Game/GamePlayEvent.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c6b7560eb16a14d1c9116351f32346cc

--- a/engines/unity/Assets/Scripts/Game/GameResultBridge.cs
+++ b/engines/unity/Assets/Scripts/Game/GameResultBridge.cs
@@ -10,7 +10,11 @@ public static class GameResultBridge
 
     public static void Emit(GameState state, TierPlaySession tierPlaySession = null, string error = null)
     {
-        var payload = GameResultPayload.FromGameState(state, tierPlaySession, error);
+        var payload = GameResultPayload.FromGameState(
+            state,
+            tierPlaySession,
+            error,
+            GamePlayEventRecorder.Snapshot());
         LastResultJson = payload.ToJson();
         Debug.Log($"[GameResultBridge] {LastResultJson}");
         OnResultJson.Invoke(LastResultJson);

--- a/engines/unity/Assets/Scripts/Game/GameResultBridge.cs
+++ b/engines/unity/Assets/Scripts/Game/GameResultBridge.cs
@@ -25,7 +25,8 @@ public static class GameResultBridge
             usedAutoMod = false,
             gameMode = GameMode.Tier.ToString(),
             tierRetry = tierPlaySession?.TierId,
-            timestamp = DateTimeOffset.UtcNow.ToString("o")
+            timestamp = DateTimeOffset.UtcNow.ToString("o"),
+            playEvents = GamePlayEventRecorder.Snapshot()
         };
         LastResultJson = payload.ToJson();
         Debug.Log($"[GameResultBridge] {LastResultJson}");
@@ -39,7 +40,8 @@ public static class GameResultBridge
             timestamp = DateTimeOffset.UtcNow.ToString("o"),
             completed = false,
             failed = true,
-            error = exception.ToString()
+            error = exception.ToString(),
+            playEvents = GamePlayEventRecorder.Snapshot()
         };
         LastResultJson = payload.ToJson();
         Debug.LogError($"[GameResultBridge] {LastResultJson}");

--- a/engines/unity/Assets/Scripts/Game/GameResultPayload.cs
+++ b/engines/unity/Assets/Scripts/Game/GameResultPayload.cs
@@ -18,7 +18,8 @@ public class GameResultPayload : LastPlayResult
     public static GameResultPayload FromGameState(
         GameState state,
         TierPlaySession tierPlaySession = null,
-        string error = null)
+        string error = null,
+        GamePlayEvent[] playEvents = null)
     {
         var result = new GameResultPayload
         {
@@ -27,7 +28,7 @@ public class GameResultPayload : LastPlayResult
             usedAutoMod = state != null && GameResultBridge.HasAutoMod(state),
             error = error,
             gameMode = state?.Mode.ToString(),
-            playEvents = GamePlayEventRecorder.Snapshot()
+            playEvents = playEvents ?? Array.Empty<GamePlayEvent>()
         };
 
         if (state == null)

--- a/engines/unity/Assets/Scripts/Game/GameResultPayload.cs
+++ b/engines/unity/Assets/Scripts/Game/GameResultPayload.cs
@@ -13,6 +13,7 @@ public class GameResultPayload : LastPlayResult
     public float? calibratedLevelNoteOffset;
     public TierPlayResult tierPlay;
     public string tierRetry;
+    public GamePlayEvent[] playEvents;
 
     public static GameResultPayload FromGameState(
         GameState state,
@@ -25,7 +26,8 @@ public class GameResultPayload : LastPlayResult
             failed = state != null && state.IsFailed,
             usedAutoMod = state != null && GameResultBridge.HasAutoMod(state),
             error = error,
-            gameMode = state?.Mode.ToString()
+            gameMode = state?.Mode.ToString(),
+            playEvents = GamePlayEventRecorder.Snapshot()
         };
 
         if (state == null)

--- a/engines/unity/Assets/Scripts/Host/GameBridge.cs
+++ b/engines/unity/Assets/Scripts/Host/GameBridge.cs
@@ -140,6 +140,7 @@ public class GameBridge : MonoBehaviour
             WireMessageTypes.GamePlayEnded,
             new JObject {["ended"] = true});
         NativeBridgeMessenger.Send(envelope.ToJsonString());
+        GamePlayEventRecorder.End();
     }
 
     private async void OnGameResultJson(string resultJson)
@@ -160,6 +161,7 @@ public class GameBridge : MonoBehaviour
         var envelope = CytoidGameCoreEnvelope.Create(playId, WireMessageTypes.GamePlayResult, payload);
         NativeBridgeMessenger.Send(envelope.ToJsonString());
         sessionState.ClearActivePlay();
+        GamePlayEventRecorder.End();
     }
 
     internal static async UniTask ShowHandoffOverlay()

--- a/engines/unity/Assets/Scripts/Host/GameBridge.cs
+++ b/engines/unity/Assets/Scripts/Host/GameBridge.cs
@@ -132,36 +132,48 @@ public class GameBridge : MonoBehaviour
             return;
         }
 
-        await ShowHandoffOverlay();
-        var playId = sessionState.ActivePlayId;
-        sessionState.MarkPlayRouteEnded();
-        var envelope = CytoidGameCoreEnvelope.Create(
-            playId,
-            WireMessageTypes.GamePlayEnded,
-            new JObject {["ended"] = true});
-        NativeBridgeMessenger.Send(envelope.ToJsonString());
-        GamePlayEventRecorder.End();
+        try
+        {
+            await ShowHandoffOverlay();
+            var playId = sessionState.ActivePlayId;
+            sessionState.MarkPlayRouteEnded();
+            var envelope = CytoidGameCoreEnvelope.Create(
+                playId,
+                WireMessageTypes.GamePlayEnded,
+                new JObject {["ended"] = true});
+            NativeBridgeMessenger.Send(envelope.ToJsonString());
+        }
+        finally
+        {
+            GamePlayEventRecorder.End();
+        }
     }
 
     private async void OnGameResultJson(string resultJson)
     {
-        JObject payload;
         try
         {
-            payload = JObject.Parse(resultJson);
-        }
-        catch (Exception e)
-        {
-            Debug.LogError($"[GameBridge] Failed to parse game result JSON: {e.Message}");
-            return;
-        }
+            JObject payload;
+            try
+            {
+                payload = JObject.Parse(resultJson);
+            }
+            catch (Exception e)
+            {
+                Debug.LogError($"[GameBridge] Failed to parse game result JSON: {e.Message}");
+                return;
+            }
 
-        await ShowHandoffOverlay();
-        var playId = sessionState.ActivePlayId ?? Guid.NewGuid().ToString();
-        var envelope = CytoidGameCoreEnvelope.Create(playId, WireMessageTypes.GamePlayResult, payload);
-        NativeBridgeMessenger.Send(envelope.ToJsonString());
-        sessionState.ClearActivePlay();
-        GamePlayEventRecorder.End();
+            await ShowHandoffOverlay();
+            var playId = sessionState.ActivePlayId ?? Guid.NewGuid().ToString();
+            var envelope = CytoidGameCoreEnvelope.Create(playId, WireMessageTypes.GamePlayResult, payload);
+            NativeBridgeMessenger.Send(envelope.ToJsonString());
+            sessionState.ClearActivePlay();
+        }
+        finally
+        {
+            GamePlayEventRecorder.End();
+        }
     }
 
     internal static async UniTask ShowHandoffOverlay()

--- a/engines/unity/flutter_plugin/example/docs/host-protocol.md
+++ b/engines/unity/flutter_plugin/example/docs/host-protocol.md
@@ -350,6 +350,7 @@ Extends score fields from `LastPlayResult`.
 | `standardTimingError` | double? | Std dev of timing error (ms). |
 | `tierPlay` | object? | Present when `gameMode` is `"Tier"` and the stage finishes in-engine. See [TierPlayResult](#tierplayresult). |
 | `tierRetry` | string? | Host retry hint for Tier. When set, Flutter should dismiss the play route and re-issue `bridge.play.start` for the same stage (Unity does not retry Tier in-engine). |
+| `playEvents` | array<object> | Unity-emitted gameplay touch events. Each event uses `{t, f, p, x, y}` where `t` is song time in milliseconds, `f` is finger index, `p` is `down` / `move` / `up`, and `x` / `y` are normalized screen coordinates from 0 to 65535. Flutter keeps this JSON payload and derives a compact binary representation for upload-size comparison. |
 
 **Tier host routing**
 

--- a/engines/unity/flutter_plugin/example/lib/src/screens/result_screen.dart
+++ b/engines/unity/flutter_plugin/example/lib/src/screens/result_screen.dart
@@ -79,6 +79,7 @@ class ResultScreen extends StatelessWidget {
                     ),
                   ],
                   _ScoreBlock(result: result),
+                  _EventTelemetryBlock(result: result),
                   const SizedBox(height: 16),
                   FilledButton.icon(
                     onPressed: () => Navigator.of(context).pop(),
@@ -91,6 +92,35 @@ class ResultScreen extends StatelessWidget {
           ],
         ),
       ),
+    );
+  }
+}
+
+class _EventTelemetryBlock extends StatelessWidget {
+  const _EventTelemetryBlock({required this.result});
+
+  final GameResultPayload result;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        _ResultTile(
+          icon: Icons.touch_app,
+          label: 'Play events',
+          value: '${result.playEvents.length}',
+        ),
+        _ResultTile(
+          icon: Icons.data_object,
+          label: 'Event JSON size',
+          value: _formatBytes(result.playEventJsonBytes),
+        ),
+        _ResultTile(
+          icon: Icons.compress,
+          label: 'Event binary size',
+          value: _formatBytes(result.playEventBinaryBytes),
+        ),
+      ],
     );
   }
 }
@@ -205,4 +235,15 @@ class _ResultTile extends StatelessWidget {
       ),
     );
   }
+}
+
+String _formatBytes(int bytes) {
+  if (bytes < 1024) {
+    return '$bytes B';
+  }
+  final kib = bytes / 1024;
+  if (kib < 1024) {
+    return '${kib.toStringAsFixed(1)} KiB';
+  }
+  return '${(kib / 1024).toStringAsFixed(2)} MiB';
 }

--- a/engines/unity/flutter_plugin/lib/src/models/game_result_payload.dart
+++ b/engines/unity/flutter_plugin/lib/src/models/game_result_payload.dart
@@ -1,8 +1,11 @@
+import 'dart:typed_data';
+
+import 'play_event_binary_codec.dart';
 import 'tier_play_result.dart';
 
 /// Outcome of a gameplay session emitted by the game core.
 class GameResultPayload {
-  const GameResultPayload({
+  GameResultPayload({
     required this.completed,
     required this.failed,
     required this.usedAutoMod,
@@ -25,6 +28,7 @@ class GameResultPayload {
     this.late,
     this.averageTimingError,
     this.standardTimingError,
+    this.playEvents = const <Map<String, Object?>>[],
   });
 
   final bool completed;
@@ -49,6 +53,20 @@ class GameResultPayload {
   final int? late;
   final double? averageTimingError;
   final double? standardTimingError;
+  final List<Map<String, Object?>> playEvents;
+
+  /// Compact binary representation of [playEvents]. Computed on first access
+  /// so payloads that never inspect telemetry (the common case in production
+  /// upload paths) pay nothing for encoding.
+  late final Uint8List playEventBinary =
+      PlayEventBinaryCodec.encode(playEvents);
+
+  /// UTF-8 byte length of [playEvents] serialized as JSON.
+  late final int playEventJsonBytes =
+      PlayEventBinaryCodec.jsonByteLength(playEvents);
+
+  /// Byte length of [playEventBinary], exposed for upload-size comparison.
+  late final int playEventBinaryBytes = playEventBinary.length;
 
   factory GameResultPayload.fromJson(Map<String, dynamic> json) {
     return GameResultPayload(
@@ -76,6 +94,7 @@ class GameResultPayload {
       late: _readInt(json, 'late'),
       averageTimingError: _readDouble(json, 'averageTimingError'),
       standardTimingError: _readDouble(json, 'standardTimingError'),
+      playEvents: _readPlayEvents(json['playEvents']),
     );
   }
 
@@ -106,6 +125,7 @@ class GameResultPayload {
       if (averageTimingError != null) 'averageTimingError': averageTimingError,
       if (standardTimingError != null)
         'standardTimingError': standardTimingError,
+      if (playEvents.isNotEmpty) 'playEvents': playEvents,
     };
   }
 
@@ -141,5 +161,22 @@ class GameResultPayload {
     return value.map(
       (key, raw) => MapEntry(key.toString(), (raw as num).toInt()),
     );
+  }
+
+  static List<Map<String, Object?>> _readPlayEvents(Object? value) {
+    if (value == null) {
+      return const <Map<String, Object?>>[];
+    }
+    if (value is! List) {
+      throw const FormatException('playEvents must be an array.');
+    }
+    return value
+        .map((event) {
+          if (event is! Map) {
+            throw const FormatException('playEvents entries must be objects.');
+          }
+          return event.map((key, raw) => MapEntry(key.toString(), raw));
+        })
+        .toList(growable: false);
   }
 }

--- a/engines/unity/flutter_plugin/lib/src/models/play_event_binary_codec.dart
+++ b/engines/unity/flutter_plugin/lib/src/models/play_event_binary_codec.dart
@@ -47,9 +47,7 @@ class PlayEventBinaryCodec {
       'down' => 1,
       'move' => 2,
       'up' => 3,
-      'cancel' => 4,
-      'hit' => 5,
-      _ => 0,
+      _ => throw FormatException('Unknown play event phase: $value'),
     };
   }
 

--- a/engines/unity/flutter_plugin/lib/src/models/play_event_binary_codec.dart
+++ b/engines/unity/flutter_plugin/lib/src/models/play_event_binary_codec.dart
@@ -1,0 +1,68 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+/// Compact binary codec for Unity-emitted gameplay input events.
+class PlayEventBinaryCodec {
+  const PlayEventBinaryCodec._();
+
+  static Uint8List encode(List<Map<String, Object?>> events) {
+    if (events.isEmpty) {
+      return Uint8List(0);
+    }
+
+    final bytes = <int>[0x43, 0x59, 0x54, 0x45, 1]; // CYTE, version 1
+    _writeVarUint(bytes, events.length);
+
+    var previousTimeMs = 0;
+    for (final event in events) {
+      final timeMs = _readInt(event['t']);
+      _writeVarInt(bytes, timeMs - previousTimeMs);
+      previousTimeMs = timeMs;
+
+      _writeVarInt(bytes, _readInt(event['f']));
+      bytes.add(_phaseCode(event['p']));
+      _writeVarUint(bytes, _readInt(event['x']));
+      _writeVarUint(bytes, _readInt(event['y']));
+    }
+
+    return Uint8List.fromList(bytes);
+  }
+
+  static int jsonByteLength(List<Map<String, Object?>> events) {
+    return utf8.encode(jsonEncode(events)).length;
+  }
+
+  static int _readInt(Object? value) {
+    if (value is int) {
+      return value;
+    }
+    if (value is num) {
+      return value.toInt();
+    }
+    throw const FormatException('Play event field must be numeric.');
+  }
+
+  static int _phaseCode(Object? value) {
+    return switch (value) {
+      'down' => 1,
+      'move' => 2,
+      'up' => 3,
+      'cancel' => 4,
+      'hit' => 5,
+      _ => 0,
+    };
+  }
+
+  static void _writeVarInt(List<int> target, int value) {
+    _writeVarUint(target, (value << 1) ^ (value >> 31));
+  }
+
+  static void _writeVarUint(List<int> target, int value) {
+    var remaining = value;
+    while (remaining >= 0x80) {
+      target.add((remaining & 0x7f) | 0x80);
+      remaining >>= 7;
+    }
+    target.add(remaining);
+  }
+}

--- a/engines/unity/flutter_plugin/test/cytoid_game_core_envelope_test.dart
+++ b/engines/unity/flutter_plugin/test/cytoid_game_core_envelope_test.dart
@@ -98,6 +98,25 @@ void main() {
     expect(result.toJson()['playEvents'], result.playEvents);
   });
 
+  test('binary codec rejects unknown play event phase at encode time', () {
+    // The Unity core only ever emits down/move/up. A payload that carries any
+    // other phase (protocol drift) must surface immediately when the compact
+    // binary representation is derived, rather than silently mapping to 0.
+    final result = GameResultPayload.fromJson({
+      'completed': true,
+      'failed': false,
+      'usedAutoMod': false,
+      'playEvents': [
+        {'t': 1000, 'f': 0, 'p': 'drag', 'x': 32768, 'y': 16384},
+      ],
+    });
+
+    expect(
+      () => result.playEventBinary,
+      throwsA(isA<FormatException>()),
+    );
+  });
+
   test('rejects missing or malformed launch assets', () {
     expect(
       () => GameLaunchPayload.fromJson({

--- a/engines/unity/flutter_plugin/test/cytoid_game_core_envelope_test.dart
+++ b/engines/unity/flutter_plugin/test/cytoid_game_core_envelope_test.dart
@@ -79,6 +79,25 @@ void main() {
     expect(result.gradeCounts, {'perfect': 10});
   });
 
+  test('reads play events and reports json and binary sizes', () {
+    final result = GameResultPayload.fromJson({
+      'completed': true,
+      'failed': false,
+      'usedAutoMod': false,
+      'playEvents': [
+        {'t': 1000, 'f': 0, 'p': 'down', 'x': 32768, 'y': 16384},
+        {'t': 1016, 'f': 0, 'p': 'move', 'x': 33000, 'y': 16400},
+        {'t': 1048, 'f': 0, 'p': 'up', 'x': 33120, 'y': 16480},
+      ],
+    });
+
+    expect(result.playEvents, hasLength(3));
+    expect(result.playEventJsonBytes, greaterThan(0));
+    expect(result.playEventBinaryBytes, greaterThan(0));
+    expect(result.playEventBinaryBytes, lessThan(result.playEventJsonBytes));
+    expect(result.toJson()['playEvents'], result.playEvents);
+  });
+
   test('rejects missing or malformed launch assets', () {
     expect(
       () => GameLaunchPayload.fromJson({


### PR DESCRIPTION
## Summary

Adds a gameplay touch-event recorder in the Unity core and threads a `playEvents` array through the host protocol (C# payload → Dart model → result screen telemetry), so the host can report event counts and compare JSON vs compact-binary upload sizes. Also documents the anti-cheat roadmap and replay-reproducibility gaps.

## Commits

- **feat(gameplay): record play events for result telemetry** — `GamePlayEventRecorder` sampling `{t, f, p, x, y}`; `Begin/Suspend/Resume/End` lifecycle owned by `GameBridge`; new `PlayEventBinaryCodec`; `host-protocol.md` + result screen telemetry block; envelope test.
- **refactor(gameplay): tighten play event payload contract** — `FromGameState` takes `playEvents` explicitly (pure factory, no hidden recorder read); three emit paths symmetric; `_phaseCode` drops dead `cancel`/`hit` branches and throws on unknown phase instead of silently mapping to 0.
- **docs: anti-cheat roadmap and playEvents replay gaps** — why client-side signing is deferred (open-source client; extractable keys; only server-side replay scales) and three replay gaps: screen-space vs canvas-space coordinates, lossy move sampling for drag/flick, undefined time-base drift tolerance.

## Review notes

- `End()` is centralized in `GameBridge` (`OnGameResultJson` + `EndActivePlayFromGame`), not scattered across the three `GameResultBridge.Emit*` methods — avoids the recorder being torn down mid-result-forward.
- `Suspend()`/`Resume()` model the pause window; `Game.Pause` → suspend, `Game.Unpause` → resume, last-sample map cleared across the boundary so move throttling never compares against a pre-pause sample.
- Dart binary fields (`playEventBinary`, `playEventJsonBytes`, `playEventBinaryBytes`) are `late final` — payloads that never inspect telemetry pay no encoding cost.
- An unrelated `RoundedCorners Button_Button_0 2.mat` serialization change is intentionally **not** included (left dirty in the working tree).

## Verification

- `flutter analyze` (4 touched Dart files): clean.
- `flutter test test/cytoid_game_core_envelope_test.dart`: 5/5 pass (incl. new `reads play events and reports json and binary sizes`).
- Unity 6000.0.75f1 Android plugin export (`CytoidCoreBuild.ExportAndroidLibraryForFlutter`): exit 0, full C# script compilation succeeded with **zero errors** (only pre-existing CS0618 deprecation warnings on `UnityWebRequest.isNetworkError/isHttpError`). AAR packaged: `cytoid-unity-core.aar` (77 MB).
- Manual play session on Pixel 7: no issues observed.

## Anti-cheat note (not in this PR)

Client-side result signing is deliberately **not** added — see `docs/2026-06-20-play-events-anti-cheat-followup.md`. Open-source clients cannot protect keys; only server-side replay re-verification scales. This PR ships `playEvents` as the *foundation* for that future work, not as a trust signal.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a client-side threat model and recording/replay limitations doc for play events.
  * Extended host protocol docs to describe the new play-events payload field.

* **New Features**
  * Gameplay now records touch input events throughout active play and attaches them to game results.
  * Result screen now shows play-event count and JSON/binary payload sizes.
  * Added compact binary encoding for play events.

* **Bug Fixes**
  * Ensured play-event recording is properly terminated even on early exits.

* **Tests**
  * Added unit tests for play-event parsing/size metrics and binary codec validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->