### PR TITLE
fix(storyboard): activate vendor filters in built plugins

### DIFF
--- a/engines/unity/Assets/Scripts/Editor/CytoidStoryboardEditor.cs
+++ b/engines/unity/Assets/Scripts/Editor/CytoidStoryboardEditor.cs
@@ -19,7 +19,9 @@ public static class CytoidStoryboardEditor
                                 .Select(a => a.GetType(BootstrapTypeName))
                                 .FirstOrDefault(t => t != null);
         var complete = VendorStoryboardInstall.IsComplete();
+        var onDisk = VendorStoryboardInstall.FilesPresentOnDisk();
         Debug.Log($"[Cytoid] Vendor install complete: {complete} ({VendorStoryboardInstall.StoryboardFiltersRelative})");
+        Debug.Log($"[Cytoid] Vendor files on disk: {onDisk}");
         Debug.Log($"[Cytoid] Vendor bootstrap type loaded: {bootstrapType != null} ({bootstrapType?.Assembly.GetName().Name ?? "not found"})");
         Debug.Log($"[Cytoid] Active backend: {(StoryboardEffects.Current != null ? StoryboardEffects.Current.GetType().Name : "(none yet — enter Play mode)")}");
     }

--- a/engines/unity/Assets/Scripts/Editor/CytoidStoryboardEditor.cs
+++ b/engines/unity/Assets/Scripts/Editor/CytoidStoryboardEditor.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Linq;
 using Cytoid.Storyboard;
 using Cytoid.Storyboard.PostProcess;
 using UnityEditor;
@@ -5,12 +7,20 @@ using UnityEngine;
 
 public static class CytoidStoryboardEditor
 {
+    const string BootstrapTypeName = "Cytoid.Storyboard.Vendor.VendorStoryboardEffectsBootstrap";
+
     [MenuItem("Cytoid/Log Storyboard Effects Backend", false, 12)]
     public static void LogBackend()
     {
+        // Mirror StoryboardVendorEffectsLoader's build-safe lookup so this menu
+        // reports the same resolution the runtime path uses in exported plugins.
+        var bootstrapType = Type.GetType(BootstrapTypeName)
+                            ?? AppDomain.CurrentDomain.GetAssemblies()
+                                .Select(a => a.GetType(BootstrapTypeName))
+                                .FirstOrDefault(t => t != null);
         var complete = VendorStoryboardInstall.IsComplete();
         Debug.Log($"[Cytoid] Vendor install complete: {complete} ({VendorStoryboardInstall.StoryboardFiltersRelative})");
-        Debug.Log($"[Cytoid] Vendor bootstrap type loaded: {System.Type.GetType("Cytoid.Storyboard.Vendor.VendorStoryboardEffectsBootstrap") != null}");
+        Debug.Log($"[Cytoid] Vendor bootstrap type loaded: {bootstrapType != null} ({bootstrapType?.Assembly.GetName().Name ?? "not found"})");
         Debug.Log($"[Cytoid] Active backend: {(StoryboardEffects.Current != null ? StoryboardEffects.Current.GetType().Name : "(none yet — enter Play mode)")}");
     }
 }

--- a/engines/unity/Assets/Scripts/Editor/CytoidStoryboardEditor.cs
+++ b/engines/unity/Assets/Scripts/Editor/CytoidStoryboardEditor.cs
@@ -1,5 +1,3 @@
-using System;
-using System.Linq;
 using Cytoid.Storyboard;
 using Cytoid.Storyboard.PostProcess;
 using UnityEditor;
@@ -7,17 +5,12 @@ using UnityEngine;
 
 public static class CytoidStoryboardEditor
 {
-    const string BootstrapTypeName = "Cytoid.Storyboard.Vendor.VendorStoryboardEffectsBootstrap";
-
     [MenuItem("Cytoid/Log Storyboard Effects Backend", false, 12)]
     public static void LogBackend()
     {
-        // Mirror StoryboardVendorEffectsLoader's build-safe lookup so this menu
-        // reports the same resolution the runtime path uses in exported plugins.
-        var bootstrapType = Type.GetType(BootstrapTypeName)
-                            ?? AppDomain.CurrentDomain.GetAssemblies()
-                                .Select(a => a.GetType(BootstrapTypeName))
-                                .FirstOrDefault(t => t != null);
+        // Use the same build-safe lookup the runtime path uses, so the menu
+        // reports what exported plugins actually resolve.
+        var bootstrapType = VendorStoryboardInstall.ResolveBootstrapType();
         var complete = VendorStoryboardInstall.IsComplete();
         var onDisk = VendorStoryboardInstall.FilesPresentOnDisk();
         Debug.Log($"[Cytoid] Vendor install complete: {complete} ({VendorStoryboardInstall.StoryboardFiltersRelative})");

--- a/engines/unity/Assets/Scripts/Storyboard/PostProcess/StoryboardVendorEffectsLoader.cs
+++ b/engines/unity/Assets/Scripts/Storyboard/PostProcess/StoryboardVendorEffectsLoader.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Reflection;
 using Cytoid.Storyboard;
 
@@ -10,7 +11,14 @@ namespace Cytoid.Storyboard.PostProcess
 
         public static bool TryRegister(StoryboardRendererProvider provider)
         {
-            var type = Type.GetType(BootstrapTypeName);
+            // Type.GetType with a bare name searches only the calling assembly and
+            // mscorlib, which fails for cross-assembly lookups in built players
+            // (IL2CPP/AOT). Fall back to an AppDomain scan so the vendor backend is
+            // resolved consistently in Editor Play Mode and in exported plugins.
+            var type = Type.GetType(BootstrapTypeName)
+                       ?? AppDomain.CurrentDomain.GetAssemblies()
+                           .Select(a => a.GetType(BootstrapTypeName))
+                           .FirstOrDefault(t => t != null);
             if (type == null)
                 return false;
 

--- a/engines/unity/Assets/Scripts/Storyboard/PostProcess/StoryboardVendorEffectsLoader.cs
+++ b/engines/unity/Assets/Scripts/Storyboard/PostProcess/StoryboardVendorEffectsLoader.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Linq;
 using System.Reflection;
 using Cytoid.Storyboard;
 
@@ -7,18 +6,9 @@ namespace Cytoid.Storyboard.PostProcess
 {
     internal static class StoryboardVendorEffectsLoader
     {
-        const string BootstrapTypeName = "Cytoid.Storyboard.Vendor.VendorStoryboardEffectsBootstrap";
-
         public static bool TryRegister(StoryboardRendererProvider provider)
         {
-            // Type.GetType with a bare name searches only the calling assembly and
-            // mscorlib, which fails for cross-assembly lookups in built players
-            // (IL2CPP/AOT). Fall back to an AppDomain scan so the vendor backend is
-            // resolved consistently in Editor Play Mode and in exported plugins.
-            var type = Type.GetType(BootstrapTypeName)
-                       ?? AppDomain.CurrentDomain.GetAssemblies()
-                           .Select(a => a.GetType(BootstrapTypeName))
-                           .FirstOrDefault(t => t != null);
+            var type = VendorStoryboardInstall.ResolveBootstrapType();
             if (type == null)
                 return false;
 

--- a/engines/unity/Assets/Scripts/Storyboard/PostProcess/VendorStoryboardInstall.cs
+++ b/engines/unity/Assets/Scripts/Storyboard/PostProcess/VendorStoryboardInstall.cs
@@ -1,20 +1,41 @@
+using System;
 using System.IO;
+using System.Linq;
 using UnityEngine;
 
 namespace Cytoid.Storyboard.PostProcess
 {
     /// <summary>
-    /// Detects optional paid packages under Assets/Vendor/ (not in public git).
+    /// Detects the optional paid packages under Assets/Vendor/ (not in public git).
     /// </summary>
     public static class VendorStoryboardInstall
     {
         public const string VendorRootRelative = "Assets/Vendor";
         public const string StoryboardFiltersRelative = "Assets/Vendor/StoryboardFilters";
 
+        // Full name of the bootstrap type that only exists when the Vendor package
+        // is compiled into the assembly. Presence is decided at compile time, so
+        // this is a build-safe gate (filesystem checks fail in built players where
+        // Assets/ does not exist and source files are gone).
+        const string BootstrapTypeName = "Cytoid.Storyboard.Vendor.VendorStoryboardEffectsBootstrap";
+
         public static string StoryboardFiltersAbsolute =>
             Path.Combine(Application.dataPath, "Vendor", "StoryboardFilters");
 
+        /// <summary>
+        /// True when the Vendor storyboard package is compiled in. Works in both
+        /// Editor and built players (IL2CPP/AOT).
+        /// </summary>
         public static bool IsComplete()
+        {
+            return ResolveBootstrapType() != null;
+        }
+
+        /// <summary>
+        /// Editor-only filesystem inspection used by the diagnostic menu to show
+        /// humans where the Vendor package lives on disk. Not used as a runtime gate.
+        /// </summary>
+        public static bool FilesPresentOnDisk()
         {
             var root = StoryboardFiltersAbsolute;
             if (!Directory.Exists(root))
@@ -23,6 +44,14 @@ namespace Cytoid.Storyboard.PostProcess
             return File.Exists(Path.Combine(root, "VendorStoryboardEffectsBootstrap.cs"))
                    && Directory.Exists(Path.Combine(root, "Camera Filter Pack"))
                    && Directory.Exists(Path.Combine(root, "Sleek Render"));
+        }
+
+        static Type ResolveBootstrapType()
+        {
+            return Type.GetType(BootstrapTypeName)
+                   ?? AppDomain.CurrentDomain.GetAssemblies()
+                       .Select(a => a.GetType(BootstrapTypeName))
+                       .FirstOrDefault(t => t != null);
         }
     }
 }

--- a/engines/unity/Assets/Scripts/Storyboard/PostProcess/VendorStoryboardInstall.cs
+++ b/engines/unity/Assets/Scripts/Storyboard/PostProcess/VendorStoryboardInstall.cs
@@ -46,7 +46,16 @@ namespace Cytoid.Storyboard.PostProcess
                    && Directory.Exists(Path.Combine(root, "Sleek Render"));
         }
 
-        static Type ResolveBootstrapType()
+        /// <summary>
+        /// Resolves the vendor bootstrap type via a build-safe two-step lookup:
+        /// <see cref="Type.GetType(string)"/> first, then an AppDomain assembly
+        /// scan. <see cref="Type.GetType(string)"/> with a bare name only searches
+        /// the calling assembly and mscorlib, which fails for cross-assembly
+        /// lookups in built players (IL2CPP/AOT). Used by IsComplete(), the
+        /// runtime loader, and the editor diagnostic menu (the latter lives in
+        /// Assembly-CSharp-Editor, so this must be public, not internal).
+        /// </summary>
+        public static Type ResolveBootstrapType()
         {
             return Type.GetType(BootstrapTypeName)
                    ?? AppDomain.CurrentDomain.GetAssemblies()

--- a/engines/unity/Assets/link.xml
+++ b/engines/unity/Assets/link.xml
@@ -50,4 +50,15 @@
         <type fullname="ImageWithRoundedCorners" preserve="all"/>
         <type fullname="ImageWithIndependentRoundedCorners" preserve="all"/>
     </assembly>
+    <!--
+        VendorStoryboardEffectsBootstrap is discovered only via reflection
+        (StoryboardVendorEffectsLoader / VendorStoryboardInstall use a string
+        literal; there is no static reference). Anchor it so IL2CPP managed
+        code stripping cannot remove it at higher stripping levels and silently
+        disable the vendor storyboard backend. Tracked here because
+        Assets/Vendor/ itself is gitignored.
+    -->
+    <assembly fullname="Assembly-CSharp">
+        <type fullname="Cytoid.Storyboard.Vendor.VendorStoryboardEffectsBootstrap" preserve="all"/>
+    </assembly>
 </linker>

--- a/engines/unity/ProjectSettings/GraphicsSettings.asset
+++ b/engines/unity/ProjectSettings/GraphicsSettings.asset
@@ -35,6 +35,10 @@ GraphicsSettings:
   - {fileID: 16001, guid: 0000000000000000f000000000000000, type: 0}
   - {fileID: 17000, guid: 0000000000000000f000000000000000, type: 0}
   - {fileID: 16003, guid: 0000000000000000f000000000000000, type: 0}
+  - {fileID: 4800000, guid: 526c71c2a8677401ea102e19623c4a2e, type: 3}
+  - {fileID: 4800000, guid: 2c8d55f3128c041b5921c8b88fa50cea, type: 3}
+  - {fileID: 4800000, guid: 492e4cd2301a8445cbe8658eac9d656e, type: 3}
+  - {fileID: 4800000, guid: e56f548ebc3b34a67bcae157ac1a541e, type: 3}
   m_PreloadedShaders: []
   m_SpritesDefaultMaterial: {fileID: 10754, guid: 0000000000000000f000000000000000,
     type: 0}


### PR DESCRIPTION
## Problem

Storyboard filters did not apply in **built plugins** (device), while working fine in Editor Play Mode. Symptom on level `8bit`: the fisheye filter (and other vendor-only effects) never took effect.

Logcat showed:
```
[StoryboardFallbackPostProcess] Fallback shaders missing; post process disabled.
```
and **no** `VendorStoryboardEffects` activation log.

## Root cause

The vendor storyboard backend never activated in built players because `VendorStoryboardInstall.IsComplete()` checked for `Vendor/*.cs` source files under `Application.dataPath`. That path only exists in the Editor; in a built player `Assets/` is gone (sources compiled into IL2CPP), so the gate returned `false` and `StoryboardEffectsHost` fell through to the fallback backend. The fallback then failed too: its `Cytoid/Storyboard/Fallback*` shaders are referenced only via `Shader.Find()`, so the build pipeline stripped them.

This was masked during development because Editor Play Mode kept working.

## Fix (3 commits)

1. **`692e4b14`** — `StoryboardVendorEffectsLoader.TryRegister()`: `Type.GetType(bareName)` only searches the calling assembly + mscorlib, which fails for cross-assembly lookups in built players. Added an `AppDomain` assembly scan fallback so the bootstrap resolves in both Editor and exported plugins.

2. **`24dda571`** — `VendorStoryboardInstall.IsComplete()` is now reflection-based (resolves the bootstrap type via the same build-safe lookup). The filesystem check moves to `FilesPresentOnDisk()`, used only by the diagnostic menu. Also adds the 4 fallback shaders to `GraphicsSettings.AlwaysIncludedShaders` so `Shader.Find()` resolves on device.

3. **`1b6c47d4`** — `link.xml` entry to anchor `VendorStoryboardEffectsBootstrap` against IL2CPP managed code stripping (the type is reflection-only, no static reference). Follow-up per code review.

## Verification

- Batchmode diagnostic: `Vendor install complete: True`, `bootstrap type loaded: True (Assembly-CSharp)`
- AAR rebuilt (IL2CPP ARM64, exit 0): bootstrap symbol present (7× in `global-metadata.dat`); fallback shaders now bundled in `globalgamemanagers` (previously only in C# string literals)
- Diagnostic menu `Cytoid > Log Storyboard Effects Backend` mirrors the runtime lookup and reports the resolved assembly

## Notes

- The `[Preserve]` attribute also lives on the vendor class itself, but `Assets/Vendor/` is gitignored (licensed package), so the `link.xml` entry is the repo-visible guarantee.
- Known follow-up (out of scope here): the repo has 349 CRLF files and no `.gitattributes`, so `git diff --check` flags trailing-whitespace on CRLF lines. This is pre-existing and tracked separately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved vendor storyboard effects loading reliability across different builds, including AOT players.
  * Enhanced runtime bootstrap type resolution using robust fallback logic, improving consistency when reflection is involved.
* **Build/Platform**
  * Updated IL2CPP/linker preservation settings to prevent the vendor storyboard backend from being stripped at higher stripping levels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->