### PR TITLE
feat(plugin): v2 health.check watchdog with last-message shortcut

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,6 +67,8 @@ Protocol spec: `docs/host-protocol-v2.md` (v1 doc at `engines/unity/flutter_plug
 - `activeSessionId == null` → `engine.error` envelope via the EventChannel, `error.code = "runtime_exception"`, message sanitized to `"<ExceptionClassSimpleName>: <first message line>"` (no raw stack trace).
 - `activeSessionId != null` → synthesized `session.failed` with `error.code = "runtime_unreachable"` via the T4 primitive. Never both — active-session failures use `session.failed` ONLY; `engine.error` is for non-session failures.
 
+**Host-side `health.check` watchdog (Dart):** `PlaySession._awaitSessionResult` arms a self-scheduling watchdog that sends `health.check` every `pollInterval` (default 10s). First response timeout = 30s, subsequent = 10s. A check is skipped when a non-terminal engine envelope arrived within the last `pollInterval`. On response timeout, the watchdog completes the session completer with `CytoidGameCoreSessionFailedException(code: 'runtime_unreachable')` — the same code the native bridge uses for send-failure synthesis, distinguished by the `message` field. This fills the gap the native synthesis paths don't cover: Unity main loop frozen with the process alive (storyboard death-spiral, GC stall). The C# handler is at `engines/unity/Assets/Scripts/Host/GameBridgeRouter.cs` (`HandleHealthCheck`, returns `health.ok` with `engine` / `generation` / `state` / `activeSessionId`).
+
 **Android Unity Activity lifecycle (warm-resident):** the exclusive Unity Activity (`me.tigerhix.cytoid.CytoidPluginActivity`) is NOT `finish()`-ed on session end. `hideGameSurface()` brings the Flutter Activity to front via `FLAG_ACTIVITY_REORDER_TO_FRONT | FLAG_ACTIVITY_SINGLE_TOP` and leaves the Unity Activity warm-resident in the back stack. This keeps Unity/IL2CPP/GL state alive across the typical play loop (select level → play → result → select next), eliminating the 5–15s cold-start tax on every session.
 
 Activity lifecycle callbacks drive the T3 state machine:
@@ -221,6 +223,7 @@ If you change envelope types or payloads:
 | 2026-05 | No Unity disk persistence (LiteDB removed) | Settings/records/scores live in Flutter; core uses in-memory `LocalPlayerSettings`, `LevelRecord`, `GameLaunchSettings` |
 | 2026-05 | Lunar Console removed; `game.log` forwarding | Bridge-embedded receives Unity logs; Graphy retained for in-engine profiler overlay |
 | 2026-05 | Cytoid top-level menu = plugin builds only | Flat `Cytoid/…` items; no Core Build submenu; exports use `PluginBuildScenes` + `CYTOID_FLUTTER_HOST` |
+| 2026-06 | Host-side `health.check` watchdog in `PlaySession` | Detects Unity main-loop freeze with process alive — the gap the native bridge synthesis paths don't cover. Reuses `runtime_unreachable`; provenance in `message`. C# handler: `GameBridgeRouter.HandleHealthCheck` |
 
 Append new rows when architecture or default paths change.
 

--- a/docs/host-protocol-v2.md
+++ b/docs/host-protocol-v2.md
@@ -228,6 +228,8 @@ The Flutter client should use this single check for long-running liveness. A
 healthy active session is represented by `state = "busy"` and the matching
 `activeSessionId`.
 
+The host SHOULD arm a self-scheduling health.check watchdog after `session.start`. The watchdog sends `health.check` every `pollInterval`; the FIRST check's `health.ok` response timeout is 30s (the engine may be cold/loading assets), and SUBSEQUENT checks use a 10s response timeout (steady-state play). The host MAY skip a check when a non-terminal engine-originated envelope (`session.started`, `logs.batch`, `settings.applied`, `engine.error`, or a prior `health.ok`) arrived within the last `pollInterval` — a responsive engine has already proven its liveness. On response timeout, the host synthesizes `session.failed` with `error.code = "runtime_unreachable"` (see [Active-Session Runtime Failure](#active-session-runtime-failure)); the host cannot distinguish a frozen main loop from a process-level unreachable at this layer, so the `message` carries the watchdog provenance for debugging.
+
 ## `engine.ready`
 
 Engine -> Flutter.
@@ -1242,12 +1244,15 @@ The engine does not emit `session.failed`; the C# engine in particular is
 v1-only on the wire and emits no v2 outcomes at all. The bridge's
 `synthesizeRuntimeFailure` primitive is the sole producer of this envelope.
 
+The host-side health.check watchdog is a SEPARATE producer of `session.failed` from the native bridge; both use `runtime_unreachable` because the host cannot distinguish a frozen main loop from a process-level unreachable — the `message` field carries the provenance.
+
 | Scenario | Required behavior |
 |---|---|
 | Engine exception during active session | Native bridge synthesizes `session.failed` with `error.code = "runtime_exception"`. |
 | Native bridge cannot deliver messages (Unity process gone) | Native bridge synthesizes `session.failed` with `error.code = "runtime_unreachable"`. |
 | Engine generation increments while `activeSessionId` is non-null | Native bridge synthesizes `session.failed` for the active session with `error.code = "runtime_recreated"`, BEFORE emitting the next `engine.ready`. |
 | Surface loss during active play | Native bridge synthesizes `session.failed` with `error.code = "runtime_surface_lost"`. |
+| Host-side health.check watchdog timeout | Host (Dart) synthesizes `session.failed` with `error.code = "runtime_unreachable"`. |
 
 After any runtime-failed termination:
 
@@ -1372,7 +1377,7 @@ Recommended error codes:
 | `runtime_unavailable` | Engine not initialized or no artifact available. | `engine.error`, or `session.result` with `outcome.kind = "rejected"` if a session was requested. |
 | `runtime_not_ready` | Engine exists but has not emitted `engine.ready` for the current generation. | `engine.error`, or `session.result` with `outcome.kind = "rejected"`. |
 | `runtime_recreated` | Engine generation incremented while a session was active. | `session.failed`. |
-| `runtime_unreachable` | Native bridge cannot reach the engine process. | `session.failed`. |
+| `runtime_unreachable` | Native bridge cannot reach the engine process, OR host-side health.check watchdog detected the engine stopped responding. Producer (native bridge vs host) is distinguished by the error `message`. | `session.failed`. |
 | `runtime_surface_lost` | Engine surface was lost during active play. | `session.failed`. |
 | `runtime_exception` | Unhandled engine exception during a session. | `session.failed`. |
 | `overlapping_session` | A `session.start` arrived while another session was active. | `session.result` with `outcome.kind = "rejected"`. |

--- a/docs/host-protocol-v2.md
+++ b/docs/host-protocol-v2.md
@@ -154,7 +154,7 @@ payload value outside the documented enum sets. Rejections caused by
 | `session.cancel` | Flutter -> Engine | Request cancellation of the active session. |
 | `session.telemetry` | Engine -> Flutter | Optional telemetry stream when requested by launch options. |
 | `session.result` | Engine -> Flutter | Terminal gameplay outcome message (engine-active outcomes). Runtime death uses `session.failed`. |
-| `session.failed` | Engine -> Flutter | Terminal runtime-failure message for an active session (native-bridge synthesis). |
+| `session.failed` | Engine -> Flutter | Terminal runtime-failure message for an active session (native-bridge or host-side watchdog synthesis). |
 | `logs.batch` | Engine -> Flutter | Buffered engine logs. |
 
 Removed v1 message types:
@@ -1242,7 +1242,9 @@ runtime itself may be dead or unreachable, the NATIVE BRIDGE synthesizes a
 `session.failed` envelope for the active session — never a `session.result`.
 The engine does not emit `session.failed`; the C# engine in particular is
 v1-only on the wire and emits no v2 outcomes at all. The bridge's
-`synthesizeRuntimeFailure` primitive is the sole producer of this envelope.
+`synthesizeRuntimeFailure` primitive is the producer on the native-bridge
+side (the host-side health.check watchdog is a separate producer — see
+the next paragraph and the runtime-failure table below).
 
 The host-side health.check watchdog is a SEPARATE producer of `session.failed` from the native bridge; both use `runtime_unreachable` because the host cannot distinguish a frozen main loop from a process-level unreachable — the `message` field carries the provenance.
 

--- a/docs/host-protocol-v2.md
+++ b/docs/host-protocol-v2.md
@@ -228,7 +228,7 @@ The Flutter client should use this single check for long-running liveness. A
 healthy active session is represented by `state = "busy"` and the matching
 `activeSessionId`.
 
-The host SHOULD arm a self-scheduling health.check watchdog after `session.start`. The watchdog sends `health.check` every `pollInterval`; the FIRST check's `health.ok` response timeout is 30s (the engine may be cold/loading assets), and SUBSEQUENT checks use a 10s response timeout (steady-state play). The host MAY skip a check when a non-terminal engine-originated envelope (`session.started`, `logs.batch`, `settings.applied`, `engine.error`, or a prior `health.ok`) arrived within the last `pollInterval` — a responsive engine has already proven its liveness. On response timeout, the host synthesizes `session.failed` with `error.code = "runtime_unreachable"` (see [Active-Session Runtime Failure](#active-session-runtime-failure)); the host cannot distinguish a frozen main loop from a process-level unreachable at this layer, so the `message` carries the watchdog provenance for debugging.
+The host SHOULD arm a self-scheduling health.check watchdog after `session.start`. The watchdog sends `health.check` every `pollInterval`; the FIRST check's `health.ok` response timeout is 30s (the engine may be cold/loading assets), and SUBSEQUENT checks use a 10s response timeout (steady-state play). The host MAY skip a check when a non-terminal engine-originated envelope (`session.started`, `logs.batch`, `settings.applied`, `engine.error`, or a prior `health.ok`) arrived within the last `pollInterval` — a responsive engine has already proven its liveness. On response timeout, the host terminates the session by throwing an exception carrying `error.code = "runtime_unreachable"` (this is the host-side equivalent of `session.failed` — unlike the native bridge, the host does NOT inject a synthetic `session.failed` envelope onto the event stream; the failure is delivered via the `PlaySession.run` future throwing). See [Active-Session Runtime Failure](#active-session-runtime-failure); the host cannot distinguish a frozen main loop from a process-level unreachable at this layer, so the `message` carries the watchdog provenance for debugging.
 
 ## `engine.ready`
 
@@ -1254,7 +1254,7 @@ The host-side health.check watchdog is a SEPARATE producer of `session.failed` f
 | Native bridge cannot deliver messages (Unity process gone) | Native bridge synthesizes `session.failed` with `error.code = "runtime_unreachable"`. |
 | Engine generation increments while `activeSessionId` is non-null | Native bridge synthesizes `session.failed` for the active session with `error.code = "runtime_recreated"`, BEFORE emitting the next `engine.ready`. |
 | Surface loss during active play | Native bridge synthesizes `session.failed` with `error.code = "runtime_surface_lost"`. |
-| Host-side health.check watchdog timeout | Host (Dart) synthesizes `session.failed` with `error.code = "runtime_unreachable"`. |
+| Host-side health.check watchdog timeout | Host (Dart) terminates the session via exception (`CytoidGameCoreSessionFailedException`) with `error.code = "runtime_unreachable"`. Unlike the native bridge, the host does NOT inject a `session.failed` envelope onto the event stream — the failure is delivered via the `PlaySession.run` future. |
 
 After any runtime-failed termination:
 

--- a/docs/host-protocol-v2.md
+++ b/docs/host-protocol-v2.md
@@ -228,7 +228,7 @@ The Flutter client should use this single check for long-running liveness. A
 healthy active session is represented by `state = "busy"` and the matching
 `activeSessionId`.
 
-The host SHOULD arm a self-scheduling health.check watchdog after `session.start`. The watchdog sends `health.check` every `pollInterval`; the FIRST check's `health.ok` response timeout is 30s (the engine may be cold/loading assets), and SUBSEQUENT checks use a 10s response timeout (steady-state play). The host MAY skip a check when a non-terminal engine-originated envelope (`session.started`, `logs.batch`, `settings.applied`, `engine.error`, or a prior `health.ok`) arrived within the last `pollInterval` — a responsive engine has already proven its liveness. On response timeout, the host terminates the session by throwing an exception carrying `error.code = "runtime_unreachable"` (this is the host-side equivalent of `session.failed` — unlike the native bridge, the host does NOT inject a synthetic `session.failed` envelope onto the event stream; the failure is delivered via the `PlaySession.run` future throwing). See [Active-Session Runtime Failure](#active-session-runtime-failure); the host cannot distinguish a frozen main loop from a process-level unreachable at this layer, so the `message` carries the watchdog provenance for debugging.
+The host SHOULD arm a self-scheduling health.check watchdog after `session.start`. The watchdog sends `health.check` every `pollInterval`; the FIRST check's `health.ok` response timeout defaults to 30s (the engine may be cold/loading assets), and SUBSEQUENT checks default to 10s (steady-state play); these are `HealthCheckWatchdogConfig` defaults and hosts MAY tune them. The host MAY skip a check when a non-terminal engine-originated envelope (`session.started`, `logs.batch`, `settings.applied`, `engine.error`, or a prior `health.ok`) arrived within the last `pollInterval` — a responsive engine has already proven its liveness. On response timeout, the host terminates the session by throwing an exception carrying `error.code = "runtime_unreachable"` (this is the host-side equivalent of `session.failed` — unlike the native bridge, the host does NOT inject a synthetic `session.failed` envelope onto the event stream; the failure is delivered via the `PlaySession.run` future throwing). See [Active-Session Runtime Failure](#active-session-runtime-failure); the host cannot distinguish a frozen main loop from a process-level unreachable at this layer, so the `message` carries the watchdog provenance for debugging.
 
 ## `engine.ready`
 
@@ -1246,7 +1246,7 @@ v1-only on the wire and emits no v2 outcomes at all. The bridge's
 side (the host-side health.check watchdog is a separate producer — see
 the next paragraph and the runtime-failure table below).
 
-The host-side health.check watchdog is a SEPARATE producer of `session.failed` from the native bridge; both use `runtime_unreachable` because the host cannot distinguish a frozen main loop from a process-level unreachable — the `message` field carries the provenance.
+The host-side health.check watchdog can also terminate a session with `error.code = "runtime_unreachable"` — via a thrown exception (`CytoidGameCoreSessionFailedException`), NOT via a `session.failed` envelope. Both the native bridge and the host use `runtime_unreachable` because the host cannot distinguish a frozen main loop from a process-level unreachable; the `message` field carries the provenance.
 
 | Scenario | Required behavior |
 |---|---|

--- a/engines/unity/flutter_plugin/CHANGELOG.md
+++ b/engines/unity/flutter_plugin/CHANGELOG.md
@@ -1,3 +1,16 @@
+## Unreleased
+
+### Added
+
+- `HealthCheckWatchdogConfig` (`lib/src/health_check_watchdog_config.dart`) and a
+  `health.check` watchdog wired into `PlaySession._awaitSessionResult`. During an
+  active session the watchdog sends `health.check` every `pollInterval` (default
+  10s); the first response timeout is 30s, subsequent 10s. A check is skipped
+  when a non-terminal engine envelope arrived within the last `pollInterval`. On
+  timeout, `PlaySession.run` throws
+  `CytoidGameCoreSessionFailedException(code: 'runtime_unreachable')`. Default-on;
+  pass `watchdogConfig: null` to opt out.
+
 ## 0.1.0 - 2026-06-27
 
 First public release on the v2 host protocol track. The Dart plugin now ships

--- a/engines/unity/flutter_plugin/lib/cytoid_game_core.dart
+++ b/engines/unity/flutter_plugin/lib/cytoid_game_core.dart
@@ -1,7 +1,8 @@
 export 'src/cytoid_game_core_client.dart';
 export 'src/cytoid_game_core_envelope.dart';
-export 'src/cytoid_game_core_lost_exception.dart';
 export 'src/cytoid_game_core_liveness_config.dart';
+export 'src/health_check_watchdog_config.dart';
+export 'src/cytoid_game_core_lost_exception.dart';
 export 'src/cytoid_game_core_session_failed_exception.dart';
 export 'src/cytoid_game_core_timeout_exception.dart';
 export 'src/game_runtime_status.dart';

--- a/engines/unity/flutter_plugin/lib/src/health_check_watchdog_config.dart
+++ b/engines/unity/flutter_plugin/lib/src/health_check_watchdog_config.dart
@@ -6,10 +6,44 @@
 /// [pollInterval] is the cadence (a check is skipped when a non-terminal
 /// engine-originated envelope arrived within the last [pollInterval]).
 class HealthCheckWatchdogConfig {
-  const HealthCheckWatchdogConfig({
-    this.firstResponseTimeout = const Duration(seconds: 30),
-    this.steadyResponseTimeout = const Duration(seconds: 10),
-    this.pollInterval = const Duration(seconds: 10),
+  /// Default watchdog tuning: 30s first response, 10s steady, 10s poll.
+  static const HealthCheckWatchdogConfig defaults = HealthCheckWatchdogConfig._(
+    firstResponseTimeout: Duration(seconds: 30),
+    steadyResponseTimeout: Duration(seconds: 10),
+    pollInterval: Duration(seconds: 10),
+  );
+
+  factory HealthCheckWatchdogConfig({
+    Duration? firstResponseTimeout,
+    Duration? steadyResponseTimeout,
+    Duration? pollInterval,
+  }) {
+    final timeout = firstResponseTimeout ?? const Duration(seconds: 30);
+    final steady = steadyResponseTimeout ?? const Duration(seconds: 10);
+    final interval = pollInterval ?? const Duration(seconds: 10);
+    assert(
+      timeout.inMicroseconds > 0,
+      'firstResponseTimeout must be strictly positive',
+    );
+    assert(
+      steady.inMicroseconds > 0,
+      'steadyResponseTimeout must be strictly positive',
+    );
+    assert(
+      interval.inMicroseconds > 0,
+      'pollInterval must be strictly positive',
+    );
+    return HealthCheckWatchdogConfig._(
+      firstResponseTimeout: timeout,
+      steadyResponseTimeout: steady,
+      pollInterval: interval,
+    );
+  }
+
+  const HealthCheckWatchdogConfig._({
+    required this.firstResponseTimeout,
+    required this.steadyResponseTimeout,
+    required this.pollInterval,
   });
 
   final Duration firstResponseTimeout;

--- a/engines/unity/flutter_plugin/lib/src/health_check_watchdog_config.dart
+++ b/engines/unity/flutter_plugin/lib/src/health_check_watchdog_config.dart
@@ -18,9 +18,12 @@ class HealthCheckWatchdogConfig {
     Duration? steadyResponseTimeout,
     Duration? pollInterval,
   }) {
-    final timeout = firstResponseTimeout ?? const Duration(seconds: 30);
-    final steady = steadyResponseTimeout ?? const Duration(seconds: 10);
-    final interval = pollInterval ?? const Duration(seconds: 10);
+    final timeout =
+        firstResponseTimeout ?? HealthCheckWatchdogConfig.defaults.firstResponseTimeout;
+    final steady =
+        steadyResponseTimeout ?? HealthCheckWatchdogConfig.defaults.steadyResponseTimeout;
+    final interval =
+        pollInterval ?? HealthCheckWatchdogConfig.defaults.pollInterval;
     if (timeout.inMicroseconds <= 0) {
       throw ArgumentError(
         'firstResponseTimeout must be strictly positive, got $timeout',

--- a/engines/unity/flutter_plugin/lib/src/health_check_watchdog_config.dart
+++ b/engines/unity/flutter_plugin/lib/src/health_check_watchdog_config.dart
@@ -21,18 +21,21 @@ class HealthCheckWatchdogConfig {
     final timeout = firstResponseTimeout ?? const Duration(seconds: 30);
     final steady = steadyResponseTimeout ?? const Duration(seconds: 10);
     final interval = pollInterval ?? const Duration(seconds: 10);
-    assert(
-      timeout.inMicroseconds > 0,
-      'firstResponseTimeout must be strictly positive',
-    );
-    assert(
-      steady.inMicroseconds > 0,
-      'steadyResponseTimeout must be strictly positive',
-    );
-    assert(
-      interval.inMicroseconds > 0,
-      'pollInterval must be strictly positive',
-    );
+    if (timeout.inMicroseconds <= 0) {
+      throw ArgumentError(
+        'firstResponseTimeout must be strictly positive, got $timeout',
+      );
+    }
+    if (steady.inMicroseconds <= 0) {
+      throw ArgumentError(
+        'steadyResponseTimeout must be strictly positive, got $steady',
+      );
+    }
+    if (interval.inMicroseconds <= 0) {
+      throw ArgumentError(
+        'pollInterval must be strictly positive, got $interval',
+      );
+    }
     return HealthCheckWatchdogConfig._(
       firstResponseTimeout: timeout,
       steadyResponseTimeout: steady,

--- a/engines/unity/flutter_plugin/lib/src/health_check_watchdog_config.dart
+++ b/engines/unity/flutter_plugin/lib/src/health_check_watchdog_config.dart
@@ -1,0 +1,18 @@
+/// Tuning for [PlaySession]'s v2 health.check watchdog.
+///
+/// The watchdog sends `health.check` envelopes while awaiting a session
+/// result; [firstResponseTimeout] covers the cold/loading engine after
+/// `session.start`, [steadyResponseTimeout] covers steady-state play, and
+/// [pollInterval] is the cadence (a check is skipped when a non-terminal
+/// engine-originated envelope arrived within the last [pollInterval]).
+class HealthCheckWatchdogConfig {
+  const HealthCheckWatchdogConfig({
+    this.firstResponseTimeout = const Duration(seconds: 30),
+    this.steadyResponseTimeout = const Duration(seconds: 10),
+    this.pollInterval = const Duration(seconds: 10),
+  });
+
+  final Duration firstResponseTimeout;
+  final Duration steadyResponseTimeout;
+  final Duration pollInterval;
+}

--- a/engines/unity/flutter_plugin/lib/src/play_session.dart
+++ b/engines/unity/flutter_plugin/lib/src/play_session.dart
@@ -27,7 +27,7 @@ import 'wire_message_type.dart';
 class PlaySession {
   PlaySession(
     this.client, {
-    this.watchdogConfig = const HealthCheckWatchdogConfig(),
+    this.watchdogConfig = HealthCheckWatchdogConfig.defaults,
   });
 
   /// The low-level client used to drive runtime, surface, and envelope I/O.

--- a/engines/unity/flutter_plugin/lib/src/play_session.dart
+++ b/engines/unity/flutter_plugin/lib/src/play_session.dart
@@ -3,6 +3,7 @@ import 'dart:async';
 import 'cytoid_game_core_client.dart';
 import 'cytoid_game_core_envelope.dart';
 import 'cytoid_game_core_session_failed_exception.dart';
+import 'health_check_watchdog_config.dart';
 import 'models/v2/session_failed_payload.dart';
 import 'models/v2/session_launch_payload.dart';
 import 'models/v2/session_result_payload.dart';
@@ -24,12 +25,22 @@ import 'wire_message_type.dart';
 /// [CytoidGameCoreClient.showGameSurface], [CytoidGameCoreClient.send]) remain
 /// available for advanced callers that need to deviate from this sequence.
 class PlaySession {
-  PlaySession(this.client);
+  PlaySession(
+    this.client, {
+    this.watchdogConfig = const HealthCheckWatchdogConfig(),
+  });
 
   /// The low-level client used to drive runtime, surface, and envelope I/O.
   final CytoidGameCoreClient client;
 
+  /// Tuning for the v2 `health.check` watchdog armed during
+  /// [_awaitSessionResult]. When `null`, the watchdog is DISABLED — no
+  /// `health.check` envelopes are sent and the session awaits a terminal
+  /// envelope indefinitely (the v2 back-compat escape hatch; defaults to ON).
+  final HealthCheckWatchdogConfig? watchdogConfig;
+
   int _sessionIdCounter = 0;
+  int _healthCheckCounter = 0;
   String? _activeSessionId;
 
   /// Runs a full v2 session lifecycle and returns the typed terminal result.
@@ -57,7 +68,7 @@ class PlaySession {
       surfaceShown = true;
       await client.waitForReady(timeout: readyTimeout);
 
-      final resultWait = _awaitSessionResult(sessionId);
+      final resultWait = _awaitSessionResult(sessionId, watchdogConfig);
       try {
         await client.send(
           CytoidGameCoreEnvelope.create(
@@ -117,48 +128,195 @@ class PlaySession {
   /// (enforced by the [Completer.isCompleted] guard — the v2 "exactly one of
   /// result OR failed, never both" lockstep invariant). Errors during payload
   /// parsing propagate via the returned future.
-  _SessionResultWait _awaitSessionResult(String sessionId) {
+  _SessionResultWait _awaitSessionResult(
+    String sessionId,
+    HealthCheckWatchdogConfig? watchdogConfig,
+  ) {
     final completer = Completer<SessionResultPayload>();
+    DateTime? lastInboundAt;
+    Timer? watchdogTimer;
+    var isFirstCheck = true;
+    var disposed = false;
+
     late StreamSubscription<dynamic> subscription;
-    subscription = client.events.listen((envelope) {
-      if (envelope.id != sessionId || completer.isCompleted) {
-        return;
-      }
-      if (envelope.type == WireMessageType.sessionResult) {
-        try {
-          completer.complete(
-            SessionResultPayload.fromJson(
+    subscription = client.events.listen(
+      (envelope) {
+        // Last-message shortcut: record ANY non-terminal engine-envelope
+        // arrival BEFORE the sessionId guard. Real engine envelopes that prove
+        // liveness carry ids that are NOT the sessionId — logs.batch and
+        // engine.error carry fresh UUIDs (GameLogBridge emits Guid.NewGuid),
+        // settings.applied carries the settings-apply id, and health.ok carries
+        // the checkId ("health-..."). Updating after the id guard would never
+        // refresh from real log flow, defeating the optimization. Terminal
+        // envelopes (sessionResult / sessionFailed) are excluded because they
+        // complete the completer below.
+        if (envelope.type != WireMessageType.sessionResult &&
+            envelope.type != WireMessageType.sessionFailed) {
+          lastInboundAt = DateTime.now();
+        }
+        if (envelope.id != sessionId || completer.isCompleted) {
+          return;
+        }
+        if (envelope.type == WireMessageType.sessionResult) {
+          try {
+            completer.complete(
+              SessionResultPayload.fromJson(
+                Map<String, dynamic>.from(envelope.payload),
+              ),
+            );
+          } catch (e, st) {
+            completer.completeError(e, st);
+          }
+          return;
+        }
+        if (envelope.type == WireMessageType.sessionFailed) {
+          try {
+            final failed = SessionFailedPayload.fromJson(
               Map<String, dynamic>.from(envelope.payload),
-            ),
-          );
-        } catch (e, st) {
-          completer.completeError(e, st);
+            );
+            completer.completeError(
+              CytoidGameCoreSessionFailedException(
+                sessionId: sessionId,
+                code: failed.error.code,
+                message: failed.error.message,
+                details: failed.error.details,
+              ),
+            );
+          } catch (e, st) {
+            completer.completeError(e, st);
+          }
+          return;
         }
-        return;
-      }
-      if (envelope.type == WireMessageType.sessionFailed) {
+      },
+      onError: (Object error, StackTrace stackTrace) {
+        // Guard: a stream error that arrives after the completer was already
+        // completed (by session.result / session.failed / watchdog timeout)
+        // MUST be silently dropped. Calling completeError on an already-
+        // completed completer throws StateError; this guard enforces the same
+        // lockstep invariant the rest of the method uses.
+        if (!completer.isCompleted) {
+          completer.completeError(error, stackTrace);
+        }
+      },
+    );
+
+    // Sends one `health.check` envelope and awaits the matching `health.ok`.
+    // CRITICAL ORDERING (race fix): the per-check listener is attached
+    // BEFORE `client.send` is called. `client.events` is a broadcast stream
+    // (`asBroadcastStream()` at cytoid_game_core_client.dart:58) and drops
+    // events with no listener — an engine that responds instantaneously
+    // during the `send` await would otherwise have its `health.ok` lost,
+    // causing a false-positive timeout.
+    Future<bool> sendAndAwaitHealthOk(String checkId, Duration timeout) async {
+      final okCompleter = Completer<bool>();
+      late StreamSubscription<dynamic> okSub;
+      okSub = client.events.listen((envelope) {
+        if (!completer.isCompleted &&
+            envelope.id == checkId &&
+            envelope.type == WireMessageType.healthOk &&
+            !okCompleter.isCompleted) {
+          okCompleter.complete(true);
+        }
+      });
+      final timer = Timer(timeout, () {
+        if (!okCompleter.isCompleted) okCompleter.complete(false);
+      });
+      try {
         try {
-          final failed = SessionFailedPayload.fromJson(
-            Map<String, dynamic>.from(envelope.payload),
-          );
-          completer.completeError(
-            CytoidGameCoreSessionFailedException(
-              sessionId: sessionId,
-              code: failed.error.code,
-              message: failed.error.message,
-              details: failed.error.details,
+          await client.send(
+            CytoidGameCoreEnvelope.create(
+              id: checkId,
+              type: WireMessageType.healthCheck,
+              payload: {'activeSessionId': sessionId},
             ),
           );
-        } catch (e, st) {
-          completer.completeError(e, st);
+        } catch (_) {
+          // Native send failed: the native bridge synthesizes session.failed
+          // (runtime_unreachable) asynchronously per AGENTS.md § Active-Session
+          // Runtime Failure. Don't short-circuit — let the timeout run; the
+          // native synthesis will complete the main completer first.
         }
+        return await okCompleter.future;
+      } finally {
+        timer.cancel();
+        await okSub.cancel();
+      }
+    }
+
+    // Self-scheduling watchdog. Declare the two mutually-recursive closures
+    // as `late` variables so each can reference the other without tripping
+    // Dart's referenced_before_declaration rule for local functions.
+    late final void Function() scheduleNextCheck;
+    late final Future<void> Function() runCheck;
+
+    scheduleNextCheck = () {
+      if (disposed || completer.isCompleted) return;
+      final cfg = watchdogConfig;
+      if (cfg == null) return;
+      watchdogTimer = Timer(cfg.pollInterval, runCheck);
+    };
+
+    runCheck = () async {
+      if (disposed || completer.isCompleted) return;
+      final cfg = watchdogConfig;
+      if (cfg == null) return;
+      // Skip sending when a non-terminal engine envelope arrived within the
+      // last pollInterval AND we're past the first check. The first check is
+      // NEVER skipped so the watchdog establishes a deterministic baseline
+      // (firstResponseTimeout) regardless of lastInboundAt.
+      if (!isFirstCheck &&
+          lastInboundAt != null &&
+          DateTime.now().difference(lastInboundAt!) < cfg.pollInterval) {
+        scheduleNextCheck();
         return;
       }
-    }, onError: completer.completeError);
+      final timeout = isFirstCheck
+          ? cfg.firstResponseTimeout
+          : cfg.steadyResponseTimeout;
+      // Set isFirstCheck=false BEFORE the await so a concurrent fire sees the
+      // post-first state (subsequent checks always use steadyResponseTimeout).
+      isFirstCheck = false;
+      final checkId = 'health-${_nextHealthCheckId()}';
+      final gotResponse = await sendAndAwaitHealthOk(checkId, timeout);
+      // The main subscription may have completed the completer via
+      // session.result/session.failed while we were awaiting health.ok.
+      if (disposed || completer.isCompleted) return;
+      if (!gotResponse) {
+        // The watchdog completes the completer with an EXCEPTION only — it
+        // MUST NOT inject a synthetic session.failed envelope onto
+        // client.events. Other listeners on the broadcast stream observe the
+        // failure via the PlaySession.run future throwing. The reused
+        // `runtime_unreachable` code carries watchdog provenance in `message`
+        // (the host cannot distinguish a frozen main loop from a process-
+        // level unreachable at this layer).
+        completer.completeError(
+          CytoidGameCoreSessionFailedException(
+            sessionId: sessionId,
+            code: 'runtime_unreachable',
+            message:
+                'Engine did not respond to health.check (id=$checkId) '
+                'within ${timeout.inSeconds}s; watchdog synthesized '
+                'runtime_unreachable.',
+          ),
+        );
+        return;
+      }
+      scheduleNextCheck();
+    };
+
+    // Arm the first check. The first fire is pollInterval after arming — well
+    // after session.start (which is sent by run() after this method returns).
+    if (watchdogConfig != null) {
+      scheduleNextCheck();
+    }
 
     return _SessionResultWait(
       future: completer.future,
       cancelSubscription: () async {
+        // Set disposed FIRST so a timer that fires during teardown no-ops
+        // (its runCheck continuation early-returns on the disposed guard).
+        disposed = true;
+        watchdogTimer?.cancel();
         await subscription.cancel();
       },
     );
@@ -168,6 +326,11 @@ class PlaySession {
     _sessionIdCounter += 1;
     return 'session-$_sessionIdCounter-'
         '${DateTime.now().microsecondsSinceEpoch}';
+  }
+
+  String _nextHealthCheckId() {
+    _healthCheckCounter += 1;
+    return '$_healthCheckCounter-${DateTime.now().microsecondsSinceEpoch}';
   }
 }
 

--- a/engines/unity/flutter_plugin/lib/src/play_session.dart
+++ b/engines/unity/flutter_plugin/lib/src/play_session.dart
@@ -135,6 +135,13 @@ class PlaySession {
     final completer = Completer<SessionResultPayload>();
     DateTime? lastInboundAt;
     Timer? watchdogTimer;
+    // In-flight per-check resources lifted to the outer scope so the
+    // session-cancel path can release them immediately. Without this, a
+    // session that completes via session.result / session.failed / stream
+    // error while runCheck is inside sendAndAwaitHealthOk would leave a
+    // passive listener + pending timer lingering for up to firstResponseTimeout.
+    Timer? inFlightCheckTimer;
+    StreamSubscription<dynamic>? inFlightCheckSub;
     var isFirstCheck = true;
     var disposed = false;
 
@@ -209,16 +216,29 @@ class PlaySession {
     // causing a false-positive timeout.
     Future<bool> sendAndAwaitHealthOk(String checkId, Duration timeout) async {
       final okCompleter = Completer<bool>();
-      late StreamSubscription<dynamic> okSub;
-      okSub = client.events.listen((envelope) {
-        if (!completer.isCompleted &&
-            envelope.id == checkId &&
-            envelope.type == WireMessageType.healthOk &&
-            !okCompleter.isCompleted) {
-          okCompleter.complete(true);
-        }
-      });
-      final timer = Timer(timeout, () {
+      // Assign to the OUTER inFlight* locals (not local finals) so the
+      // session-cancel closure can release these resources immediately if
+      // the session completes via another path while we're awaiting. The
+      // local finally block below still cancels them on normal completion.
+      inFlightCheckSub = client.events.listen(
+        (envelope) {
+          if (!completer.isCompleted &&
+              envelope.id == checkId &&
+              envelope.type == WireMessageType.healthOk &&
+              !okCompleter.isCompleted) {
+            okCompleter.complete(true);
+          }
+        },
+        onError: (Object _, StackTrace _) {
+          // Silently ignore stream errors on the per-check listener. Stream
+          // errors are delivered to EVERY subscription on a broadcast stream;
+          // the MAIN subscription owns stream-error completion of the session
+          // completer (with the isCompleted guard). This listener's only job
+          // is to match health.ok — without this no-op onError, a stream
+          // error would surface as an uncaught async error on this listener.
+        },
+      );
+      inFlightCheckTimer = Timer(timeout, () {
         if (!okCompleter.isCompleted) okCompleter.complete(false);
       });
       try {
@@ -238,8 +258,10 @@ class PlaySession {
         }
         return await okCompleter.future;
       } finally {
-        timer.cancel();
-        await okSub.cancel();
+        inFlightCheckTimer?.cancel();
+        inFlightCheckTimer = null;
+        await inFlightCheckSub?.cancel();
+        inFlightCheckSub = null;
       }
     }
 
@@ -317,6 +339,12 @@ class PlaySession {
         // (its runCheck continuation early-returns on the disposed guard).
         disposed = true;
         watchdogTimer?.cancel();
+        // Release in-flight per-check resources too — covers the race where
+        // session.result / session.failed / stream error completes the
+        // session while runCheck is inside sendAndAwaitHealthOk. Cancel is
+        // idempotent (no-op on already-cancelled sub/timer).
+        inFlightCheckTimer?.cancel();
+        await inFlightCheckSub?.cancel();
         await subscription.cancel();
       },
     );

--- a/engines/unity/flutter_plugin/lib/src/play_session.dart
+++ b/engines/unity/flutter_plugin/lib/src/play_session.dart
@@ -77,6 +77,7 @@ class PlaySession {
             payload: launch.toJson(),
           ),
         );
+        resultWait.armWatchdog?.call();
         return await resultWait.future;
       } finally {
         await resultWait.cancelSubscription();
@@ -326,12 +327,6 @@ class PlaySession {
       scheduleNextCheck();
     };
 
-    // Arm the first check. The first fire is pollInterval after arming — well
-    // after session.start (which is sent by run() after this method returns).
-    if (watchdogConfig != null) {
-      scheduleNextCheck();
-    }
-
     return _SessionResultWait(
       future: completer.future,
       cancelSubscription: () async {
@@ -347,6 +342,7 @@ class PlaySession {
         await inFlightCheckSub?.cancel();
         await subscription.cancel();
       },
+      armWatchdog: watchdogConfig != null ? scheduleNextCheck : null,
     );
   }
 
@@ -369,8 +365,15 @@ class _SessionResultWait {
   const _SessionResultWait({
     required this.future,
     required this.cancelSubscription,
+    this.armWatchdog,
   });
 
   final Future<SessionResultPayload> future;
   final Future<void> Function() cancelSubscription;
+
+  /// Called by `run()` AFTER `session.start` is sent, to arm the first
+  /// health.check. Null when the watchdog is disabled (watchdogConfig == null).
+  /// Splitting setup from arming prevents the watchdog from firing before the
+  /// engine has received `session.start` (CodeRabbit finding on PR #179).
+  final void Function()? armWatchdog;
 }

--- a/engines/unity/flutter_plugin/test/health_check_watchdog_config_test.dart
+++ b/engines/unity/flutter_plugin/test/health_check_watchdog_config_test.dart
@@ -4,17 +4,17 @@ import 'package:flutter_test/flutter_test.dart';
 void main() {
   group('HealthCheckWatchdogConfig', () {
     test('const default has expected timeouts', () {
-      const config = HealthCheckWatchdogConfig();
+      final config = HealthCheckWatchdogConfig();
       expect(config.firstResponseTimeout, const Duration(seconds: 30));
       expect(config.steadyResponseTimeout, const Duration(seconds: 10));
       expect(config.pollInterval, const Duration(seconds: 10));
     });
 
     test('custom values round-trip through fields', () {
-      const config = HealthCheckWatchdogConfig(
-        firstResponseTimeout: Duration(seconds: 5),
-        steadyResponseTimeout: Duration(seconds: 2),
-        pollInterval: Duration(seconds: 1),
+      final config = HealthCheckWatchdogConfig(
+        firstResponseTimeout: const Duration(seconds: 5),
+        steadyResponseTimeout: const Duration(seconds: 2),
+        pollInterval: const Duration(seconds: 1),
       );
       expect(config.firstResponseTimeout, const Duration(seconds: 5));
       expect(config.steadyResponseTimeout, const Duration(seconds: 2));
@@ -22,9 +22,26 @@ void main() {
     });
 
     test('identical const instances', () {
-      const a = HealthCheckWatchdogConfig();
-      const b = HealthCheckWatchdogConfig();
-      expect(identical(a, b), isTrue);
+      final a = HealthCheckWatchdogConfig();
+      final b = HealthCheckWatchdogConfig();
+      expect(identical(a, b), isFalse);
+    });
+
+    test('rejects non-positive durations with AssertionError', () {
+      expect(
+        () => HealthCheckWatchdogConfig(pollInterval: Duration.zero),
+        throwsA(isA<AssertionError>()),
+      );
+      expect(
+        () => HealthCheckWatchdogConfig(
+          firstResponseTimeout: Duration(seconds: -1),
+        ),
+        throwsA(isA<AssertionError>()),
+      );
+      expect(
+        () => HealthCheckWatchdogConfig(steadyResponseTimeout: Duration.zero),
+        throwsA(isA<AssertionError>()),
+      );
     });
   });
 }

--- a/engines/unity/flutter_plugin/test/health_check_watchdog_config_test.dart
+++ b/engines/unity/flutter_plugin/test/health_check_watchdog_config_test.dart
@@ -21,10 +21,20 @@ void main() {
       expect(config.pollInterval, const Duration(seconds: 1));
     });
 
-    test('identical const instances', () {
-      final a = HealthCheckWatchdogConfig();
-      final b = HealthCheckWatchdogConfig();
-      expect(identical(a, b), isFalse);
+    test('factory default matches defaults constant', () {
+      final fromFactory = HealthCheckWatchdogConfig();
+      expect(
+        fromFactory.firstResponseTimeout,
+        HealthCheckWatchdogConfig.defaults.firstResponseTimeout,
+      );
+      expect(
+        fromFactory.steadyResponseTimeout,
+        HealthCheckWatchdogConfig.defaults.steadyResponseTimeout,
+      );
+      expect(
+        fromFactory.pollInterval,
+        HealthCheckWatchdogConfig.defaults.pollInterval,
+      );
     });
 
     test('rejects non-positive durations with ArgumentError', () {

--- a/engines/unity/flutter_plugin/test/health_check_watchdog_config_test.dart
+++ b/engines/unity/flutter_plugin/test/health_check_watchdog_config_test.dart
@@ -1,0 +1,30 @@
+import 'package:cytoid_game_core/cytoid_game_core.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('HealthCheckWatchdogConfig', () {
+    test('const default has expected timeouts', () {
+      const config = HealthCheckWatchdogConfig();
+      expect(config.firstResponseTimeout, const Duration(seconds: 30));
+      expect(config.steadyResponseTimeout, const Duration(seconds: 10));
+      expect(config.pollInterval, const Duration(seconds: 10));
+    });
+
+    test('custom values round-trip through fields', () {
+      const config = HealthCheckWatchdogConfig(
+        firstResponseTimeout: Duration(seconds: 5),
+        steadyResponseTimeout: Duration(seconds: 2),
+        pollInterval: Duration(seconds: 1),
+      );
+      expect(config.firstResponseTimeout, const Duration(seconds: 5));
+      expect(config.steadyResponseTimeout, const Duration(seconds: 2));
+      expect(config.pollInterval, const Duration(seconds: 1));
+    });
+
+    test('identical const instances', () {
+      const a = HealthCheckWatchdogConfig();
+      const b = HealthCheckWatchdogConfig();
+      expect(identical(a, b), isTrue);
+    });
+  });
+}

--- a/engines/unity/flutter_plugin/test/health_check_watchdog_config_test.dart
+++ b/engines/unity/flutter_plugin/test/health_check_watchdog_config_test.dart
@@ -27,20 +27,20 @@ void main() {
       expect(identical(a, b), isFalse);
     });
 
-    test('rejects non-positive durations with AssertionError', () {
+    test('rejects non-positive durations with ArgumentError', () {
       expect(
         () => HealthCheckWatchdogConfig(pollInterval: Duration.zero),
-        throwsA(isA<AssertionError>()),
+        throwsA(isA<ArgumentError>()),
       );
       expect(
         () => HealthCheckWatchdogConfig(
           firstResponseTimeout: Duration(seconds: -1),
         ),
-        throwsA(isA<AssertionError>()),
+        throwsA(isA<ArgumentError>()),
       );
       expect(
         () => HealthCheckWatchdogConfig(steadyResponseTimeout: Duration.zero),
-        throwsA(isA<AssertionError>()),
+        throwsA(isA<ArgumentError>()),
       );
     });
   });

--- a/engines/unity/flutter_plugin/test/play_session_test.dart
+++ b/engines/unity/flutter_plugin/test/play_session_test.dart
@@ -707,10 +707,10 @@ void main() {
   // Millisecond-scale watchdog config for deterministic tests (NOT real 30s;
   // NOT FakeAsync — the latter is scope-OUT per the plan). Hundreds of ms, not
   // single-digit ms, to avoid CI flakiness.
-  const msConfig = HealthCheckWatchdogConfig(
-    firstResponseTimeout: Duration(milliseconds: 2000),
-    steadyResponseTimeout: Duration(milliseconds: 200),
-    pollInterval: Duration(milliseconds: 100),
+  final msConfig = HealthCheckWatchdogConfig(
+    firstResponseTimeout: const Duration(milliseconds: 2000),
+    steadyResponseTimeout: const Duration(milliseconds: 200),
+    pollInterval: const Duration(milliseconds: 100),
   );
 
   group('PlaySession.run health.check watchdog', () {
@@ -1147,6 +1147,8 @@ void main() {
       // HealthCheckWatchdogConfig(). A regression that flipped the default to
       // null would make this test fail (no health.check ever sent).
       final session = PlaySession(client);
+      expect(session.watchdogConfig, isNotNull,
+          reason: 'default constructor must set a non-null config (default-on)');
 
       final runFuture = session.run(
         launch: _buildTestLaunch(),
@@ -1195,6 +1197,8 @@ void main() {
         eventStream: events.stream,
       );
       final session = PlaySession(client, watchdogConfig: null);
+      expect(session.watchdogConfig, isNull,
+          reason: 'null watchdogConfig must leave the field null (opt-out)');
 
       final runFuture = session.run(
         launch: _buildTestLaunch(),

--- a/engines/unity/flutter_plugin/test/play_session_test.dart
+++ b/engines/unity/flutter_plugin/test/play_session_test.dart
@@ -1124,5 +1124,123 @@ void main() {
       expect(healthCheckSendCount(), 1);
       expect(primaryCalls.map((c) => c.method), contains('hideGameSurface'));
     });
+
+    test('watchdog: default constructor arms the watchdog — health.check is '
+        'sent (no watchdogConfig kwarg)', () async {
+      // Verify the default `PlaySession(client)` ctor ENABLES the watchdog.
+      // The default pollInterval is 10s — use a generous deadline on
+      // awaitSentEnvelope so the test still bounds total runtime while
+      // accommodating the real default cadence.
+      installSendInterceptor(
+        onSend: (env) {
+          if (env.type == WireMessageType.healthCheck) {
+            Future.microtask(() => emitHealthOk(env.id));
+          }
+        },
+      );
+
+      final client = CytoidGameCoreClient(
+        methodChannel: primaryChannel,
+        eventStream: events.stream,
+      );
+      // NO watchdogConfig kwarg — relies on the default = const
+      // HealthCheckWatchdogConfig(). A regression that flipped the default to
+      // null would make this test fail (no health.check ever sent).
+      final session = PlaySession(client);
+
+      final runFuture = session.run(
+        launch: _buildTestLaunch(),
+        readyTimeout: const Duration(seconds: 2),
+      );
+
+      final startEnvelope = await awaitSentEnvelope(
+        WireMessageType.sessionStart,
+      );
+
+      // Default pollInterval is 10s — wait up to 15s for the first check.
+      await awaitSentEnvelope(
+        WireMessageType.healthCheck,
+        deadline: const Duration(seconds: 15),
+      );
+
+      // Cleanup: emit session.result so run() completes cleanly.
+      final resultJson = _loadFixture('session_result_payload.valid.json');
+      resultJson['sessionId'] = startEnvelope.id;
+      events.add(
+        CytoidGameCoreEnvelope.create(
+          id: startEnvelope.id,
+          type: WireMessageType.sessionResult,
+          payload: resultJson,
+        ).toJsonString(),
+      );
+
+      final result = await runFuture.timeout(
+        const Duration(seconds: 2),
+        onTimeout: () => throw TimeoutException('run() never returned'),
+      );
+      expect(result.outcome.kind, OutcomePayload.completedKind);
+      expect(healthCheckSendCount(), greaterThanOrEqualTo(1));
+      expect(primaryCalls.map((c) => c.method), contains('hideGameSurface'));
+    });
+
+    test('watchdog: null watchdogConfig disables the watchdog — no '
+        'health.check sent', () async {
+      // Verify the OPT-OUT escape hatch. Passing watchdogConfig: null MUST
+      // disable the watchdog entirely — no health.check envelopes are sent
+      // regardless of how long the session runs.
+      installSendInterceptor(onSend: (_) {});
+
+      final client = CytoidGameCoreClient(
+        methodChannel: primaryChannel,
+        eventStream: events.stream,
+      );
+      final session = PlaySession(client, watchdogConfig: null);
+
+      final runFuture = session.run(
+        launch: _buildTestLaunch(),
+        readyTimeout: const Duration(seconds: 2),
+      );
+
+      final startEnvelope = await awaitSentEnvelope(
+        WireMessageType.sessionStart,
+      );
+
+      // Emit session.started + session.result promptly so the run completes.
+      events.add(
+        CytoidGameCoreEnvelope.create(
+          id: startEnvelope.id,
+          type: WireMessageType.sessionStarted,
+          payload: {'sessionId': startEnvelope.id},
+        ).toJsonString(),
+      );
+      final resultJson = _loadFixture('session_result_payload.valid.json');
+      resultJson['sessionId'] = startEnvelope.id;
+      events.add(
+        CytoidGameCoreEnvelope.create(
+          id: startEnvelope.id,
+          type: WireMessageType.sessionResult,
+          payload: resultJson,
+        ).toJsonString(),
+      );
+
+      final result = await runFuture.timeout(
+        const Duration(seconds: 2),
+        onTimeout: () => throw TimeoutException('run() never returned'),
+      );
+      expect(result.outcome.kind, OutcomePayload.completedKind);
+
+      // Wait past what would have been the first pollInterval if the watchdog
+      // were armed with msConfig (100ms). 300ms gives comfortable margin.
+      await Future<void>.delayed(const Duration(milliseconds: 300));
+
+      // ZERO health.check envelopes — the watchdog was disabled.
+      expect(healthCheckSendCount(), 0);
+      expect(
+        sentEnvelopeOfType(WireMessageType.healthCheck),
+        isNull,
+        reason: 'watchdogConfig: null MUST disable health.check sends',
+      );
+      expect(primaryCalls.map((c) => c.method), contains('hideGameSurface'));
+    });
   });
 }

--- a/engines/unity/flutter_plugin/test/play_session_test.dart
+++ b/engines/unity/flutter_plugin/test/play_session_test.dart
@@ -231,7 +231,9 @@ void main() {
         );
 
         // Let the first run complete so it doesn't dangle into sibling tests.
-        final startEnvelope = await awaitSentEnvelope(WireMessageType.sessionStart);
+        final startEnvelope = await awaitSentEnvelope(
+          WireMessageType.sessionStart,
+        );
         final resultJson = _loadFixture('session_result_payload.valid.json');
         resultJson['sessionId'] = startEnvelope.id;
         events.add(
@@ -279,11 +281,11 @@ void main() {
       resultJson['sessionId'] = startEnvelope.id;
       events.add(
         CytoidGameCoreEnvelope.create(
-            id: startEnvelope.id,
-            type: WireMessageType.sessionResult,
-            payload: resultJson,
-          ).toJsonString(),
-        );
+          id: startEnvelope.id,
+          type: WireMessageType.sessionResult,
+          payload: resultJson,
+        ).toJsonString(),
+      );
 
       final result = await runFuture.timeout(
         const Duration(seconds: 2),
@@ -339,11 +341,11 @@ void main() {
       resultJson['sessionId'] = startEnvelope.id;
       events.add(
         CytoidGameCoreEnvelope.create(
-            id: startEnvelope.id,
-            type: WireMessageType.sessionResult,
-            payload: resultJson,
-          ).toJsonString(),
-        );
+          id: startEnvelope.id,
+          type: WireMessageType.sessionResult,
+          payload: resultJson,
+        ).toJsonString(),
+      );
 
       await runFuture.timeout(const Duration(seconds: 2));
     });
@@ -442,17 +444,17 @@ void main() {
     // Helper: emit a `session.failed` envelope on the broadcast event stream
     // matching the supplied session id. Mirrors how the native bridge
     // synthesizes a runtime-death envelope for an active session.
-    void emitSessionFailed(String sessionId, {String code = 'runtime_unreachable'}) {
+    void emitSessionFailed(
+      String sessionId, {
+      String code = 'runtime_unreachable',
+    }) {
       events.add(
         CytoidGameCoreEnvelope.create(
           id: sessionId,
           type: WireMessageType.sessionFailed,
           payload: {
             'sessionId': sessionId,
-            'error': {
-              'code': code,
-              'message': 'Unity process gone',
-            },
+            'error': {'code': code, 'message': 'Unity process gone'},
             'timestamp': DateTime.now().millisecondsSinceEpoch,
           },
         ).toJsonString(),
@@ -599,10 +601,528 @@ void main() {
           onTimeout: () => throw TimeoutException('run() never threw'),
         ),
         throwsA(
-          isA<CytoidGameCoreSessionFailedException>()
-              .having((e) => e.code, 'code', 'runtime_unreachable'),
+          isA<CytoidGameCoreSessionFailedException>().having(
+            (e) => e.code,
+            'code',
+            'runtime_unreachable',
+          ),
         ),
       );
+    });
+  });
+
+  group('PlaySession.run stream error lockstep', () {
+    // Regression: the main subscription's onError MUST guard against
+    // completer.isCompleted. A stream error arriving after session.result /
+    // session.failed / watchdog-timeout completed the completer MUST be
+    // silently dropped — calling completeError on an already-completed
+    // completer throws StateError, which would propagate out of run() and
+    // mask the real result/failure.
+    //
+    // Triggering the race deterministically requires a SYNC broadcast
+    // controller: with sync=true, events.addError dispatches to listeners
+    // SYNCHRONOUSLY (not via microtask). Combined with events.add firing
+    // onData synchronously, we can deliver session.result (completing the
+    // completer) and then immediately an error in the SAME synchronous
+    // call frame — before run()'s finally block has a chance to cancel the
+    // subscription. Without the production guard, the synchronous
+    // completeError-on-completed-completer throws StateError out of
+    // events.addError; with the guard, the error is silently dropped.
+    test('late stream error after session.result is silently dropped — '
+        'no StateError', () async {
+      // Local sync broadcast controller — does NOT replace the suite-level
+      // `events` (which tearDown still owns). Bypasses async microtask
+      // reordering that would otherwise cancel S1 before M2 fires.
+      final syncEvents = StreamController<dynamic>.broadcast(sync: true);
+      addTearDown(syncEvents.close);
+
+      final client = CytoidGameCoreClient(
+        methodChannel: primaryChannel,
+        eventStream: syncEvents.stream,
+      );
+      final session = PlaySession(client);
+
+      final runFuture = session.run(
+        launch: _buildTestLaunch(),
+        readyTimeout: const Duration(seconds: 2),
+      );
+
+      final startEnvelope = await awaitSentEnvelope(
+        WireMessageType.sessionStart,
+      );
+
+      // Complete the session cleanly with a valid session.result. add() on a
+      // SYNC broadcast controller delivers onData IMMEDIATELY — the
+      // subscription's onData fires synchronously here, completing the
+      // completer before this line returns.
+      final resultJson = _loadFixture('session_result_payload.valid.json');
+      resultJson['sessionId'] = startEnvelope.id;
+      syncEvents.add(
+        CytoidGameCoreEnvelope.create(
+          id: startEnvelope.id,
+          type: WireMessageType.sessionResult,
+          payload: resultJson,
+        ).toJsonString(),
+      );
+
+      // Inject a stream error in the SAME synchronous call frame. The
+      // subscription is STILL alive (run()'s finally block hasn't run yet
+      // — it's scheduled as a microtask continuation of completer.future).
+      // Without the production guard, this throws StateError out of addError.
+      Object? addErrorThrown;
+      try {
+        syncEvents.addError(StateError('late stream error after completion'));
+      } catch (e) {
+        addErrorThrown = e;
+      }
+
+      // The error from inside the listener dispatcher is NOT propagated via
+      // addError's synchronous return (the dispatcher catches it and routes
+      // to the subscription's zone). Drain any microtasks so a deferred
+      // StateError reaches the test framework's uncaught-error sink.
+      await Future<void>.delayed(const Duration(milliseconds: 50));
+
+      expect(
+        addErrorThrown,
+        isNull,
+        reason:
+            'stream listener dispatcher must not propagate the '
+            'completeError-on-completed StateError synchronously; got: '
+            '$addErrorThrown',
+      );
+
+      // run() must return the result cleanly, NOT a StateError. Without the
+      // guard, the uncaught StateError masks the result.
+      final result = await runFuture.timeout(
+        const Duration(seconds: 2),
+        onTimeout: () => throw TimeoutException('run() never returned'),
+      );
+      expect(result.outcome.kind, OutcomePayload.completedKind);
+
+      // Surface MUST still be hidden via the finally block.
+      expect(primaryCalls.map((c) => c.method), contains('hideGameSurface'));
+    });
+  });
+
+  // Millisecond-scale watchdog config for deterministic tests (NOT real 30s;
+  // NOT FakeAsync — the latter is scope-OUT per the plan). Hundreds of ms, not
+  // single-digit ms, to avoid CI flakiness.
+  const msConfig = HealthCheckWatchdogConfig(
+    firstResponseTimeout: Duration(milliseconds: 2000),
+    steadyResponseTimeout: Duration(milliseconds: 200),
+    pollInterval: Duration(milliseconds: 100),
+  );
+
+  group('PlaySession.run health.check watchdog', () {
+    /// Replaces the default mock `primaryChannel` handler with one that
+    /// delegates the standard setUp behavior but additionally routes every
+    /// `send` envelope through [onSend]. Tests use this to intercept
+    /// `health.check` envelopes and decide whether to emit a matching
+    /// `health.ok` (or to record timing).
+    void installSendInterceptor({
+      required void Function(CytoidGameCoreEnvelope env) onSend,
+    }) {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(primaryChannel, (call) async {
+            primaryCalls.add(call);
+            switch (call.method) {
+              case 'ensureRuntimeStarted':
+              case 'showGameSurface':
+              case 'hideGameSurface':
+                return null;
+              case 'send':
+                final env = CytoidGameCoreEnvelope.fromJsonString(
+                  call.arguments as String,
+                );
+                onSend(env);
+                return null;
+              case 'getEngineMode':
+                return 'mock';
+              case 'queryRuntimeStatus':
+                return <String, Object?>{
+                  'state': statusState,
+                  'engine': 'mock',
+                  'mode': 'mock',
+                  'generation': 1,
+                  if (statusState == 'failed')
+                    'error': {
+                      'code': 'runtime_failed',
+                      'message': 'Runtime failed',
+                    },
+                };
+            }
+            throw PlatformException(code: 'not_implemented');
+          });
+    }
+
+    int healthCheckSendCount() {
+      var count = 0;
+      for (final call in primaryCalls) {
+        if (call.method != 'send') continue;
+        final env = CytoidGameCoreEnvelope.fromJsonString(
+          call.arguments as String,
+        );
+        if (env.type == WireMessageType.healthCheck) count += 1;
+      }
+      return count;
+    }
+
+    Future<void> waitForHealthCheckCount(
+      int target, {
+      Duration deadline = const Duration(seconds: 2),
+    }) async {
+      final end = DateTime.now().add(deadline);
+      while (DateTime.now().isBefore(end)) {
+        if (healthCheckSendCount() >= target) return;
+        await Future<void>.delayed(const Duration(milliseconds: 5));
+      }
+      throw TimeoutException(
+        'Never saw $target health.check envelopes within $deadline',
+      );
+    }
+
+    void emitHealthOk(String checkId) {
+      events.add(
+        CytoidGameCoreEnvelope.create(
+          id: checkId,
+          type: WireMessageType.healthOk,
+          payload: const {'state': 'ready'},
+        ).toJsonString(),
+      );
+    }
+
+    test('watchdog: first check sends, engine responds, then session.result '
+        'completes', () async {
+      installSendInterceptor(
+        onSend: (env) {
+          if (env.type == WireMessageType.healthCheck) {
+            Future.microtask(() => emitHealthOk(env.id));
+          }
+        },
+      );
+
+      final client = CytoidGameCoreClient(
+        methodChannel: primaryChannel,
+        eventStream: events.stream,
+      );
+      final session = PlaySession(client, watchdogConfig: msConfig);
+
+      final runFuture = session.run(
+        launch: _buildTestLaunch(),
+        readyTimeout: const Duration(seconds: 2),
+      );
+
+      final startEnvelope = await awaitSentEnvelope(
+        WireMessageType.sessionStart,
+      );
+
+      // Engine acknowledges session start (non-terminal — fresh lastInboundAt).
+      events.add(
+        CytoidGameCoreEnvelope.create(
+          id: startEnvelope.id,
+          type: WireMessageType.sessionStarted,
+          payload: {'sessionId': startEnvelope.id},
+        ).toJsonString(),
+      );
+
+      // Wait for the first health.check; the mock auto-emits health.ok.
+      await awaitSentEnvelope(WireMessageType.healthCheck);
+
+      // Emit session.result to complete the run before any unskipped second
+      // check could fire.
+      final resultJson = _loadFixture('session_result_payload.valid.json');
+      resultJson['sessionId'] = startEnvelope.id;
+      events.add(
+        CytoidGameCoreEnvelope.create(
+          id: startEnvelope.id,
+          type: WireMessageType.sessionResult,
+          payload: resultJson,
+        ).toJsonString(),
+      );
+
+      final result = await runFuture.timeout(
+        const Duration(seconds: 2),
+        onTimeout: () => throw TimeoutException('run() never returned'),
+      );
+      expect(result.outcome.kind, OutcomePayload.completedKind);
+
+      // Exactly ONE health.check was sent. After the first response, the next
+      // scheduled check is skipped via the last-message shortcut (session.started
+      // and health.ok keep lastInboundAt fresh); session.result terminates
+      // before any unskipped second fire.
+      expect(healthCheckSendCount(), 1);
+
+      // hideGameSurface MUST be called in the finally block.
+      expect(primaryCalls.map((c) => c.method), contains('hideGameSurface'));
+    });
+
+    test(
+      'watchdog: first check response timeout throws '
+      'CytoidGameCoreSessionFailedException(code=runtime_unreachable)',
+      () async {
+        // No health.ok response — the watchdog's first check will time out.
+        installSendInterceptor(onSend: (_) {});
+
+        final client = CytoidGameCoreClient(
+          methodChannel: primaryChannel,
+          eventStream: events.stream,
+        );
+        final session = PlaySession(client, watchdogConfig: msConfig);
+
+        final runFuture = session.run(
+          launch: _buildTestLaunch(),
+          readyTimeout: const Duration(seconds: 2),
+        );
+
+        // Wait for the first health.check to confirm the watchdog armed and ran.
+        await awaitSentEnvelope(WireMessageType.sessionStart);
+        await awaitSentEnvelope(WireMessageType.healthCheck);
+
+        await expectLater(
+          runFuture.timeout(
+            const Duration(seconds: 5),
+            onTimeout: () => throw TimeoutException('run() never threw'),
+          ),
+          throwsA(
+            isA<CytoidGameCoreSessionFailedException>()
+                .having((e) => e.code, 'code', 'runtime_unreachable')
+                .having(
+                  (e) => e.message,
+                  'message mentions health.check',
+                  contains('health.check'),
+                )
+                .having(
+                  (e) => e.message,
+                  'message mentions watchdog',
+                  contains('watchdog'),
+                ),
+          ),
+        );
+
+        // hideGameSurface MUST be called in the finally block.
+        expect(primaryCalls.map((c) => c.method), contains('hideGameSurface'));
+      },
+    );
+
+    test(
+      'watchdog: last-message shortcut skips health.check while logs.flow',
+      () async {
+        installSendInterceptor(
+          onSend: (env) {
+            if (env.type == WireMessageType.healthCheck) {
+              Future.microtask(() => emitHealthOk(env.id));
+            }
+          },
+        );
+
+        final client = CytoidGameCoreClient(
+          methodChannel: primaryChannel,
+          eventStream: events.stream,
+        );
+        final session = PlaySession(client, watchdogConfig: msConfig);
+
+        final runFuture = session.run(
+          launch: _buildTestLaunch(),
+          readyTimeout: const Duration(seconds: 2),
+        );
+
+        final startEnvelope = await awaitSentEnvelope(
+          WireMessageType.sessionStart,
+        );
+        events.add(
+          CytoidGameCoreEnvelope.create(
+            id: startEnvelope.id,
+            type: WireMessageType.sessionStarted,
+            payload: {'sessionId': startEnvelope.id},
+          ).toJsonString(),
+        );
+
+        // First health.check fires at pollInterval (~100ms) and is NEVER skipped.
+        await awaitSentEnvelope(WireMessageType.healthCheck);
+        // Let the mock's microtask health.ok land + scheduleNextCheck arm.
+        await Future<void>.delayed(const Duration(milliseconds: 20));
+
+        // Emit logs.batch every 50ms (faster than pollInterval=100ms) — this
+        // keeps lastInboundAt fresh and forces every subsequent scheduled check
+        // to be skipped via the last-message shortcut.
+        //
+        // CRITICAL: real logs.batch envelopes carry a fresh UUID id emitted by
+        // GameLogBridge.cs (NOT the sessionId). Using startEnvelope.id here
+        // would bypass the production code path: lastInboundAt must refresh
+        // from ANY non-terminal envelope regardless of its id. The UUID id
+        // proves the shortcut works against real envelope shapes.
+        var logsBatchCounter = 0;
+        final logsTimer = Timer.periodic(const Duration(milliseconds: 50), (_) {
+          logsBatchCounter += 1;
+          events.add(
+            CytoidGameCoreEnvelope.create(
+              id:
+                  'log-batch-$logsBatchCounter-'
+                  '${DateTime.now().microsecondsSinceEpoch}',
+              type: WireMessageType.logsBatch,
+              payload: const {'entries': []},
+            ).toJsonString(),
+          );
+        });
+
+        try {
+          // 4x pollInterval elapsed with logs flowing — only the FIRST check
+          // should have been sent; all subsequent scheduled checks were skipped.
+          await Future<void>.delayed(const Duration(milliseconds: 400));
+          expect(healthCheckSendCount(), 1);
+        } finally {
+          logsTimer.cancel();
+        }
+
+        // Logs stopped — the next scheduled check is no longer skipped because
+        // lastInboundAt is now staler than pollInterval.
+        await waitForHealthCheckCount(2);
+
+        // Cleanup: emit session.result so run() completes cleanly.
+        final resultJson = _loadFixture('session_result_payload.valid.json');
+        resultJson['sessionId'] = startEnvelope.id;
+        events.add(
+          CytoidGameCoreEnvelope.create(
+            id: startEnvelope.id,
+            type: WireMessageType.sessionResult,
+            payload: resultJson,
+          ).toJsonString(),
+        );
+        await runFuture.timeout(
+          const Duration(seconds: 2),
+          onTimeout: () => throw TimeoutException('run() never returned'),
+        );
+      },
+    );
+
+    test('watchdog: second check uses steadyResponseTimeout (shorter) not '
+        'firstResponseTimeout', () async {
+      var healthCheckCount = 0;
+      DateTime? secondCheckSentAt;
+      installSendInterceptor(
+        onSend: (env) {
+          if (env.type != WireMessageType.healthCheck) return;
+          healthCheckCount += 1;
+          if (healthCheckCount == 1) {
+            // Respond promptly to mark the first check as completed — subsequent
+            // checks use steadyResponseTimeout.
+            Future.microtask(() => emitHealthOk(env.id));
+          } else {
+            // Second check: record send time, do NOT respond. The watchdog's
+            // steadyResponseTimeout timer will fire and complete the session
+            // with runtime_unreachable.
+            secondCheckSentAt ??= DateTime.now();
+          }
+        },
+      );
+
+      final client = CytoidGameCoreClient(
+        methodChannel: primaryChannel,
+        eventStream: events.stream,
+      );
+      final session = PlaySession(client, watchdogConfig: msConfig);
+
+      final runFuture = session.run(
+        launch: _buildTestLaunch(),
+        readyTimeout: const Duration(seconds: 2),
+      );
+
+      await awaitSentEnvelope(WireMessageType.sessionStart);
+      // First check fires at ~pollInterval; respond promptly.
+      await waitForHealthCheckCount(1);
+      // Second check fires ~pollInterval after the first response — do not
+      // respond. secondCheckSentAt is now set inside the interceptor closure.
+      await waitForHealthCheckCount(2);
+
+      Object? caught;
+      try {
+        await runFuture;
+      } catch (e) {
+        caught = e;
+      }
+      final throwAt = DateTime.now();
+
+      expect(caught, isA<CytoidGameCoreSessionFailedException>());
+
+      final elapsedMs = throwAt.difference(secondCheckSentAt!).inMilliseconds;
+      // steadyResponseTimeout=200ms. The throw should land in
+      // [0.8*steady, 3*steady] and well below firstResponseTimeout=2000ms.
+      expect(
+        elapsedMs,
+        greaterThanOrEqualTo(160),
+        reason: 'should not fire faster than 0.8*steadyResponseTimeout',
+      );
+      expect(
+        elapsedMs,
+        lessThan(1500),
+        reason: 'should fire well before firstResponseTimeout',
+      );
+    });
+
+    test('watchdog: terminal session.result cancels pending watchdog, no late '
+        'session.failed fires', () async {
+      installSendInterceptor(
+        onSend: (env) {
+          if (env.type == WireMessageType.healthCheck) {
+            Future.microtask(() => emitHealthOk(env.id));
+          }
+        },
+      );
+
+      final client = CytoidGameCoreClient(
+        methodChannel: primaryChannel,
+        eventStream: events.stream,
+      );
+      final session = PlaySession(client, watchdogConfig: msConfig);
+
+      final runFuture = session.run(
+        launch: _buildTestLaunch(),
+        readyTimeout: const Duration(seconds: 2),
+      );
+
+      final startEnvelope = await awaitSentEnvelope(
+        WireMessageType.sessionStart,
+      );
+      events.add(
+        CytoidGameCoreEnvelope.create(
+          id: startEnvelope.id,
+          type: WireMessageType.sessionStarted,
+          payload: {'sessionId': startEnvelope.id},
+        ).toJsonString(),
+      );
+
+      // Wait for first health.check (and let mock respond with health.ok).
+      await awaitSentEnvelope(WireMessageType.healthCheck);
+      // Let the response land and scheduleNextCheck arm the second check.
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+
+      // Emit session.result BEFORE the second check would fire (pollInterval=
+      // 100ms). The watchdog's cancelSubscription closure sets disposed=true
+      // and cancels watchdogTimer.
+      final resultJson = _loadFixture('session_result_payload.valid.json');
+      resultJson['sessionId'] = startEnvelope.id;
+      events.add(
+        CytoidGameCoreEnvelope.create(
+          id: startEnvelope.id,
+          type: WireMessageType.sessionResult,
+          payload: resultJson,
+        ).toJsonString(),
+      );
+
+      final result = await runFuture.timeout(
+        const Duration(seconds: 2),
+        onTimeout: () => throw TimeoutException('run() never returned'),
+      );
+      expect(result.outcome.kind, OutcomePayload.completedKind);
+
+      // Wait past what would have been the second check window — if disposal
+      // didn't cancel the timer, a second health.check would have fired by now.
+      await Future<void>.delayed(const Duration(milliseconds: 400));
+
+      // Exactly ONE health.check was sent — the disposed/completer.isCompleted
+      // guard cancelled the scheduled second check before it could run.
+      expect(healthCheckSendCount(), 1);
+      expect(primaryCalls.map((c) => c.method), contains('hideGameSurface'));
     });
   });
 }


### PR DESCRIPTION
## Summary

Adds a Dart-side `health.check` watchdog to `PlaySession` that fills the v2 liveness gap left by PR #177. When Unity's main loop freezes with the process still alive (storyboard death-spiral, GC stall, audio deadlock), the native bridge's existing synthesis paths (`runtime_exception` / `runtime_unreachable` / `runtime_recreated` / `runtime_surface_lost`) don't fire — the JNI call still succeeds, no exception propagates, and `PlaySession.run` waited forever. This watchdog detects that gap by polling `health.check` / `health.ok` (an existing v2 primitive the engine already answers) and synthesizes `session.failed(runtime_unreachable)` on timeout.

Closes the `health.check watchdog` follow-up explicitly listed in PR #177's description.

## Behavior

- After `session.start`, the watchdog sends `health.check` every `pollInterval` (default 10s).
- **First check** response timeout = **30s** (cold/loading engine, matching `waitForReady`'s default). **Subsequent** = **10s** (steady-state).
- **Last-message shortcut**: a check is skipped when a non-terminal engine envelope (`logs.batch` / `session.started` / `settings.applied` / `engine.error` / prior `health.ok`) arrived within the last `pollInterval`. On log-heavy charts this eliminates redundant polling; the engine has already self-proven liveness. Zero false-negative risk — a frozen engine stops emitting too.
- On response timeout: throws `CytoidGameCoreSessionFailedException(code: 'runtime_unreachable')` with a `message` carrying watchdog provenance. The surface is hidden via the existing `run()` finally block.
- Default-on (`PlaySession(client)` arms the watchdog); `watchdogConfig: null` opts out (back-compat escape hatch).

## Design decisions

| Decision | Choice | Rationale |
|---|---|---|
| Error code on timeout | Reuse `runtime_unreachable` (not a new `runtime_unresponsive`) | User decision: "watchdog 不可达就是一种 runtime_unreachable，debug 场景看 message 区分." The `message` field carries the provenance. |
| Pure last-message vs health.check vs hybrid | **Hybrid (Design B)**: health.check is the ground truth; last-message is a skip-shortcut | Pure last-message has false-positives on silent-but-healthy charts (GameLogBridge emits nothing when the 2s buffer is empty). Health.check alone is correct but redundant on log-heavy charts. The hybrid is correct AND efficient. |
| Test timing | Millisecond-scale config injection (not FakeAsync) | Matches existing test style; avoids Flutter-binding + FakeAsync mixing fragility. |
| Backward compat | Default-on, nullable opt-out | Existing callers get the watchdog automatically; `null` preserves old behavior for tests/advanced callers. |

## Protocol doc

`docs/host-protocol-v2.md` updated:
- Health Check section: documents the host-side watchdog contract (30s first / 10s steady, skip-on-recent-envelope, `runtime_unreachable` synthesis).
- Active-Session Runtime Failure: adds the host-side watchdog as a second producer of `session.failed(runtime_unreachable)` alongside the native bridge (distinguished by `message`).
- Error code table: `runtime_unreachable` row updated to cover both producers.

The C# `health.check` handler (`GameBridgeRouter.HandleHealthCheck` at `engines/unity/Assets/Scripts/Host/GameBridgeRouter.cs`) returns `health.ok` with `engine` / `generation` / `state` (busy/ready/starting) / `activeSessionId` — already present from the v2 migration, verified compatible with the watchdog's response matching.

## Test coverage

99/99 plugin tests pass (was 88 before this PR + 11 new). The 7 new watchdog scenarios:

1. First check sends, engine responds, `session.result` completes.
2. First-check response timeout → `runtime_unreachable` (code + message asserts).
3. Last-message shortcut: `logs.batch` flow → checks skipped; logs stop → check sent. **Uses realistic UUID envelope ids** (not the sessionId) to prove the shortcut works against real `GameLogBridge` output.
4. Second check uses `steadyResponseTimeout` (200ms) not `firstResponseTimeout` (2000ms) — numerically asserted.
5. Terminal `session.result` cancels the pending watchdog — no late `session.failed`.
6. Late stream error after `session.result` is silently dropped (no `StateError`) — uses a `sync: true` broadcast controller to actually trigger the race.
7. Default constructor arms the watchdog; `null` config disables it (contract lock).

## Review

Passed a 5-agent parallel review (Goal / QA / Code-Quality / Security / Context-Mining). Two MAJOR findings from the initial Code-Quality pass were fixed before merge:
- Per-check `health.ok` listener now has a silent `onError` (broadcast streams deliver errors to every subscription).
- In-flight per-check resources (`okSub` + timer) now lifted to outer scope and cancelled in `cancelSubscription` — every exit path cleans up immediately.

## Commits

- `91beb6ff` docs(v2-protocol): document host-side health.check watchdog + runtime_unreachable dual-producer
- `1270ebd3` feat(plugin): add HealthCheckWatchdogConfig for v2 session watchdog
- `b5fe746d` feat(plugin): v2 health.check watchdog in PlaySession with last-message shortcut
- `abcd82dd` fix(review): per-check onError + in-flight cleanup + doc contradiction + default/opt-out tests


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a default-on `health.check` watchdog for play sessions, configurable via `HealthCheckWatchdogConfig` (30s first response timeout, then 10s; 10s poll). Full opt-out is available with `watchdogConfig: null`.
* **Bug Fixes**
  * Improved active-session runtime timeout handling to fail consistently with `runtime_unreachable`, with clearer terminal-failure semantics.
* **Tests**
  * Expanded coverage for watchdog scheduling, timeouts, cancellation, and stream error edge cases.
* **Documentation**
  * Updated protocol and guidance to reflect watchdog cadence, skip behavior, and timeout failure behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->