### PR TITLE
fix: correct .git-blame-ignore-revs SHA after rebase merge

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -8,4 +8,5 @@
 # logical diff; skipping them restores blame attribution to the real authors.
 
 # chore: normalize line endings to LF + strip trailing whitespace (354 files, pure ws)
-3f2580b260fd47489acb0dbdc3c9eb2c7e171b56
+# Note: SHA is the post-rebase-merge SHA on main (rebase merge rewrites SHAs).
+7ff69df6d1028fc567abdbc3b859917726f7c530


### PR DESCRIPTION
## Problem

PR #174 was merged with **rebase merge**, which rewrote the commit SHAs (the base advanced, so rebased commits got new SHAs):

| commit | PR branch SHA | main SHA after rebase |
|---|---|---|
| normalize line endings + strip ws | \`3f2580b2\` | \`7ff69df6\` |

\`.git-blame-ignore-revs\` still referenced \`3f2580b2\`, which **does not exist on main**. As a result, \`git blame\` and the GitHub blame view were not skipping the normalization commit — blame attribution was still blocked by the mass-whitespace commit.

> My earlier claim that "rebase merge preserves SHAs" was wrong. Only fast-forward merge preserves SHAs; both squash and rebase rewrites them (rebase rebases onto the advanced base, producing new SHAs). This was a misjudgment on my part when advising the merge method for #174.

## Fix

One-line change: update the SHA in \`.git-blame-ignore-revs\` from \`3f2580b2\` to \`7ff69df6\` (the actual SHA on main).

## Verification

\`\`\`
git blame --ignore-revs-file .git-blame-ignore-revs <file>
→ attributes to 7fc8ba8b (2026-05-31, real author)
  instead of 7ff69df6 (the normalization commit)
\`\`\`

## Note on merge method

This PR itself can use **any** merge method — it changes a SHA string in a config file, and the content is what matters, not this PR's own SHA. (The blame-ignore only needs the *referenced* SHA to match main, which is already fixed at \`7ff69df6\`.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Git configuration files for internal development tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->