### PR TITLE
fix: suppress AssetMemory leak while loading error

### DIFF
--- a/engines/unity/Assets/Scripts/Game/Game.cs
+++ b/engines/unity/Assets/Scripts/Game/Game.cs
@@ -262,19 +262,25 @@ public class Game : MonoBehaviour
         StoryboardPath = contentProvider.IsExternal ? null : Level.Path + (chartMeta.storyboard?.path ?? "storyboard.json");
         if (!string.IsNullOrEmpty(storyboardText))
         {
+            Debug.Log($"[CYTOID-DBG] Game.Initialize: loading storyboard (text length={storyboardText.Length})");
             // Initialize storyboard
             try
             {
                 Storyboard = new Cytoid.Storyboard.Storyboard(this, storyboardText);
                 Storyboard.Parse();
                 await Storyboard.Initialize();
+                Debug.Log("[CYTOID-DBG] Game.Initialize: storyboard loaded OK");
                 print(contentProvider.IsExternal ? "Loaded storyboard from external payload" : $"Loaded storyboard from {StoryboardPath}");
             }
             catch (Exception e)
             {
-                Debug.LogError(e);
+                Debug.LogError($"[CYTOID-DBG] Game.Initialize: STORYBOARD LOAD FAILED: {e}");
                 Debug.LogError("Could not load storyboard.");
             }
+        }
+        else
+        {
+            Debug.Log("[CYTOID-DBG] Game.Initialize: storyboard text empty/null — skipping");
         }
 
         // Load hit sound
@@ -314,6 +320,7 @@ public class Game : MonoBehaviour
         onGameLoaded.Invoke(this);
         if (GameEmbedMode.IsBridgeEmbedded)
         {
+            Debug.Log("[CYTOID-DBG] Game.Initialize complete — calling HideHandoffOverlay");
             GameBridge.HideHandoffOverlay();
         }
 

--- a/engines/unity/Assets/Scripts/Host/GameBridge.cs
+++ b/engines/unity/Assets/Scripts/Host/GameBridge.cs
@@ -83,10 +83,12 @@ public class GameBridge : MonoBehaviour
     {
         if (sessionState.IsReadyForBridge)
         {
+            Debug.Log("[CYTOID-DBG] SendReadyToBridge: skipped (already ready)");
             return;
         }
 
         sessionState.IsReadyForBridge = true;
+        Debug.Log("[CYTOID-DBG] SendReadyToBridge: sending game.ready envelope");
 
         SyncTargetFrameRateToDisplay();
 
@@ -110,6 +112,8 @@ public class GameBridge : MonoBehaviour
             return;
         }
 
+        Debug.Log("[CYTOID-DBG] ReannounceReadyToBridge: re-sending game.ready");
+
         SyncTargetFrameRateToDisplay();
 
         var payload = new JObject
@@ -129,14 +133,17 @@ public class GameBridge : MonoBehaviour
     {
         if (!GameEmbedMode.IsBridgeEmbedded || sessionState == null || !sessionState.HasActivePlay)
         {
+            Debug.Log($"[CYTOID-DBG] EndActivePlayFromGame: skipped (HasActivePlay={sessionState?.HasActivePlay})");
             return;
         }
 
+        Debug.Log($"[CYTOID-DBG] EndActivePlayFromGame ENTER: ActivePlayId={sessionState.ActivePlayId}");
         try
         {
             await ShowHandoffOverlay();
             var playId = sessionState.ActivePlayId;
             sessionState.MarkPlayRouteEnded();
+            Debug.Log($"[CYTOID-DBG] EndActivePlayFromGame: MarkPlayRouteEnded cleared, playId={playId}");
             var envelope = CytoidGameCoreEnvelope.Create(
                 playId,
                 WireMessageTypes.GamePlayEnded,
@@ -164,11 +171,16 @@ public class GameBridge : MonoBehaviour
                 return;
             }
 
+            Debug.Log($"[CYTOID-DBG] OnGameResultJson ENTER: HasActivePlay={sessionState.HasActivePlay} ActivePlayId={sessionState.ActivePlayId}");
+            Debug.Log("[CYTOID-DBG] OnGameResultJson: BEFORE await ShowHandoffOverlay (0.2s window starts)");
             await ShowHandoffOverlay();
+            Debug.Log($"[CYTOID-DBG] OnGameResultJson: AFTER await ShowHandoffOverlay — HasActivePlay still={sessionState.HasActivePlay} (race window ends)");
             var playId = sessionState.ActivePlayId ?? Guid.NewGuid().ToString();
             var envelope = CytoidGameCoreEnvelope.Create(playId, WireMessageTypes.GamePlayResult, payload);
             NativeBridgeMessenger.Send(envelope.ToJsonString());
+            Debug.Log("[CYTOID-DBG] OnGameResultJson: BEFORE ClearActivePlay");
             sessionState.ClearActivePlay();
+            Debug.Log($"[CYTOID-DBG] OnGameResultJson EXIT: HasActivePlay={sessionState.HasActivePlay}");
         }
         finally
         {
@@ -179,17 +191,20 @@ public class GameBridge : MonoBehaviour
     internal static async UniTask ShowHandoffOverlay()
     {
         EnsureHandoffOverlay();
+        Debug.Log($"[CYTOID-DBG] ShowHandoffOverlay: alpha before={handoffCanvasGroup.alpha} enabled={handoffCanvas.enabled}");
         handoffCanvas.enabled = true;
         handoffCanvasGroup.blocksRaycasts = true;
         handoffCanvasGroup.interactable = true;
         handoffCanvasGroup.DOKill();
         handoffCanvasGroup.DOFade(1, 0.2f).SetEase(Ease.OutCubic);
         await UniTask.Delay(TimeSpan.FromSeconds(0.2f));
+        Debug.Log($"[CYTOID-DBG] ShowHandoffOverlay: alpha after={handoffCanvasGroup.alpha}");
     }
 
     internal static void HideHandoffOverlay()
     {
         EnsureHandoffOverlay();
+        Debug.Log($"[CYTOID-DBG] HideHandoffOverlay: alpha before={handoffCanvasGroup.alpha} enabled={handoffCanvas.enabled}");
         handoffCanvasGroup.blocksRaycasts = false;
         handoffCanvasGroup.interactable = false;
         handoffCanvasGroup.DOKill();
@@ -199,6 +214,11 @@ public class GameBridge : MonoBehaviour
             if (handoffCanvasGroup != null && handoffCanvasGroup.alpha <= 0.01f)
             {
                 handoffCanvas.enabled = false;
+                Debug.Log("[CYTOID-DBG] HideHandoffOverlay: canvas disabled (faded out fully)");
+            }
+            else
+            {
+                Debug.Log($"[CYTOID-DBG] HideHandoffOverlay: deferred check alpha={handoffCanvasGroup?.alpha} (kept visible — race with ShowHandoffOverlay!)");
             }
         });
     }

--- a/engines/unity/Assets/Scripts/Host/GameBridgeRouter.cs
+++ b/engines/unity/Assets/Scripts/Host/GameBridgeRouter.cs
@@ -79,8 +79,11 @@ public class GameBridgeRouter
 
     private void HandleGameStart(CytoidGameCoreEnvelope envelope)
     {
+        Debug.Log($"[CYTOID-DBG] HandleGameStart ENTER: id={envelope.Id} HasActivePlay={sessionState.HasActivePlay} ActivePlayId={sessionState.ActivePlayId} IsReadyForBridge={sessionState.IsReadyForBridge}");
+
         if (sessionState.HasActivePlay)
         {
+            Debug.LogWarning($"[CYTOID-DBG] HandleGameStart: REJECTING as Overlapping (current ActivePlayId={sessionState.ActivePlayId})");
             EmitRejectedGameStart(envelope.Id,
                 $"Overlapping {WireMessageTypes.BridgePlayStart}: session {sessionState.ActivePlayId} is still active.");
             return;
@@ -88,6 +91,7 @@ public class GameBridgeRouter
 
         if (envelope.Payload == null || envelope.Payload.Type == JTokenType.Null)
         {
+            Debug.LogWarning("[CYTOID-DBG] HandleGameStart: REJECTING (payload required)");
             EmitRejectedGameStart(envelope.Id, $"{WireMessageTypes.BridgePlayStart} payload is required.");
             return;
         }
@@ -95,11 +99,13 @@ public class GameBridgeRouter
         var payload = envelope.Payload as JObject;
         if (payload == null)
         {
+            Debug.LogWarning("[CYTOID-DBG] HandleGameStart: REJECTING (payload not object)");
             EmitRejectedGameStart(envelope.Id, $"{WireMessageTypes.BridgePlayStart} payload must be an object.");
             return;
         }
 
         sessionState.SetActivePlay(envelope.Id);
+        Debug.Log($"[CYTOID-DBG] HandleGameStart: SetActivePlay({envelope.Id}) — HasActivePlay now={sessionState.HasActivePlay}");
         ApplyPendingSettings(payload);
         var launchJson = payload.ToString();
         Debug.Log($"[GameBridge] Starting play {envelope.Id}");
@@ -108,6 +114,7 @@ public class GameBridgeRouter
 
     private async void HandleSessionEnd(CytoidGameCoreEnvelope envelope)
     {
+        Debug.Log($"[CYTOID-DBG] HandleSessionEnd ENTER: id={envelope.Id} HasActivePlay={sessionState.HasActivePlay} ActivePlayId={sessionState.ActivePlayId}");
         Debug.Log($"[GameBridge] {WireMessageTypes.BridgePlayEnd} received (id={envelope.Id}).");
         await GameBridge.ShowHandoffOverlay();
         var emittedCalibrationResult = AbortCurrentExternalGame();
@@ -116,6 +123,7 @@ public class GameBridgeRouter
             await UniTask.Delay(TimeSpan.FromSeconds(0.25));
         }
         sessionState.MarkPlayRouteEnded();
+        Debug.Log($"[CYTOID-DBG] HandleSessionEnd: MarkPlayRouteEnded cleared — HasActivePlay now={sessionState.HasActivePlay}");
         EmitPlayRouteEnded(envelope.Id);
     }
 

--- a/engines/unity/Assets/Scripts/Storyboard/Storyboard.cs
+++ b/engines/unity/Assets/Scripts/Storyboard/Storyboard.cs
@@ -128,6 +128,7 @@ namespace Cytoid.Storyboard
 
         public void Dispose()
         {
+            Renderer.Dispose();
             Texts.Clear();
             Sprites.Clear();
             Controllers.Clear();

--- a/engines/unity/Assets/Scripts/Utils/AssetMemory.cs
+++ b/engines/unity/Assets/Scripts/Utils/AssetMemory.cs
@@ -115,7 +115,21 @@ public class AssetMemory
 
         if (PrintDebugMessages) Debug.Log($"AssetMemory: Started loading {path} with variant {suffix}.");
         isLoading.Add(path);
+        try
+        {
+            return await LoadAssetCore<T>(path, tag, cancellationToken, options, useFileCacheOnly, variantPath, variantExists);
+        }
+        finally
+        {
+            isLoading.Remove(path);
+        }
+    }
 
+    private async UniTask<T> LoadAssetCore<T>(
+        string path, AssetTag tag, CancellationToken cancellationToken,
+        AssetOptions options, bool useFileCacheOnly, string variantPath, bool variantExists)
+        where T : Object
+    {
         var time = DateTimeOffset.Now.ToUnixTimeMilliseconds();
         var loadPath = path;
         
@@ -133,18 +147,9 @@ public class AssetMemory
                         request.SetRequestHeader("User-Agent", $"CytoidClient/{Context.VersionIdentifier}");
                         request.downloadHandler =
                             new DownloadHandlerFile(cachePath).Also(it => it.removeFileOnAbort = true);
-                        try
-                        {
-                            await request.SendWebRequest();
-                        }
-                        catch (UnityWebRequestException)
-                        {
-                            // Suppress: the isNetworkError/isHttpError check below handles cleanup
-                            // (including isLoading.Remove) and returns default.
-                        }
+                        await request.SendWebRequest();
                         if (cancellationToken != default && cancellationToken.IsCancellationRequested)
                         {
-                            isLoading.Remove(path);
                             return default;
                         }
 
@@ -164,7 +169,6 @@ public class AssetMemory
                                     Debug.LogError(request.error);
                                 }
                             }
-                            isLoading.Remove(path);
                             return default;
                         }
                        
@@ -173,7 +177,6 @@ public class AssetMemory
                 }
                 else
                 {
-                    isLoading.Remove(path);
                     return default;
                 }
             }
@@ -191,19 +194,10 @@ public class AssetMemory
             using (var request = UnityWebRequest.Get(loadPath))
             {
                 request.SetRequestHeader("User-Agent", $"CytoidClient/{Context.VersionIdentifier}");
-                try
-                {
-                    await request.SendWebRequest();
-                }
-                catch (UnityWebRequestException)
-                {
-                    // Suppress: the isNetworkError/isHttpError check below handles cleanup
-                    // (including isLoading.Remove) and returns default.
-                }
+                await request.SendWebRequest();
 
                 if (cancellationToken != default && cancellationToken.IsCancellationRequested)
                 {
-                    isLoading.Remove(path);
                     return default;
                 }
 
@@ -215,7 +209,6 @@ public class AssetMemory
                         Debug.LogError(
                             $"AssetMemory: Failed to load {loadPath}");
                         Debug.LogError(request.error);
-                        isLoading.Remove(path);
                         return default;
                     }
                 }
@@ -223,7 +216,6 @@ public class AssetMemory
                 var bytes = request.downloadHandler.data;
                 if (bytes == null)
                 {
-                    isLoading.Remove(path);
                     return default;
                 }
 
@@ -287,14 +279,12 @@ public class AssetMemory
             
             if (cancellationToken != default && cancellationToken.IsCancellationRequested)
             {
-                isLoading.Remove(path);
                 loader.Unload();
                 return default;
             }
             
             if (loader.Error != null)
             {
-                isLoading.Remove(path);
                 Debug.LogError($"AssetMemory: Failed to download audio from {variantPath}");
                 Debug.LogError(loader.Error);
                 return default;
@@ -310,7 +300,6 @@ public class AssetMemory
         time = DateTimeOffset.Now.ToUnixTimeMilliseconds() - time;
         if (PrintDebugMessages) Debug.Log($"AssetMemory: Loaded {variantPath} in {time}ms");
 
-        isLoading.Remove(path);
         return asset;
     }
 
@@ -362,6 +351,7 @@ public class AssetMemory
         }
         memoryCache.Clear();
         taggedMemoryCache.Clear();
+        isLoading.Clear();
     }
 
     private void CheckIfExceedTagLimit(AssetTag tag)

--- a/engines/unity/Assets/Scripts/Utils/AssetMemory.cs
+++ b/engines/unity/Assets/Scripts/Utils/AssetMemory.cs
@@ -133,7 +133,15 @@ public class AssetMemory
                         request.SetRequestHeader("User-Agent", $"CytoidClient/{Context.VersionIdentifier}");
                         request.downloadHandler =
                             new DownloadHandlerFile(cachePath).Also(it => it.removeFileOnAbort = true);
-                        await request.SendWebRequest();
+                        try
+                        {
+                            await request.SendWebRequest();
+                        }
+                        catch (UnityWebRequestException)
+                        {
+                            // Suppress: the isNetworkError/isHttpError check below handles cleanup
+                            // (including isLoading.Remove) and returns default.
+                        }
                         if (cancellationToken != default && cancellationToken.IsCancellationRequested)
                         {
                             isLoading.Remove(path);
@@ -183,7 +191,15 @@ public class AssetMemory
             using (var request = UnityWebRequest.Get(loadPath))
             {
                 request.SetRequestHeader("User-Agent", $"CytoidClient/{Context.VersionIdentifier}");
-                await request.SendWebRequest();
+                try
+                {
+                    await request.SendWebRequest();
+                }
+                catch (UnityWebRequestException)
+                {
+                    // Suppress: the isNetworkError/isHttpError check below handles cleanup
+                    // (including isLoading.Remove) and returns default.
+                }
 
                 if (cancellationToken != default && cancellationToken.IsCancellationRequested)
                 {

--- a/engines/unity/Assets/StaticResources/Materials/RoundedCorners Button_Button_0 2.mat
+++ b/engines/unity/Assets/StaticResources/Materials/RoundedCorners Button_Button_0 2.mat
@@ -39,6 +39,6 @@ Material:
     - _UseUIAlphaClip: 0
     m_Colors:
     - _OuterUV: {r: 0, g: 0, b: 1, a: 1}
-    - _WidthHeightRadius: {r: 154, g: 64, b: 12, a: 0}
+    - _WidthHeightRadius: {r: 103.652176, g: 64, b: 12, a: 0}
   m_BuildTextureStacks: []
   m_AllowLocking: 1

--- a/engines/unity/flutter_plugin/android/src/main/kotlin/org/cytoid/gamecore/CytoidGameCoreBridge.kt
+++ b/engines/unity/flutter_plugin/android/src/main/kotlin/org/cytoid/gamecore/CytoidGameCoreBridge.kt
@@ -39,6 +39,7 @@ class CytoidGameCoreBridge private constructor(
 
             override fun onActivityResumed(activity: Activity) {
                 if (isUnityGameplayActivity(activity)) {
+                    Log.i(TAG, "[CYTOID-DBG] Unity activity RESUMED (lifecycle)")
                     mainHandler.postDelayed({
                         applyExclusiveDisplayRefreshRate(activity)
                     }, REFRESH_RATE_APPLY_DELAY_MS)
@@ -51,6 +52,7 @@ class CytoidGameCoreBridge private constructor(
 
             override fun onActivityDestroyed(activity: Activity) {
                 if (exclusiveUnityActivity === activity) {
+                    Log.i(TAG, "[CYTOID-DBG] Unity activity DESTROYED")
                     exclusiveUnityActivity = null
                     surfaceVisible = false
                 }
@@ -86,6 +88,7 @@ class CytoidGameCoreBridge private constructor(
 
     fun showGameSurface(result: MethodChannel.Result) {
         runtimeStarted = true
+        Log.i(TAG, "[CYTOID-DBG] showGameSurface called: useUnityRuntime=$useUnityRuntime exclusiveUnityActivity=$exclusiveUnityActivity")
 
         if (useUnityRuntime) {
             val intent =
@@ -96,8 +99,10 @@ class CytoidGameCoreBridge private constructor(
             runCatching {
                 activity.startActivity(intent)
                 surfaceVisible = true
+                Log.i(TAG, "[CYTOID-DBG] showGameSurface: startActivity OK (REORDER_TO_FRONT|SINGLE_TOP)")
                 result.success(null)
             }.onFailure { error ->
+                Log.e(TAG, "[CYTOID-DBG] showGameSurface: startActivity FAILED", error)
                 result.error(
                     "unity_launch_failed",
                     error.message ?: "Failed to launch exclusive Unity activity.",
@@ -113,6 +118,7 @@ class CytoidGameCoreBridge private constructor(
     }
 
     fun hideGameSurface() {
+        Log.i(TAG, "[CYTOID-DBG] hideGameSurface called: surfaceVisible=$surfaceVisible exclusiveUnityActivity=$exclusiveUnityActivity")
         surfaceVisible = false
         DisplayRefreshRateHelper.restoreDefaultRefreshRate(activity)
 
@@ -133,6 +139,9 @@ class CytoidGameCoreBridge private constructor(
     }
 
     fun onOutboundMessage(jsonString: String) {
+        val type = runCatching { JSONObject(jsonString).optString("type") }.getOrDefault("")
+        Log.i(TAG, "[CYTOID-DBG] -> Unity: type=$type engineReady=$engineReady activePlayId=$activePlayId")
+
         if (isGameStartMessage(jsonString)) {
             activePlayId = JSONObject(jsonString).optString("id").takeIf { it.isNotEmpty() }
         }
@@ -148,11 +157,15 @@ class CytoidGameCoreBridge private constructor(
     }
 
     fun onUnityMessage(jsonString: String) {
+        val type = runCatching { JSONObject(jsonString).optString("type") }.getOrDefault("")
+        Log.i(TAG, "[CYTOID-DBG] <- Unity: type=$type engineReady=$engineReady activePlayId=$activePlayId")
+
         emit(jsonString)
 
         if (isHostReadyMessage(jsonString)) {
             engineReady = true
             runtimeStarted = true
+            Log.i(TAG, "[CYTOID-DBG] <- Unity: game.ready received — engineReady now true")
         }
         if (isGameResultMessage(jsonString)) {
             activePlayId = null
@@ -242,6 +255,12 @@ class CytoidGameCoreBridge private constructor(
                 runtimeStarted || surfaceVisible || useUnityRuntime -> RUNTIME_STARTING
                 else -> RUNTIME_UNAVAILABLE
             }
+        Log.i(
+            TAG,
+            "[CYTOID-DBG] runtimeStatus(): state=$state engineReady=$engineReady " +
+                "runtimeStarted=$runtimeStarted surfaceVisible=$surfaceVisible " +
+                "useUnityRuntime=$useUnityRuntime activePlayId=$activePlayId"
+        )
         return mapOf(
             "state" to state,
             "engine" to engineMode,
@@ -260,7 +279,9 @@ class CytoidGameCoreBridge private constructor(
                 )
                 .invoke(null, UNITY_BRIDGE_OBJECT, UNITY_BRIDGE_METHOD, jsonString)
         }.onFailure { error ->
-            Log.e(TAG, "UnitySendMessage failed", error)
+            Log.e(TAG, "[CYTOID-DBG] UnitySendMessage FAILED (Unity not loaded yet?): ${error.javaClass.simpleName}: ${error.message}")
+        }.onSuccess {
+            Log.i(TAG, "[CYTOID-DBG] UnitySendMessage OK")
         }
     }
 

--- a/engines/unity/flutter_plugin/example/lib/src/models/example_level.dart
+++ b/engines/unity/flutter_plugin/example/lib/src/models/example_level.dart
@@ -100,6 +100,16 @@ class ExampleLevelRepository {
     }
 
     levels.sort((a, b) => a.title.compareTo(b.title));
+
+    // Reclaim temp space from removed/renamed levels before the user starts
+    // playing. Best-effort — failures here do not block level loading.
+    final activeIds = levels.map((l) => l.id).toSet();
+    try {
+      await LevelVfsMaterializer.pruneOrphanedLevels(activeIds);
+    } on Object {
+      // Swallow: GC failure is non-fatal.
+    }
+
     return levels;
   }
 

--- a/engines/unity/flutter_plugin/example/lib/src/models/example_level.dart
+++ b/engines/unity/flutter_plugin/example/lib/src/models/example_level.dart
@@ -103,7 +103,20 @@ class ExampleLevelRepository {
 
     // Reclaim temp space from removed/renamed levels before the user starts
     // playing. Best-effort — failures here do not block level loading.
+    //
+    // Include the hidden calibration guide's ID so its cache survives pruning;
+    // otherwise it would be deleted on every startup and rebuilt on next use.
     final activeIds = levels.map((l) => l.id).toSet();
+    try {
+      final guideMeta = jsonDecode(
+        await rootBundle.loadString(
+          '$exampleLevelAssetRoot/$exampleHiddenLevelFolderName/level.json',
+        ),
+      ) as Map<String, dynamic>;
+      activeIds.add(guideMeta['id'] as String);
+    } on Object {
+      // Hidden level may not be bundled in this build.
+    }
     try {
       await LevelVfsMaterializer.pruneOrphanedLevels(activeIds);
     } on Object {

--- a/engines/unity/flutter_plugin/example/lib/src/screens/game_session_screen.dart
+++ b/engines/unity/flutter_plugin/example/lib/src/screens/game_session_screen.dart
@@ -54,8 +54,10 @@ class _GameSessionScreenState extends State<GameSessionScreen> {
       if (!mounted) return;
       setState(() => _status = 'Opening surface');
 
+      debugPrint('[CYTOID-DBG] calling showGameSurface');
       await _client.showGameSurface();
       _surfaceVisible = true;
+      debugPrint('[CYTOID-DBG] showGameSurface returned, awaiting host ready');
       await _awaitHostReady();
       unawaited(
         _client
@@ -66,7 +68,9 @@ class _GameSessionScreenState extends State<GameSessionScreen> {
       if (!mounted) return;
       setState(() => _status = 'Loading chart');
 
+      debugPrint('[CYTOID-DBG] calling startPlay');
       result = await _client.startPlay(payload);
+      debugPrint('[CYTOID-DBG] startPlay returned: failed=${result.failed} completed=${result.completed}');
       widget.args.onCalibrationResult?.call(result);
       await _hideSurface();
     } on CytoidGameCorePlayRouteEndedException {
@@ -133,10 +137,12 @@ class _GameSessionScreenState extends State<GameSessionScreen> {
   }
 
   Future<void> _awaitHostReady() async {
+    debugPrint('[CYTOID-DBG] _awaitHostReady enter');
     final readyCompleter = Completer<void>();
     late StreamSubscription<CytoidGameCoreEnvelope> readySubscription;
     readySubscription = _client.readyEvents.listen((_) {
       if (!readyCompleter.isCompleted) {
+        debugPrint('[CYTOID-DBG] _awaitHostReady: game.ready event received');
         readyCompleter.complete();
       }
     });
@@ -146,11 +152,13 @@ class _GameSessionScreenState extends State<GameSessionScreen> {
       while (!readyCompleter.isCompleted) {
         final status = await _client.queryStatus();
         if (status.state == GameRuntimeStatus.ready) {
+          debugPrint('[CYTOID-DBG] _awaitHostReady: status=ready, returning');
           return;
         }
         unawaited(_pingReady());
         final remaining = deadline.difference(DateTime.now());
         if (remaining <= Duration.zero) {
+          debugPrint('[CYTOID-DBG] _awaitHostReady: DEADLINE HIT — returning without ready!');
           return;
         }
         await Future.any<void>([

--- a/engines/unity/flutter_plugin/example/lib/src/services/level_vfs_materializer.dart
+++ b/engines/unity/flutter_plugin/example/lib/src/services/level_vfs_materializer.dart
@@ -6,6 +6,10 @@ import 'package:path/path.dart' as p;
 import 'package:path_provider/path_provider.dart';
 
 /// Copies bundled level folder assets into a temp directory for Unity VFS access.
+///
+/// On every call the destination is rebuilt from scratch so that added, updated,
+/// or removed source assets are always reflected — the total payload per level
+/// is a few MB at most.
 class LevelVfsMaterializer {
   const LevelVfsMaterializer();
 
@@ -28,17 +32,21 @@ class LevelVfsMaterializer {
       p.join(cacheRoot.path, 'cytoid', 'levels', levelId),
     );
 
-    if (!levelDir.existsSync()) {
-      await levelDir.create(recursive: true);
-      for (final assetKey in assetKeys) {
-        final relative = assetKey.substring(folderAssetPath.length + 1);
-        final output = File(p.join(levelDir.path, relative));
-        await output.parent.create(recursive: true);
-        final data = await assetBundle.load(assetKey);
-        await output.writeAsBytes(
-          data.buffer.asUint8List(data.offsetInBytes, data.lengthInBytes),
-        );
-      }
+    // Always rebuild: delete stale directory then recreate so that new or
+    // updated source assets are picked up on every launch.
+    if (levelDir.existsSync()) {
+      await levelDir.delete(recursive: true);
+    }
+    await levelDir.create(recursive: true);
+
+    for (final assetKey in assetKeys) {
+      final relative = assetKey.substring(folderAssetPath.length + 1);
+      final output = File(p.join(levelDir.path, relative));
+      await output.parent.create(recursive: true);
+      final data = await assetBundle.load(assetKey);
+      await output.writeAsBytes(
+        data.buffer.asUint8List(data.offsetInBytes, data.lengthInBytes),
+      );
     }
 
     final vfsPath = '${levelDir.path}${Platform.pathSeparator}';
@@ -48,6 +56,32 @@ class LevelVfsMaterializer {
       musicPath: musicPath,
       storyboardPath: storyboardPath,
     );
+  }
+
+  /// Deletes VFS cache directories for levels no longer present in the asset
+  /// bundle. Call after level discovery with the set of active level IDs.
+  ///
+  /// Best-effort: individual deletion failures are swallowed so that one
+  /// stuck directory does not prevent cleanup of the rest.
+  static Future<void> pruneOrphanedLevels(
+    Set<String> activeLevelIds, {
+    Directory? cacheRootOverride,
+  }) async {
+    final cacheRoot = cacheRootOverride ?? await getTemporaryDirectory();
+    final levelsRoot = Directory(p.join(cacheRoot.path, 'cytoid', 'levels'));
+
+    if (!levelsRoot.existsSync()) return;
+
+    await for (final entry in levelsRoot.list()) {
+      if (entry is! Directory) continue;
+      final name = p.basename(entry.path);
+      if (activeLevelIds.contains(name)) continue;
+      try {
+        await entry.delete(recursive: true);
+      } on FileSystemException {
+        // Best-effort: skip directories we cannot remove.
+      }
+    }
   }
 }
 

--- a/engines/unity/flutter_plugin/example/pubspec.yaml
+++ b/engines/unity/flutter_plugin/example/pubspec.yaml
@@ -62,7 +62,7 @@ flutter:
   uses-material-design: true
   assets:
     # BEGIN example_level_assets (manual: dart run tool/sync_level_assets.dart)
-    - assets/levels/8bit_adventurer/
+    - assets/levels/io.cytoid.8bit_adventurer/
     - assets/levels/offset_guide/
     # END example_level_assets
 

--- a/engines/unity/flutter_plugin/example/test/example_level_discovery_test.dart
+++ b/engines/unity/flutter_plugin/example/test/example_level_discovery_test.dart
@@ -7,8 +7,8 @@ void main() {
   group('discoverPlayableLevelFolderRoots', () {
     test('includes folders with level.json except offset_guide', () {
       final keys = [
-        'assets/levels/8bit_adventurer/level.json',
-        'assets/levels/8bit_adventurer/music.mp3',
+        'assets/levels/io.cytoid.8bit_adventurer/level.json',
+        'assets/levels/io.cytoid.8bit_adventurer/music.mp3',
         'assets/levels/offset_guide/level.json',
         'assets/levels/my_demo/level.json',
       ];
@@ -16,7 +16,7 @@ void main() {
       expect(
         discoverPlayableLevelFolderRoots(keys),
         [
-          'assets/levels/8bit_adventurer',
+          'assets/levels/io.cytoid.8bit_adventurer',
           'assets/levels/my_demo',
         ],
       );


### PR DESCRIPTION
## Root causes

Two independent bugs surfaced when replaying levels on Android (Xiaomi 13 / HyperOS 3):

### 1. AssetMemory `isLoading` leak → black screen on replay

`AssetMemory.LoadAsset` awaited `UnityWebRequest.SendWebRequest()` which throws `UnityRequestException` on HTTP 404. The `isLoading.Remove(path)` call lived after the await, so on failure the path was never removed from the `isLoading` HashSet. Since `AssetMemory` is a process-level static singleton (`Context.AssetMemory`), the entry persisted across game sessions. The next session's `LoadAsset` for the same path hit `await UniTask.WaitUntil(() => !isLoading.Contains(path))` → infinite hang → `Game.Initialize()` never completed → `HideHandoffOverlay()` never called → black overlay (sortingOrder=32000) stayed forever.

### 2. VFS materializer stale cache → storyboard sprite 404s

`LevelVfsMaterializer.materializeFolder` gated the entire file-copy loop behind `if (!levelDir.existsSync())`. Once the temp directory was created on first run, subsequent runs with added/updated source assets were silently skipped. Newly added storyboard sprites never reached the device → `UnityWebRequest` 404.

## Fixes

| Commit | Fix |
|--------|-----|
| `218ddeda` | `AssetMemory.LoadAsset`: extracted body to `LoadAssetCore`, wrapped in `try/finally` to guarantee `isLoading.Remove(path)` on any exception |
| `b0d6d0ca` | `Storyboard.Dispose()`: now calls `Renderer.Dispose()` → `DisposeTaggedCacheAssets(AssetTag.Storyboard)` to free sprite textures on game disposal (was never called) |
| `96436b25` | `LevelVfsMaterializer.materializeFolder`: always delete + rebuild the level dir. Added `pruneOrphanedLevels()` GC for removed/renamed levels |

Superseded commit `9ea0db52` (targeted try/catch) is kept for history; `218ddeda` replaces it with the structural fix.

## Debug instrumentation

3 commits add `[CYTOID-DBG]` markers across the host bridge call chain (Unity C# → Kotlin → Dart) for diagnosis. These can be kept or stripped before merge.

## Testing

- [x] Black screen on replay: **fixed** (verified on device)
- [x] Storyboard sprite 404s: fix applied, pending device verification after `flutter run`
- [x] `dart analyze`: zero issues
- [x] `dart format`: applied

## Notes

- `LevelVfsMaterializer` is example-app-only. The real app (`cytoid_flutter`) stores levels on the filesystem and passes paths directly to `GameLaunchAssets`, bypassing the materializer entirely.
- The UI material tweak (`31522286`) is an unrelated button width adjustment picked up during the build.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup of temporary level cache files so removed or renamed levels no longer leave stale data.
  * Rebuilt per-level VFS cache more reliably to ensure updated bundled assets are reflected on load.
  * Fixed asset loading tracking to always clear in-flight state, reducing stuck/incorrect loads.
  * Improved renderer/resource cleanup during storyboard disposal to reduce lingering memory usage.
* **New Features**
  * Added orphaned level cache pruning to remove unused level subdirectories.
* **Tests**
  * Updated example level discovery tests to match revised asset paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->