### PR TITLE
fix(game): keep safe-area adaptation horizontal-only

### DIFF
--- a/engines/unity/Assets/Scripts/Game/Screens/Overlay/OverlayScreen.cs
+++ b/engines/unity/Assets/Scripts/Game/Screens/Overlay/OverlayScreen.cs
@@ -90,10 +90,8 @@ public class OverlayScreen : Screen
     {
         var left = safeArea.xMin / canvasScale;
         var right = (UnityEngine.Screen.width - safeArea.xMax) / canvasScale;
-        var top = (UnityEngine.Screen.height - safeArea.yMax) / canvasScale;
-        var bottom = safeArea.yMin / canvasScale;
         var horizontal = Mathf.Min(Mathf.Max(left, right), UnityEngine.Screen.width * 0.5f / canvasScale);
-        return new Vector4(horizontal, bottom, horizontal, top);
+        return new Vector4(horizontal, 0, horizontal, 0);
     }
 
     private float GetCanvasScale()


### PR DESCRIPTION
## Summary

`OverlayScreen` previously applied four-direction safe-area insets. This drops the vertical (`top` / `bottom`) insets and keeps horizontal-only adaptation.

## Rationale

- App is **landscape-locked** (`ProjectSettings.asset`: `allowedAutorotateToLandscapeLeft/Right = 1`, portrait = 0). Notch / Dynamic Island only intrudes on the **left/right** edges in landscape.
- Vertical safe-area padding shrank the overlay (pause / result / failed screens) without any real-world benefit.
- Game-scene gameplay elements (`Scanner`, notes, judgment area) already use full screen width and are intentionally unaffected — this PR keeps that contract for the overlay too.

## Change

`engines/unity/Assets/Scripts/Game/Screens/Overlay/OverlayScreen.cs` — `GetSafeAreaInsets`:

```csharp
// before
return new Vector4(horizontal, bottom, horizontal, top);

// after
return new Vector4(horizontal, 0, horizontal, 0);
```

The local `top` / `bottom` computations are removed.

## Scope

- ✅ Touched: `OverlayScreen` only
- ❌ Not touched: `Scanner`, `Navigation`, `PlayerSettings.AdaptOverlayToSafeArea` (toggle still works — when off, insets are already `Vector4.zero`), CanvasScaler logic, caching, `LateUpdate` polling, `TransitionElement` refresh

## Equivalent-path verification

Downstream `RectTransformSnapshot.Apply` consumes `insets.y` (bottom) and `insets.w` (top):

| Call site | New behavior with `0` |
|---|---|
| `position.y += insets.y` (bottom-anchor) | `+= 0` → noop |
| `position.y -= insets.w` (top-anchor) | `-= 0` → noop |
| `offsetMin.y = offsetMin.y + insets.y` (y-stretch) | `+ 0` → noop |
| `offsetMax.y = offsetMax.y - insets.w` (y-stretch) | `- 0` → noop |

All vertical paths degenerate to identity; horizontal paths (`insets.x` / `insets.z`) are byte-for-byte unchanged.

## Not yet verified

- No on-device visual regression test (requires landscape iPhone with Dynamic Island / Pixel fold). Static equivalence is exact; behavior change is limited to "top/bottom padding gone."
- Unity Editor compile not run in this environment, but the edit is a literal replacement with no signature/type change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted safe-area handling so vertical margins are no longer applied in overlay screens, helping content use the full height of the display.
  * Horizontal safe-area spacing remains in effect for devices that need it.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->