### PR TITLE
fix(bridge): clear host session state on game scene launch failure

### DIFF
--- a/engines/unity/Assets/Scripts/Game/GameLaunchBridge.cs
+++ b/engines/unity/Assets/Scripts/Game/GameLaunchBridge.cs
@@ -69,7 +69,7 @@ public static class GameLaunchBridge
         return ExternalGameContentProvider.FromJson(launchJson);
     }
 
-    internal static async UniTask LoadGameScene(IGameContentProvider provider)
+    internal static async UniTask LoadGameScene(IGameContentProvider provider, Action onLaunchFailed = null)
     {
         try
         {
@@ -85,6 +85,7 @@ public static class GameLaunchBridge
             {
                 Context.GameContentProvider = null;
             }
+            onLaunchFailed?.Invoke();
             GameResultBridge.EmitError(e);
         }
     }

--- a/engines/unity/Assets/Scripts/Game/GameLaunchBridge.cs
+++ b/engines/unity/Assets/Scripts/Game/GameLaunchBridge.cs
@@ -85,8 +85,8 @@ public static class GameLaunchBridge
             {
                 Context.GameContentProvider = null;
             }
-            onLaunchFailed?.Invoke();
             GameResultBridge.EmitError(e);
+            onLaunchFailed?.Invoke();
         }
     }
 

--- a/engines/unity/Assets/Scripts/Host/GameBridgeRouter.cs
+++ b/engines/unity/Assets/Scripts/Host/GameBridgeRouter.cs
@@ -110,7 +110,11 @@ public class GameBridgeRouter
         }
 
         EmitSessionStarted(envelope.Id, payload["mode"]?.Value<string>() ?? "ranked");
-        GameLaunchBridge.LoadGameScene(provider).Forget();
+        GameLaunchBridge.LoadGameScene(provider, onLaunchFailed: () =>
+        {
+            sessionState.ClearActiveSession();
+            GameResultBridge.ActiveSessionRecordPlayEvents = null;
+        }).Forget();
     }
 
     private async void HandleSessionCancel(CytoidGameCoreEnvelope envelope)


### PR DESCRIPTION
Follow-up to #177 — the merge missed this commit.

## Problem

After #177, when `LoadGameScene` fails in `PrepareProviderContext`, `SceneLoader.Load`, or `sceneLoader.Activate` — i.e. **after** `session.started` was already emitted — the host stayed stuck in `BUSY` with a stale `ActiveSessionId`. The catch block reported the error via `GameResultBridge.EmitError` but never rolled back the active-session state, so the host could not accept a new session.

## Fix

`LoadGameScene` now takes an optional `onLaunchFailed` callback, invoked at the end of the catch block. The router wires it to clear:

- `sessionState.ClearActiveSession()` → drops `ActiveSessionId`
- `GameResultBridge.ActiveSessionRecordPlayEvents = null`

so the runtime returns to `READY` and the next `bridge.play.start` is accepted.

## Changes

- `GameLaunchBridge.cs`: `LoadGameScene(provider, Action onLaunchFailed = null)` — invoke callback after `EmitError`.
- `GameBridgeRouter.cs`: pass rollback callback that clears active-session state.

## Risk

Contained to the launch-failure path; success path unchanged. No protocol/payload change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved game launch error handling by adding a dedicated failure callback during scene loading.
  * Ensures failed launches now reliably emit the error and perform session cleanup, preventing stale session/play-event data from persisting into the next attempt.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->