### PR TITLE
refactor(audio): replace Controller hierarchy with `AudioServer` pattern

### DIFF
--- a/engines/unity/Assets/Scripts/Audio.meta
+++ b/engines/unity/Assets/Scripts/Audio.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7c104967b14034de1a390d9dcbddda0f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/engines/unity/Assets/Scripts/Audio/AudioServerType.cs
+++ b/engines/unity/Assets/Scripts/Audio/AudioServerType.cs
@@ -1,0 +1,9 @@
+/// <summary>
+/// User-selectable audio backend. Stored in LocalPlayerSettings and applied at AudioManager.Initialize().
+/// </summary>
+public enum AudioServerType
+{
+    Unity = 0,
+    Exceed7 = 1,
+    Bass = 2
+}

--- a/engines/unity/Assets/Scripts/Audio/AudioServerType.cs.meta
+++ b/engines/unity/Assets/Scripts/Audio/AudioServerType.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3e74372aa99074b0fa08eba0f07c1c24

--- a/engines/unity/Assets/Scripts/Audio/IAudioServer.cs
+++ b/engines/unity/Assets/Scripts/Audio/IAudioServer.cs
@@ -1,0 +1,29 @@
+using UnityEngine;
+
+/// <summary>
+/// Complete audio backend abstraction. Each implementation is a user-selectable
+/// audio server that handles both music and sound effects.
+/// </summary>
+public interface IAudioServer
+{
+    void Initialize();
+    void Dispose();
+
+    // Music
+    IMusicTrack LoadMusic(string id, AudioClip clip, bool isResource);
+    void UnloadMusic();
+    void SetMusicVolume(float volume);
+
+    // Sound effects
+    ISoundEffect LoadSfx(string id, AudioClip clip, bool isResource, bool isPreloaded = false);
+    ISoundEffect GetSfx(string id);
+    void UnloadSfx(string id);
+    bool IsSfxLoaded(string id);
+    void SetSfxVolume(float volume);
+
+    // Both
+    void UpdateVolumes(float musicVolume, float sfxVolume);
+
+    /// <summary>The audio engine's internal clock in seconds, for scheduling alignment.</summary>
+    double AudioClockSeconds { get; }
+}

--- a/engines/unity/Assets/Scripts/Audio/IAudioServer.cs.meta
+++ b/engines/unity/Assets/Scripts/Audio/IAudioServer.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: dd7f927cfe2194db3882760e1f9e9d32

--- a/engines/unity/Assets/Scripts/Audio/IMusicTrack.cs
+++ b/engines/unity/Assets/Scripts/Audio/IMusicTrack.cs
@@ -1,0 +1,24 @@
+/// <summary>
+/// A handle to a playing or loaded music track. Obtained from <see cref="IAudioServer.LoadMusic"/>.
+/// </summary>
+public interface IMusicTrack
+{
+    /// <summary>Schedules playback after a delay. Returns the scheduled start time on the audio clock.</summary>
+    double SchedulePlay(double delaySeconds);
+
+    /// <summary>The scheduled start time on the audio clock, from SchedulePlay's return value.</summary>
+    double ScheduledStartTime { get; }
+
+    /// <summary>Current playback position in seconds. For editor scrubbing and completion detection only — NOT the game clock.</summary>
+    float SourceTimeSeconds { get; set; }
+
+    float Length { get; }
+    float Volume { get; set; }
+    bool IsPlaying { get; }
+    bool IsFinished { get; }
+
+    void Pause();
+    void Resume();
+    void Stop();
+    void Unload();
+}

--- a/engines/unity/Assets/Scripts/Audio/IMusicTrack.cs.meta
+++ b/engines/unity/Assets/Scripts/Audio/IMusicTrack.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: eaefd7460b38a4b9389d3ee7cea2344f

--- a/engines/unity/Assets/Scripts/Audio/ISoundEffect.cs
+++ b/engines/unity/Assets/Scripts/Audio/ISoundEffect.cs
@@ -1,0 +1,12 @@
+/// <summary>
+/// A handle to a loaded sound effect. Obtained from <see cref="IAudioServer.LoadSfx"/> or <see cref="IAudioServer.GetSfx"/>.
+/// </summary>
+public interface ISoundEffect
+{
+    /// <param name="ignoreListenerPause">If true, plays even when AudioListener.pause is true (for UI sounds in paused menus).</param>
+    void Play(bool ignoreListenerPause = false);
+
+    float Volume { get; set; }
+    bool IsPlaying { get; }
+    void Unload();
+}

--- a/engines/unity/Assets/Scripts/Audio/ISoundEffect.cs.meta
+++ b/engines/unity/Assets/Scripts/Audio/ISoundEffect.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 5e88c4dc4c1ae46219b7e84f834fe866

--- a/engines/unity/Assets/Scripts/Audio/Internal.meta
+++ b/engines/unity/Assets/Scripts/Audio/Internal.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8706039c82fec413487477234db497f1
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/engines/unity/Assets/Scripts/Audio/Internal/Exceed7AudioServer.cs
+++ b/engines/unity/Assets/Scripts/Audio/Internal/Exceed7AudioServer.cs
@@ -1,0 +1,56 @@
+using UnityEngine;
+
+/// <summary>
+/// Hybrid audio server: Unity for music (scheduling + clock), NativeAudio for SFX (low latency).
+/// Uses COMPOSITION — holds a private UnityAudioServer and NativeSfxBackend, NOT inheritance.
+/// </summary>
+public class Exceed7AudioServer : IAudioServer
+{
+    private readonly UnityAudioServer _unity;
+    private readonly NativeSfxBackend _native;
+
+    public Exceed7AudioServer(AudioSource musicSource, AudioSource[] sfxPool)
+    {
+        _unity = new UnityAudioServer(musicSource, sfxPool);
+        _native = new NativeSfxBackend();
+    }
+
+    public void Initialize()
+    {
+        _unity.Initialize();
+        _native.Initialize();
+    }
+
+    public void Dispose()
+    {
+        // Reverse order: native first (release native sources), then Unity
+        _native.Dispose();
+        _unity.Dispose();
+    }
+
+    // Music: delegate to Unity (Unity is ALWAYS the music backend, even in Exceed7)
+    public IMusicTrack LoadMusic(string id, AudioClip clip, bool isResource)
+        => _unity.LoadMusic(id, clip, isResource);
+
+    public void UnloadMusic() => _unity.UnloadMusic();
+    public void SetMusicVolume(float volume) => _unity.SetMusicVolume(volume);
+
+    // SFX: delegate to Native
+    public ISoundEffect LoadSfx(string id, AudioClip clip, bool isResource, bool isPreloaded = false)
+        => _native.LoadSfx(id, clip, isResource, isPreloaded);
+
+    public ISoundEffect GetSfx(string id) => _native.GetSfx(id);
+    public void UnloadSfx(string id) => _native.UnloadSfx(id);
+    public bool IsSfxLoaded(string id) => _native.IsSfxLoaded(id);
+    public void SetSfxVolume(float volume) => _native.SetSfxVolume(volume);
+
+    // Both
+    public void UpdateVolumes(float musicVolume, float sfxVolume)
+    {
+        _unity.SetMusicVolume(musicVolume);
+        _native.SetSfxVolume(sfxVolume);
+    }
+
+    // HARD INVARIANT: Unity is always the music clock, even in Exceed7
+    public double AudioClockSeconds => _unity.AudioClockSeconds;
+}

--- a/engines/unity/Assets/Scripts/Audio/Internal/Exceed7AudioServer.cs.meta
+++ b/engines/unity/Assets/Scripts/Audio/Internal/Exceed7AudioServer.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: edfcd3e3125544b7ea17eaf0c9383df3

--- a/engines/unity/Assets/Scripts/Audio/Internal/NativeSfxBackend.cs
+++ b/engines/unity/Assets/Scripts/Audio/Internal/NativeSfxBackend.cs
@@ -125,8 +125,7 @@ internal class NativeSfxBackend
             var sourceIndex = parent.GetNextNativeSourceIndex();
             source = NativeAudio.GetNativeSource(sourceIndex);
             source.Play(pointer);
-            // Clamp on all platforms: some OpenAL/OpenSL implementations break on very small gain values
-            source.SetVolume(volume >= 0.05f ? volume : float.Epsilon);
+            source.SetVolume(volume);
             isPlaying = true;
         }
 

--- a/engines/unity/Assets/Scripts/Audio/Internal/NativeSfxBackend.cs
+++ b/engines/unity/Assets/Scripts/Audio/Internal/NativeSfxBackend.cs
@@ -52,6 +52,8 @@ internal class NativeSfxBackend
 
     public ISoundEffect LoadSfx(string id, AudioClip clip, bool isResource, bool isPreloaded)
     {
+        if (sfx.TryGetValue(id, out var existing))
+            existing.Unload();
         var effect = new NativeSoundEffect(this, clip, isPreloaded);
         sfx[id] = effect;
         return effect;

--- a/engines/unity/Assets/Scripts/Audio/Internal/NativeSfxBackend.cs
+++ b/engines/unity/Assets/Scripts/Audio/Internal/NativeSfxBackend.cs
@@ -29,10 +29,7 @@ internal class NativeSfxBackend
             entry.Value.Stop();
 
         foreach (var entry in sfx)
-        {
-            if (!entry.Value.IsPreloaded)
-                entry.Value.UnloadPointerSync();
-        }
+            entry.Value.UnloadPointerSync();
 
         try { NativeAudio.Dispose(); }
         catch (Exception e) { Debug.LogError($"Error disposing native audio: {e}"); }

--- a/engines/unity/Assets/Scripts/Audio/Internal/NativeSfxBackend.cs
+++ b/engines/unity/Assets/Scripts/Audio/Internal/NativeSfxBackend.cs
@@ -25,8 +25,13 @@ internal class NativeSfxBackend
 
     public void Dispose()
     {
-        foreach (var entry in sfx)
-            entry.Value.Stop();
+        if (NativeAudio.Initialized)
+        {
+            // Stop ALL native sources first — ensures no play head is reading any pointer's memory
+            var sourceCount = NativeAudio.GetNativeSourceCount();
+            for (var i = 0; i < sourceCount; i++)
+                NativeAudio.GetNativeSource(i).Stop();
+        }
 
         foreach (var entry in sfx)
             entry.Value.UnloadPointerSync();

--- a/engines/unity/Assets/Scripts/Audio/Internal/NativeSfxBackend.cs
+++ b/engines/unity/Assets/Scripts/Audio/Internal/NativeSfxBackend.cs
@@ -115,18 +115,7 @@ internal class NativeSfxBackend
         public float Volume
         {
             get => volume;
-            set
-            {
-                volume = value;
-                if (source.IsValid)
-                {
-#if UNITY_ANDROID
-                    source.SetVolume(volume >= 0.05f ? volume : float.Epsilon);
-#else
-                    source.SetVolume(volume);
-#endif
-                }
-            }
+            set => volume = Mathf.Clamp01(value);
         }
 
         public bool IsPlaying => isPlaying;
@@ -136,11 +125,8 @@ internal class NativeSfxBackend
             var sourceIndex = parent.GetNextNativeSourceIndex();
             source = NativeAudio.GetNativeSource(sourceIndex);
             source.Play(pointer);
-#if UNITY_ANDROID
+            // Clamp on all platforms: some OpenAL/OpenSL implementations break on very small gain values
             source.SetVolume(volume >= 0.05f ? volume : float.Epsilon);
-#else
-            source.SetVolume(volume);
-#endif
             isPlaying = true;
         }
 

--- a/engines/unity/Assets/Scripts/Audio/Internal/NativeSfxBackend.cs
+++ b/engines/unity/Assets/Scripts/Audio/Internal/NativeSfxBackend.cs
@@ -26,26 +26,16 @@ internal class NativeSfxBackend
     public void Dispose()
     {
         foreach (var entry in sfx)
-        {
             entry.Value.Stop();
-        }
 
         foreach (var entry in sfx)
         {
             if (!entry.Value.IsPreloaded)
-            {
-                entry.Value.Unload();
-            }
+                entry.Value.UnloadPointerSync();
         }
 
-        try
-        {
-            NativeAudio.Dispose();
-        }
-        catch (Exception e)
-        {
-            Debug.LogError($"Error disposing native audio: {e}");
-        }
+        try { NativeAudio.Dispose(); }
+        catch (Exception e) { Debug.LogError($"Error disposing native audio: {e}"); }
 
         sfx.Clear();
     }
@@ -139,6 +129,12 @@ internal class NativeSfxBackend
                 await UniTask.DelayFrame(10);
                 pointer.Unload();
             });
+        }
+
+        internal void UnloadPointerSync()
+        {
+            Stop();
+            pointer.Unload();
         }
 
         public void Stop()

--- a/engines/unity/Assets/Scripts/Audio/Internal/NativeSfxBackend.cs
+++ b/engines/unity/Assets/Scripts/Audio/Internal/NativeSfxBackend.cs
@@ -1,0 +1,166 @@
+using System;
+using System.Collections.Generic;
+using Cysharp.Threading.Tasks;
+using E7.Native;
+using UnityEngine;
+
+internal class NativeSfxBackend
+{
+    private readonly Dictionary<string, NativeSoundEffect> sfx = new();
+    private int _nextNativeSource;
+    private float sfxVolume;
+
+    public void Initialize()
+    {
+        var options = new NativeAudio.InitializationOptions
+        {
+            androidAudioTrackCount = 2,
+            androidBufferSize = -1
+        };
+        NativeAudio.Initialize(options);
+        Debug.Log($"Native Audio initialized with {NativeAudio.GetNativeSourceCount()} sources");
+        _nextNativeSource = 0;
+        sfxVolume = Context.Player.Settings.SoundEffectsVolume;
+    }
+
+    public void Dispose()
+    {
+        foreach (var entry in sfx)
+        {
+            entry.Value.Stop();
+        }
+
+        foreach (var entry in sfx)
+        {
+            if (!entry.Value.IsPreloaded)
+            {
+                entry.Value.Unload();
+            }
+        }
+
+        try
+        {
+            NativeAudio.Dispose();
+        }
+        catch (Exception e)
+        {
+            Debug.LogError($"Error disposing native audio: {e}");
+        }
+
+        sfx.Clear();
+    }
+
+    public ISoundEffect LoadSfx(string id, AudioClip clip, bool isResource, bool isPreloaded)
+    {
+        var effect = new NativeSoundEffect(this, clip, isPreloaded);
+        sfx[id] = effect;
+        return effect;
+    }
+
+    public ISoundEffect GetSfx(string id)
+    {
+        return sfx.TryGetValue(id, out var effect) ? effect : null;
+    }
+
+    public void UnloadSfx(string id)
+    {
+        if (sfx.TryGetValue(id, out var effect))
+        {
+            effect.Unload();
+            sfx.Remove(id);
+        }
+    }
+
+    public bool IsSfxLoaded(string id)
+    {
+        return sfx.ContainsKey(id);
+    }
+
+    public void SetSfxVolume(float vol)
+    {
+        sfxVolume = vol;
+        foreach (var entry in sfx)
+        {
+            entry.Value.Volume = vol;
+        }
+    }
+
+    internal int GetNextNativeSourceIndex()
+    {
+        var index = _nextNativeSource;
+        _nextNativeSource = (_nextNativeSource + 1) % NativeAudio.GetNativeSourceCount();
+        return index;
+    }
+
+    internal class NativeSoundEffect : ISoundEffect
+    {
+        private readonly NativeSfxBackend parent;
+        private NativeSource source;
+        private NativeAudioPointer pointer;
+        private readonly float length;
+        private float volume;
+        private bool isPlaying;
+
+        internal bool IsPreloaded { get; }
+
+        public NativeSoundEffect(NativeSfxBackend parent, AudioClip clip, bool isPreloaded)
+        {
+            this.parent = parent;
+            pointer = NativeAudio.Load(clip, NativeAudio.LoadOptions.defaultOptions);
+            length = clip.length;
+            volume = Context.Player.Settings.SoundEffectsVolume;
+            IsPreloaded = isPreloaded;
+        }
+
+        public float Volume
+        {
+            get => volume;
+            set
+            {
+                volume = value;
+                if (source.IsValid)
+                {
+#if UNITY_ANDROID
+                    source.SetVolume(volume >= 0.05f ? volume : float.Epsilon);
+#else
+                    source.SetVolume(volume);
+#endif
+                }
+            }
+        }
+
+        public bool IsPlaying => isPlaying;
+
+        public void Play(bool ignoreListenerPause = false)
+        {
+            var sourceIndex = parent.GetNextNativeSourceIndex();
+            source = NativeAudio.GetNativeSource(sourceIndex);
+            source.Play(pointer);
+#if UNITY_ANDROID
+            source.SetVolume(volume >= 0.05f ? volume : float.Epsilon);
+#else
+            source.SetVolume(volume);
+#endif
+            isPlaying = true;
+        }
+
+        public void Unload()
+        {
+            Stop();
+            UniTask.Void(async () =>
+            {
+                await UniTask.DelayFrame(10);
+                pointer.Unload();
+            });
+        }
+
+        public void Stop()
+        {
+            isPlaying = false;
+            if (source.IsValid)
+            {
+                source.Stop();
+            }
+        }
+    }
+}

--- a/engines/unity/Assets/Scripts/Audio/Internal/NativeSfxBackend.cs.meta
+++ b/engines/unity/Assets/Scripts/Audio/Internal/NativeSfxBackend.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 82f7ba6d3c20343ccabf59c009550d41

--- a/engines/unity/Assets/Scripts/Audio/Internal/UnityAudioServer.cs
+++ b/engines/unity/Assets/Scripts/Audio/Internal/UnityAudioServer.cs
@@ -15,7 +15,7 @@ public class UnityAudioServer : IAudioServer
     private float musicVolume;
     private float sfxVolume;
 
-    private class RoundRobinIndex
+    internal class RoundRobinIndex
     {
         public int Value;
         public int PoolSize;

--- a/engines/unity/Assets/Scripts/Audio/Internal/UnityAudioServer.cs
+++ b/engines/unity/Assets/Scripts/Audio/Internal/UnityAudioServer.cs
@@ -1,0 +1,125 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+/// <summary>
+/// Unity-only audio server implementation. Manages a dedicated music AudioSource
+/// and a round-robin SFX pool. The backend used when AudioServerType is Unity.
+/// </summary>
+public class UnityAudioServer : IAudioServer
+{
+    private readonly AudioSource musicSource;
+    private readonly AudioSource[] sfxPool;
+    private readonly Dictionary<string, UnitySoundEffect> sfx = new Dictionary<string, UnitySoundEffect>();
+    private UnityMusicTrack currentMusic;
+    private float musicVolume;
+    private float sfxVolume;
+
+    private class RoundRobinIndex
+    {
+        public int Value;
+        public int PoolSize;
+        public int Next() => Value++ % PoolSize;
+    }
+
+    private readonly RoundRobinIndex sfxRoundRobin;
+
+    public UnityAudioServer(AudioSource musicSource, AudioSource[] sfxPool)
+    {
+        this.musicSource = musicSource;
+        this.sfxPool = sfxPool;
+        this.sfxRoundRobin = new RoundRobinIndex { Value = 0, PoolSize = sfxPool.Length };
+    }
+
+    public void Initialize()
+    {
+        musicVolume = Context.Player.Settings.MusicVolume;
+        sfxVolume = Context.Player.Settings.SoundEffectsVolume;
+    }
+
+    public void Dispose()
+    {
+        // Unload all non-preloaded SFX
+        var sfxKeys = new List<string>(sfx.Keys);
+        foreach (var id in sfxKeys)
+        {
+            var effect = sfx[id];
+            if (!effect.IsPreloaded)
+            {
+                effect.Unload();
+                sfx.Remove(id);
+            }
+        }
+
+        // Unload music if loaded
+        if (currentMusic != null)
+        {
+            currentMusic.Unload();
+            currentMusic = null;
+        }
+    }
+
+    public IMusicTrack LoadMusic(string id, AudioClip clip, bool isResource)
+    {
+        currentMusic = new UnityMusicTrack(musicSource, clip, isResource);
+        return currentMusic;
+    }
+
+    public void UnloadMusic()
+    {
+        if (currentMusic != null)
+        {
+            currentMusic.Unload();
+            currentMusic = null;
+        }
+    }
+
+    public void SetMusicVolume(float volume)
+    {
+        musicVolume = volume;
+        if (currentMusic != null)
+        {
+            currentMusic.Volume = musicVolume;
+        }
+    }
+
+    public ISoundEffect LoadSfx(string id, AudioClip clip, bool isResource, bool isPreloaded = false)
+    {
+        var effect = new UnitySoundEffect(sfxPool, sfxRoundRobin, clip, isResource, isPreloaded);
+        sfx[id] = effect;
+        return effect;
+    }
+
+    public ISoundEffect GetSfx(string id)
+    {
+        return sfx.TryGetValue(id, out var effect) ? effect : null;
+    }
+
+    public void UnloadSfx(string id)
+    {
+        if (sfx.TryGetValue(id, out var effect))
+        {
+            effect.Unload();
+            sfx.Remove(id);
+        }
+    }
+
+    public bool IsSfxLoaded(string id) => sfx.ContainsKey(id);
+
+    public void SetSfxVolume(float volume)
+    {
+        sfxVolume = volume;
+        foreach (var effect in sfx.Values)
+        {
+            effect.Volume = sfxVolume;
+        }
+    }
+
+    public void UpdateVolumes(float musicVolume, float sfxVolume)
+    {
+        SetMusicVolume(musicVolume);
+        SetSfxVolume(sfxVolume);
+    }
+
+    public double AudioClockSeconds => AudioSettings.dspTime;
+}

--- a/engines/unity/Assets/Scripts/Audio/Internal/UnityAudioServer.cs
+++ b/engines/unity/Assets/Scripts/Audio/Internal/UnityAudioServer.cs
@@ -85,6 +85,8 @@ public class UnityAudioServer : IAudioServer
 
     public ISoundEffect LoadSfx(string id, AudioClip clip, bool isResource, bool isPreloaded = false)
     {
+        if (sfx.TryGetValue(id, out var existing))
+            existing.Unload();
         var effect = new UnitySoundEffect(sfxPool, sfxRoundRobin, clip, isResource, isPreloaded);
         sfx[id] = effect;
         return effect;

--- a/engines/unity/Assets/Scripts/Audio/Internal/UnityAudioServer.cs.meta
+++ b/engines/unity/Assets/Scripts/Audio/Internal/UnityAudioServer.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 175f9f95a044d44d89de26fd8e35e6b0

--- a/engines/unity/Assets/Scripts/Audio/Internal/UnityMusicTrack.cs
+++ b/engines/unity/Assets/Scripts/Audio/Internal/UnityMusicTrack.cs
@@ -1,3 +1,4 @@
+using System;
 using UnityEngine;
 
 /// <summary>
@@ -87,7 +88,7 @@ public class UnityMusicTrack : IMusicTrack
 
             if (!isResource)
             {
-                Object.Destroy(audioClip);
+                UnityEngine.Object.Destroy(audioClip);
             }
             else
             {

--- a/engines/unity/Assets/Scripts/Audio/Internal/UnityMusicTrack.cs
+++ b/engines/unity/Assets/Scripts/Audio/Internal/UnityMusicTrack.cs
@@ -1,0 +1,98 @@
+using UnityEngine;
+
+/// <summary>
+/// Unity-only music track implementation. Uses a dedicated AudioSource.
+/// </summary>
+public class UnityMusicTrack : IMusicTrack
+{
+    private readonly AudioSource source;
+    private readonly AudioClip audioClip;
+    private readonly bool isResource;
+    private double scheduledStartTime;
+
+    public UnityMusicTrack(AudioSource source, AudioClip clip, bool isResource)
+    {
+        this.source = source;
+        this.audioClip = clip;
+        this.isResource = isResource;
+        this.scheduledStartTime = 0;
+        Volume = Context.Player.Settings.MusicVolume;
+    }
+
+    public double SchedulePlay(double delaySeconds)
+    {
+        var time = AudioSettings.dspTime + delaySeconds;
+        source.PlayScheduled(time);
+        scheduledStartTime = time;
+        return time;
+    }
+
+    public double ScheduledStartTime => scheduledStartTime;
+
+    public float SourceTimeSeconds
+    {
+        get => source.timeSamples * 1f / source.clip.frequency;
+        set => source.time = value;
+    }
+
+    public float Length => audioClip.length;
+
+    private float volume;
+    public float Volume
+    {
+        get => volume;
+        set
+        {
+            volume = value;
+            source.volume = volume;
+        }
+    }
+
+    public bool IsPlaying => source.isPlaying;
+
+    public bool IsFinished => !source.isPlaying;
+
+    public void Pause()
+    {
+        source.Pause();
+    }
+
+    public void Resume()
+    {
+        source.UnPause();
+    }
+
+    public void Stop()
+    {
+        source.Stop();
+    }
+
+    public void Unload()
+    {
+        Stop();
+        source.clip = null;
+
+        if (audioClip != null)
+        {
+            try
+            {
+                audioClip.UnloadAudioData();
+            }
+            catch (MissingReferenceException)
+            {
+            }
+            catch (NullReferenceException)
+            {
+            }
+
+            if (!isResource)
+            {
+                Object.Destroy(audioClip);
+            }
+            else
+            {
+                Resources.UnloadAsset(audioClip);
+            }
+        }
+    }
+}

--- a/engines/unity/Assets/Scripts/Audio/Internal/UnityMusicTrack.cs
+++ b/engines/unity/Assets/Scripts/Audio/Internal/UnityMusicTrack.cs
@@ -22,6 +22,8 @@ public class UnityMusicTrack : IMusicTrack
 
     public double SchedulePlay(double delaySeconds)
     {
+        source.clip = audioClip;
+        source.volume = Volume;
         var time = AudioSettings.dspTime + delaySeconds;
         source.PlayScheduled(time);
         scheduledStartTime = time;

--- a/engines/unity/Assets/Scripts/Audio/Internal/UnityMusicTrack.cs.meta
+++ b/engines/unity/Assets/Scripts/Audio/Internal/UnityMusicTrack.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8adc0faa2cf7c416fa649752073f75eb

--- a/engines/unity/Assets/Scripts/Audio/Internal/UnitySoundEffect.cs
+++ b/engines/unity/Assets/Scripts/Audio/Internal/UnitySoundEffect.cs
@@ -14,7 +14,7 @@ public class UnitySoundEffect : ISoundEffect
 
     private int lastIndex = -1;
 
-    public UnitySoundEffect(AudioSource[] pool, UnityAudioServer.RoundRobinIndex roundRobinIndex, AudioClip clip, bool isResource, bool isPreloaded)
+    internal UnitySoundEffect(AudioSource[] pool, UnityAudioServer.RoundRobinIndex roundRobinIndex, AudioClip clip, bool isResource, bool isPreloaded)
     {
         this.pool = pool;
         this.audioClip = clip;

--- a/engines/unity/Assets/Scripts/Audio/Internal/UnitySoundEffect.cs
+++ b/engines/unity/Assets/Scripts/Audio/Internal/UnitySoundEffect.cs
@@ -52,6 +52,12 @@ public class UnitySoundEffect : ISoundEffect
 
     public void Unload()
     {
+        if (lastIndex >= 0 && pool[lastIndex].clip == audioClip)
+        {
+            pool[lastIndex].Stop();
+            pool[lastIndex].clip = null;
+        }
+
         if (audioClip != null)
         {
             try

--- a/engines/unity/Assets/Scripts/Audio/Internal/UnitySoundEffect.cs
+++ b/engines/unity/Assets/Scripts/Audio/Internal/UnitySoundEffect.cs
@@ -1,0 +1,78 @@
+using System;
+using UnityEngine;
+
+/// <summary>
+/// Unity-only sound effect implementation. Uses round-robin on a pool of AudioSources.
+/// </summary>
+public class UnitySoundEffect : ISoundEffect
+{
+    private readonly AudioSource[] pool;
+    private readonly Func<AudioSource> sourceSelector;
+    private readonly AudioClip audioClip;
+    private readonly bool isResource;
+    public readonly bool IsPreloaded;
+
+    private int lastIndex = -1;
+
+    public UnitySoundEffect(AudioSource[] pool, UnityAudioServer.RoundRobinIndex roundRobinIndex, AudioClip clip, bool isResource, bool isPreloaded)
+    {
+        this.pool = pool;
+        this.audioClip = clip;
+        this.isResource = isResource;
+        this.IsPreloaded = isPreloaded;
+
+        // Capture the round-robin counter reference via a delegate
+        sourceSelector = () =>
+        {
+            var index = roundRobinIndex.Next();
+            lastIndex = index;
+            return pool[index];
+        };
+
+        Volume = Context.Player.Settings.SoundEffectsVolume;
+    }
+
+    public void Play(bool ignoreListenerPause = false)
+    {
+        var source = sourceSelector();
+        source.ignoreListenerPause = ignoreListenerPause;
+        source.clip = audioClip;
+        source.volume = Volume;
+        source.Play();
+    }
+
+    private float volume;
+    public float Volume
+    {
+        get => volume;
+        set => volume = value;
+    }
+
+    public bool IsPlaying => lastIndex >= 0 && pool[lastIndex].isPlaying;
+
+    public void Unload()
+    {
+        if (audioClip != null)
+        {
+            try
+            {
+                audioClip.UnloadAudioData();
+            }
+            catch (MissingReferenceException)
+            {
+            }
+            catch (NullReferenceException)
+            {
+            }
+
+            if (!isResource)
+            {
+                UnityEngine.Object.Destroy(audioClip);
+            }
+            else
+            {
+                Resources.UnloadAsset(audioClip);
+            }
+        }
+    }
+}

--- a/engines/unity/Assets/Scripts/Audio/Internal/UnitySoundEffect.cs.meta
+++ b/engines/unity/Assets/Scripts/Audio/Internal/UnitySoundEffect.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 48c97e49609704b0a93b6a3653d988f4

--- a/engines/unity/Assets/Scripts/AudioManager.cs
+++ b/engines/unity/Assets/Scripts/AudioManager.cs
@@ -17,8 +17,8 @@ public class AudioManager : SingletonMonoBehavior<AudioManager>
     private const int RoundRobinEndIndex = 6;
     private int trackCurrentIndex = RoundRobinStartIndex;
 
-    private bool useNativeAudio;
-    private bool isInitialized;
+private bool useNativeAudio;
+public bool IsInitialized { get; private set; }
 
     protected override void Awake()
     {
@@ -28,12 +28,12 @@ public class AudioManager : SingletonMonoBehavior<AudioManager>
         trackCurrentIndex = RoundRobinStartIndex;
     }
 
-    public void Initialize()
-    {
-        if (isInitialized) return;
-        isInitialized = true;
-        SetUseNativeAudio(Context.Player.Settings.UseNativeAudio);
-        if (useNativeAudio)
+public void Initialize()
+{
+    if (IsInitialized) return;
+    IsInitialized = true;
+    // SetUseNativeAudio(Context.Player.Settings.UseNativeAudio);  // REMOVED: server selection now in Initialize() via AudioServerType (T6)
+    if (useNativeAudio)
         {
             var options = new NativeAudio.InitializationOptions
             {
@@ -57,11 +57,11 @@ public class AudioManager : SingletonMonoBehavior<AudioManager>
         Dispose();
     }
 
-    public void Dispose()
-    {
-        if (!isInitialized) return;
+public void Dispose()
+{
+    if (!IsInitialized) return;
 
-        isInitialized = false;
+    IsInitialized = false;
 
         // First stop all playing audio
         foreach (var controller in controllers.Values)
@@ -104,10 +104,11 @@ public class AudioManager : SingletonMonoBehavior<AudioManager>
         }
     }
 
-    public void SetUseNativeAudio(bool useNativeAudio)
-    {
-        this.useNativeAudio = NativeAudio.OnSupportedPlatform && useNativeAudio;
-    }
+[Obsolete("Use AudioServerType selection in Initialize(). Will be removed in T7.")]
+public void SetUseNativeAudio(bool useNativeAudio)
+{
+    this.useNativeAudio = NativeAudio.OnSupportedPlatform && useNativeAudio;
+}
 
     public Controller Load(string id, AudioClip audioClip, bool? useNativeAudio = null, bool isResource = false, bool isMusic = false, bool isPreloaded = false)
     {

--- a/engines/unity/Assets/Scripts/AudioManager.cs
+++ b/engines/unity/Assets/Scripts/AudioManager.cs
@@ -37,10 +37,19 @@ public class AudioManager : SingletonMonoBehavior<AudioManager>
             AudioServerType.Exceed7 => new Exceed7AudioServer(audioSources[0], audioSources[1..]),
             _ => new UnityAudioServer(audioSources[0], audioSources[1..]),
         };
-        server.Initialize();
 
-        foreach (var clip in preloadedAudioClips)
-            server.LoadSfx(clip.name, clip, isResource: false, isPreloaded: true);
+        try
+        {
+            server.Initialize();
+            foreach (var clip in preloadedAudioClips)
+                server.LoadSfx(clip.name, clip, isResource: false, isPreloaded: true);
+        }
+        catch
+        {
+            try { server.Dispose(); }
+            catch { }
+            throw;
+        }
 
         _server = server;
         IsInitialized = true;

--- a/engines/unity/Assets/Scripts/AudioManager.cs
+++ b/engines/unity/Assets/Scripts/AudioManager.cs
@@ -28,21 +28,21 @@ public class AudioManager : SingletonMonoBehavior<AudioManager>
         var serverType = Context.Player.Settings.AudioServer;
         if (serverType == AudioServerType.Exceed7 && !NativeAudio.OnSupportedPlatform)
         {
-            Debug.LogWarning("[Audio] Exceed7 requested but Native Audio not supported; falling back to Unity");
+            Debug.LogWarning("[Audio] Exceed7 not supported on this platform; falling back to Unity");
             serverType = AudioServerType.Unity;
         }
-        _server = serverType switch
+
+        var server = serverType switch
         {
-            AudioServerType.Unity   => new UnityAudioServer(audioSources[0], audioSources[1..]),
             AudioServerType.Exceed7 => new Exceed7AudioServer(audioSources[0], audioSources[1..]),
-            _ => throw new NotSupportedException($"AudioServer {serverType} not supported"),
+            _ => new UnityAudioServer(audioSources[0], audioSources[1..]),
         };
-        _server.Initialize();
+        server.Initialize();
 
-        // Preload SFX
         foreach (var clip in preloadedAudioClips)
-            _server.LoadSfx(clip.name, clip, isResource: false, isPreloaded: true);
+            server.LoadSfx(clip.name, clip, isResource: false, isPreloaded: true);
 
+        _server = server;
         IsInitialized = true;
     }
 

--- a/engines/unity/Assets/Scripts/AudioManager.cs
+++ b/engines/unity/Assets/Scripts/AudioManager.cs
@@ -78,5 +78,8 @@ public class AudioManager : SingletonMonoBehavior<AudioManager>
     public double AudioClockSeconds => _server.AudioClockSeconds;
 
     public void UpdateVolumes()
-        => _server.UpdateVolumes(Context.Player.Settings.MusicVolume, Context.Player.Settings.SoundEffectsVolume);
+    {
+        if (!IsInitialized || _server == null) return;
+        _server.UpdateVolumes(Context.Player.Settings.MusicVolume, Context.Player.Settings.SoundEffectsVolume);
+    }
 }

--- a/engines/unity/Assets/Scripts/AudioManager.cs
+++ b/engines/unity/Assets/Scripts/AudioManager.cs
@@ -1,7 +1,6 @@
 using System;
 using E7.Native;
 using UnityEngine;
-using UnityEngine.Assertions;
 
 public class AudioManager : SingletonMonoBehavior<AudioManager>
 {
@@ -22,8 +21,9 @@ public class AudioManager : SingletonMonoBehavior<AudioManager>
     {
         if (IsInitialized) return;
 
-        // Partition assertion FIRST — fail clearly on bad Inspector wiring before indexing.
-        Assert.AreEqual(7, audioSources.Length, "Expected 1 music + 6 SFX AudioSources");
+        if (audioSources.Length != 7)
+            throw new InvalidOperationException(
+                $"Expected 7 AudioSources (1 music + 6 SFX), got {audioSources.Length}");
 
         var serverType = Context.Player.Settings.AudioServer;
         if (serverType == AudioServerType.Exceed7 && !NativeAudio.OnSupportedPlatform)
@@ -61,21 +61,24 @@ public class AudioManager : SingletonMonoBehavior<AudioManager>
         _server = null;
     }
 
+    private IAudioServer Server =>
+        _server ?? throw new InvalidOperationException("AudioManager not initialized");
+
     public IMusicTrack LoadMusic(string id, AudioClip clip, bool isResource)
-        => _server.LoadMusic(id, clip, isResource);
+        => Server.LoadMusic(id, clip, isResource);
 
     public ISoundEffect LoadSfx(string id, AudioClip clip, bool isResource, bool isPreloaded = false)
-        => _server.LoadSfx(id, clip, isResource, isPreloaded);
+        => Server.LoadSfx(id, clip, isResource, isPreloaded);
 
-    public ISoundEffect GetSfx(string id) => _server.GetSfx(id);
+    public ISoundEffect GetSfx(string id) => Server.GetSfx(id);
 
-    public bool IsSfxLoaded(string id) => _server.IsSfxLoaded(id);
+    public bool IsSfxLoaded(string id) => Server.IsSfxLoaded(id);
 
-    public void UnloadMusic() => _server.UnloadMusic();
+    public void UnloadMusic() => Server.UnloadMusic();
 
-    public void UnloadSfx(string id) => _server.UnloadSfx(id);
+    public void UnloadSfx(string id) => Server.UnloadSfx(id);
 
-    public double AudioClockSeconds => _server.AudioClockSeconds;
+    public double AudioClockSeconds => Server.AudioClockSeconds;
 
     public void UpdateVolumes()
     {

--- a/engines/unity/Assets/Scripts/AudioManager.cs
+++ b/engines/unity/Assets/Scripts/AudioManager.cs
@@ -1,8 +1,5 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using E7.Native;
-using Cysharp.Threading.Tasks;
 using UnityEngine;
 using UnityEngine.Assertions;
 
@@ -11,44 +8,42 @@ public class AudioManager : SingletonMonoBehavior<AudioManager>
     public AudioSource[] audioSources;
     public AudioClip[] preloadedAudioClips;
 
-    private Dictionary<string, Controller> controllers = new Dictionary<string, Controller>();
+    public bool IsInitialized { get; private set; }
 
-    private const int RoundRobinStartIndex = 3;
-    private const int RoundRobinEndIndex = 6;
-    private int trackCurrentIndex = RoundRobinStartIndex;
-
-private bool useNativeAudio;
-public bool IsInitialized { get; private set; }
+    private IAudioServer _server;
 
     protected override void Awake()
     {
         base.Awake();
         Context.AudioManager = this;
-        Assert.AreEqual(audioSources.Length, 7);
-        trackCurrentIndex = RoundRobinStartIndex;
     }
 
-public void Initialize()
-{
-    if (IsInitialized) return;
-    IsInitialized = true;
-    // SetUseNativeAudio(Context.Player.Settings.UseNativeAudio);  // REMOVED: server selection now in Initialize() via AudioServerType (T6)
-    if (useNativeAudio)
-        {
-            var options = new NativeAudio.InitializationOptions
-            {
-                androidAudioTrackCount = 2,
-                androidBufferSize = -1
-            };
-            NativeAudio.Initialize(options);
-            Debug.Log($"Native Audio initialized with {NativeAudio.GetNativeSourceCount()} sources");
-        }
-        else
-        {
-            Debug.Log("Native Audio is disabled, using Unity Audio");
-        }
+    public void Initialize()
+    {
+        if (IsInitialized) return;
 
-        preloadedAudioClips.ForEach(it => Load(it.name, it, isPreloaded: true));
+        // Partition assertion FIRST — fail clearly on bad Inspector wiring before indexing.
+        Assert.AreEqual(7, audioSources.Length, "Expected 1 music + 6 SFX AudioSources");
+
+        var serverType = Context.Player.Settings.AudioServer;
+        if (serverType == AudioServerType.Exceed7 && !NativeAudio.OnSupportedPlatform)
+        {
+            Debug.LogWarning("[Audio] Exceed7 requested but Native Audio not supported; falling back to Unity");
+            serverType = AudioServerType.Unity;
+        }
+        _server = serverType switch
+        {
+            AudioServerType.Unity   => new UnityAudioServer(audioSources[0], audioSources[1..]),
+            AudioServerType.Exceed7 => new Exceed7AudioServer(audioSources[0], audioSources[1..]),
+            _ => throw new NotSupportedException($"AudioServer {serverType} not supported"),
+        };
+        _server.Initialize();
+
+        // Preload SFX
+        foreach (var clip in preloadedAudioClips)
+            _server.LoadSfx(clip.name, clip, isResource: false, isPreloaded: true);
+
+        IsInitialized = true;
     }
 
     protected override void OnDestroy()
@@ -57,358 +52,31 @@ public void Initialize()
         Dispose();
     }
 
-public void Dispose()
-{
-    if (!IsInitialized) return;
-
-    IsInitialized = false;
-
-        // First stop all playing audio
-        foreach (var controller in controllers.Values)
-        {
-            try
-            {
-                controller.Stop();
-            }
-            catch (Exception e)
-            {
-                Debug.LogError($"Error stopping audio controller: {e}");
-            }
-        }
-
-        // Then unload non-preloaded audio
-        var keysToUnload = controllers.Keys.ToList().FindAll(it => !controllers[it].IsPreloaded);
-        foreach (var key in keysToUnload)
-        {
-            try
-            {
-                Unload(key);
-            }
-            catch (Exception e)
-            {
-                Debug.LogError($"Error unloading audio {key}: {e}");
-            }
-        }
-
-        // Clear controllers dictionary
-        controllers.Clear();
-
-        // Finally dispose native audio
-        try
-        {
-            NativeAudio.Dispose();
-        }
-        catch (Exception e)
-        {
-            Debug.LogError($"Error disposing native audio: {e}");
-        }
-    }
-
-[Obsolete("Use AudioServerType selection in Initialize(). Will be removed in T7.")]
-public void SetUseNativeAudio(bool useNativeAudio)
-{
-    this.useNativeAudio = NativeAudio.OnSupportedPlatform && useNativeAudio;
-}
-
-    public Controller Load(string id, AudioClip audioClip, bool? useNativeAudio = null, bool isResource = false, bool isMusic = false, bool isPreloaded = false)
+    public void Dispose()
     {
-        if (useNativeAudio == null) useNativeAudio = this.useNativeAudio;
-        if (controllers.ContainsKey(id)) Unload(id);
-        print("[AudioManager] Loading " + id);
-        return controllers[id] = useNativeAudio.Value
-            ? (Controller)new Exceed7Controller(this, audioClip, isMusic, isPreloaded)
-            : new UnityController(this, audioClip, isResource, isMusic, isPreloaded);
+        if (!IsInitialized) return;
+        IsInitialized = false;
+        try { _server?.Dispose(); }
+        catch (Exception e) { Debug.LogError($"Error disposing audio server: {e}"); }
+        _server = null;
     }
 
-    public void Unload(string id)
-    {
-        if (controllers.ContainsKey(id))
-        {
-            print("[AudioManager] Unloading " + id);
-            controllers[id].Unload();
-            controllers.Remove(id);
-        }
-    }
+    public IMusicTrack LoadMusic(string id, AudioClip clip, bool isResource)
+        => _server.LoadMusic(id, clip, isResource);
 
-    public bool IsLoaded(string id) => controllers.ContainsKey(id);
+    public ISoundEffect LoadSfx(string id, AudioClip clip, bool isResource, bool isPreloaded = false)
+        => _server.LoadSfx(id, clip, isResource, isPreloaded);
 
-    public Controller Get(string id) => controllers[id];
+    public ISoundEffect GetSfx(string id) => _server.GetSfx(id);
+
+    public bool IsSfxLoaded(string id) => _server.IsSfxLoaded(id);
+
+    public void UnloadMusic() => _server.UnloadMusic();
+
+    public void UnloadSfx(string id) => _server.UnloadSfx(id);
+
+    public double AudioClockSeconds => _server.AudioClockSeconds;
 
     public void UpdateVolumes()
-    {
-        foreach (var controller in controllers.Values)
-        {
-            controller.Volume = controller.IsMusic ? Context.Player.Settings.MusicVolume : Context.Player.Settings.SoundEffectsVolume;
-        }
-    }
-
-    private int GetAvailableIndex(AudioTrackIndex trackIndex)
-    {
-        var index = (int)trackIndex;
-        if (index == -1)
-        {
-            index = trackCurrentIndex;
-            trackCurrentIndex++;
-            if (trackCurrentIndex > RoundRobinEndIndex)
-                trackCurrentIndex = RoundRobinStartIndex;
-        }
-        return index;
-    }
-
-    public abstract class Controller
-    {
-        protected AudioManager Parent;
-        public bool IsMusic { get; }
-        public bool IsPreloaded { get; }
-
-        public Controller(AudioManager parent, bool isMusic, bool isPreloaded)
-        {
-            Parent = parent;
-            IsMusic = isMusic;
-            IsPreloaded = isPreloaded;
-        }
-
-        public abstract float Volume { get; set; }
-        public abstract float PlaybackTime { get; set; }
-        public abstract float Length { get; }
-        public abstract void Play(AudioTrackIndex trackIndex = AudioTrackIndex.RoundRobin, bool ignoreDsp = false);
-        public abstract double PlayScheduled(AudioTrackIndex trackIndex = AudioTrackIndex.RoundRobin, double delay = 1.0, bool ignoreDsp = false);
-        public abstract void Pause();
-        public abstract void Resume();
-        public abstract void Stop();
-        public abstract void Unload();
-        public abstract bool IsFinished();
-        public abstract bool IsPlaying();
-    }
-
-    public class UnityController : Controller
-    {
-        private AudioClip audioClip;
-        private int index = -1;
-        private bool isResource;
-        private float volume = 1f;
-
-        public UnityController(AudioManager parent, AudioClip audioClip, bool isResource, bool isMusic, bool isPreloaded) : base(parent, isMusic, isPreloaded)
-        {
-            this.audioClip = audioClip;
-            this.isResource = isResource;
-            volume = isMusic ? Context.Player.Settings.MusicVolume : Context.Player.Settings.SoundEffectsVolume;
-        }
-
-        public AudioSource Source => Parent.audioSources[index];
-
-        public override float Volume
-        {
-            get => volume;
-            set
-            {
-                volume = value;
-                if (index >= 0) Source.volume = volume;
-            }
-        }
-
-        public override float PlaybackTime
-        {
-            get => Source.timeSamples * 1f / Source.clip.frequency;
-            set => Source.time = value;
-        }
-
-        public override float Length => audioClip.length;
-
-        public override void Play(AudioTrackIndex trackIndex = AudioTrackIndex.RoundRobin, bool ignoreDsp = false)
-        {
-            index = Parent.GetAvailableIndex(trackIndex);
-            Source.ignoreListenerPause = ignoreDsp;
-            Source.Apply(it =>
-            {
-                it.clip = audioClip;
-                it.volume = Volume;
-                it.Play();
-            });
-        }
-
-        public override double PlayScheduled(AudioTrackIndex trackIndex = AudioTrackIndex.RoundRobin, double delay = 1.0, bool ignoreDsp = false)
-        {
-            index = Parent.GetAvailableIndex(trackIndex);
-            Source.ignoreListenerPause = ignoreDsp;
-            Source.clip = audioClip;
-            Source.volume = Volume;
-            var time = AudioSettings.dspTime + delay;
-            Source.PlayScheduled(time);
-            return time;
-        }
-
-        public override void Pause()
-        {
-            if (index < 0) return;
-            Source.Pause();
-        }
-
-        public override void Resume()
-        {
-            if (index < 0) return;
-            Source.UnPause();
-        }
-
-        public override void Stop()
-        {
-            if (index < 0) return;
-            Source.Stop();
-        }
-
-        public override void Unload()
-        {
-            if (index >= 0)
-            {
-                Stop();
-                Source.clip = null;
-            }
-            if (audioClip != null)
-            {
-                try
-                {
-                    audioClip.UnloadAudioData();
-                }
-                catch (MissingReferenceException)
-                {
-                }
-                catch (NullReferenceException)
-                {
-                }
-                if (!isResource)
-                {
-                    Destroy(audioClip);
-                }
-                else
-                {
-                    Resources.UnloadAsset(audioClip);
-                }
-            }
-        }
-
-        public override bool IsFinished()
-        {
-            return !Source.isPlaying;
-        }
-
-        public override bool IsPlaying()
-        {
-            return Source.isPlaying;
-        }
-    }
-
-    public class Exceed7Controller : Controller
-    {
-        private NativeAudioPointer pointer;
-        private NativeSource source;
-        private float length;
-        private float volume = 1f;
-        private bool isPlaying = false;
-
-        public Exceed7Controller(AudioManager parent, AudioClip audioClip, bool isMusic, bool isPreloaded) : base(parent, isMusic, isPreloaded)
-        {
-            pointer = NativeAudio.Load(audioClip, NativeAudio.LoadOptions.defaultOptions);
-            length = audioClip.length;
-            volume = isMusic ? Context.Player.Settings.MusicVolume : Context.Player.Settings.SoundEffectsVolume;
-        }
-
-        public override float Volume
-        {
-            get => volume;
-            set
-            {
-                volume = value;
-                if (source.IsValid)
-                {
-                    source.SetVolume(volume);
-                }
-            }
-        }
-
-        public override float PlaybackTime
-        {
-            get => source.IsValid ? source.GetPlaybackTime() : 0f;
-            set
-            {
-                if (source.IsValid)
-                {
-                    source.SetPlaybackTime(value);
-                }
-            }
-        }
-
-        public override float Length => length;
-
-        public override void Play(AudioTrackIndex trackIndex = AudioTrackIndex.RoundRobin, bool ignoreDsp = false)
-        {
-            var sourceIndex = Parent.GetAvailableIndex(trackIndex);
-            source = NativeAudio.GetNativeSource(sourceIndex);
-            source.Play(pointer);
-#if UNITY_ANDROID
-            source.SetVolume(volume >= 0.05f ? volume : float.Epsilon);
-#else
-            source.SetVolume(volume);
-#endif
-            isPlaying = true;
-            Debug.Log("Source volume set to " + volume);
-        }
-
-        public override double PlayScheduled(AudioTrackIndex trackIndex = AudioTrackIndex.RoundRobin, double delay = 1.0, bool ignoreDsp = false)
-        {
-            throw new NotImplementedException();
-        }
-
-        public override void Pause()
-        {
-            isPlaying = false;
-            if (source.IsValid)
-            {
-                source.Pause();
-            }
-        }
-
-        public override void Resume()
-        {
-            isPlaying = true;
-            if (source.IsValid)
-            {
-                source.Resume();
-            }
-        }
-
-        public override void Stop()
-        {
-            isPlaying = false;
-            if (source.IsValid)
-            {
-                source.Stop();
-            }
-        }
-
-        public override async void Unload()
-        {
-            Stop();
-            await UniTask.DelayFrame(10);
-            pointer.Unload();
-        }
-
-        public override bool IsFinished()
-        {
-            print("Playback time: " + PlaybackTime + ", Length: " + length);
-            return Mathf.Approximately(PlaybackTime, 0) || PlaybackTime >= length;
-        }
-
-        public override bool IsPlaying()
-        {
-            return isPlaying;
-        }
-    }
-}
-
-public enum AudioTrackIndex
-{
-    Reserved1 = 0,
-    Reserved2 = 1,
-    Reserved3 = 2,
-    RoundRobin = -1
+        => _server.UpdateVolumes(Context.Player.Settings.MusicVolume, Context.Player.Settings.SoundEffectsVolume);
 }

--- a/engines/unity/Assets/Scripts/Game/Elements/AllPerfectSplash.cs
+++ b/engines/unity/Assets/Scripts/Game/Elements/AllPerfectSplash.cs
@@ -13,7 +13,7 @@ public class AllPerfectSplash : CleanTitleTransitionElement
         if (game.State.Mode != GameMode.Calibration && game.State.Score == 1000000 && !game.EditorImmediatelyComplete)
         {
             game.BeforeExitTasks.Add(Animate());
-            Context.AudioManager.Get("LevelMax").Play();
+            Context.AudioManager.GetSfx("LevelMax").Play();
         }
     }
 }

--- a/engines/unity/Assets/Scripts/Game/Elements/FullComboSplash.cs
+++ b/engines/unity/Assets/Scripts/Game/Elements/FullComboSplash.cs
@@ -17,7 +17,7 @@ public class FullComboSplash : CleanTitleTransitionElement
         {
             text.text = game.State.Combo + "x";
             game.BeforeExitTasks.Add(Animate());
-            Context.AudioManager.Get("LevelFullCombo").Play();
+            Context.AudioManager.GetSfx("LevelFullCombo").Play();
         }
     }
 }

--- a/engines/unity/Assets/Scripts/Game/ExternalGameContentProvider.cs
+++ b/engines/unity/Assets/Scripts/Game/ExternalGameContentProvider.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using Cysharp.Threading.Tasks;
+using E7.Native;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using UnityEngine;
@@ -184,11 +185,20 @@ public sealed class ExternalGameContentProvider : IGameContentProvider
             target.HitTapticFeedback = settings.hitTapticFeedback.Value;
         }
 
-        if (settings.useNativeAudio.HasValue)
-        {
-            target.UseNativeAudio = settings.useNativeAudio.Value;
-            Context.AudioManager?.SetUseNativeAudio(settings.useNativeAudio.Value);
-        }
+if (settings.useNativeAudio.HasValue)
+{
+    // Translate wire protocol bool? to AudioServerType enum (wire field stays bool? for protocol compat)
+    var requested = settings.useNativeAudio.Value ? AudioServerType.Exceed7 : AudioServerType.Unity;
+    var effective = (requested == AudioServerType.Exceed7 && !NativeAudio.OnSupportedPlatform)
+        ? AudioServerType.Unity
+        : requested;
+    if (requested != effective)
+        Debug.LogWarning("[Audio] Exceed7 requested but Native Audio not supported on this platform; falling back to Unity");
+    target.AudioServer = effective;
+    // No runtime server swap — applied at next AudioManager.Initialize()
+    if (Context.AudioManager != null && Context.AudioManager.IsInitialized)
+        Debug.LogWarning("[Audio] AudioServer change deferred to next session");
+}
 
         if (settings.androidDspBufferSize.HasValue)
         {

--- a/engines/unity/Assets/Scripts/Game/ExternalGameContentProvider.cs
+++ b/engines/unity/Assets/Scripts/Game/ExternalGameContentProvider.cs
@@ -185,20 +185,20 @@ public sealed class ExternalGameContentProvider : IGameContentProvider
             target.HitTapticFeedback = settings.hitTapticFeedback.Value;
         }
 
-if (settings.useNativeAudio.HasValue)
-{
-    // Translate wire protocol bool? to AudioServerType enum (wire field stays bool? for protocol compat)
-    var requested = settings.useNativeAudio.Value ? AudioServerType.Exceed7 : AudioServerType.Unity;
-    var effective = (requested == AudioServerType.Exceed7 && !NativeAudio.OnSupportedPlatform)
-        ? AudioServerType.Unity
-        : requested;
-    if (requested != effective)
-        Debug.LogWarning("[Audio] Exceed7 requested but Native Audio not supported on this platform; falling back to Unity");
-    target.AudioServer = effective;
-    // No runtime server swap — applied at next AudioManager.Initialize()
-    if (Context.AudioManager != null && Context.AudioManager.IsInitialized)
-        Debug.LogWarning("[Audio] AudioServer change deferred to next session");
-}
+        if (settings.useNativeAudio.HasValue)
+        {
+            // Translate wire protocol bool? to AudioServerType enum (wire field stays bool? for protocol compat)
+            var requested = settings.useNativeAudio.Value ? AudioServerType.Exceed7 : AudioServerType.Unity;
+            var effective = (requested == AudioServerType.Exceed7 && !NativeAudio.OnSupportedPlatform)
+                ? AudioServerType.Unity
+                : requested;
+            if (requested != effective)
+                Debug.LogWarning("[Audio] Exceed7 requested but Native Audio not supported on this platform; falling back to Unity");
+            target.AudioServer = effective;
+            // No runtime server swap — applied at next AudioManager.Initialize()
+            if (Context.AudioManager != null && Context.AudioManager.IsInitialized)
+                Debug.LogWarning("[Audio] AudioServer change deferred to next session");
+        }
 
         if (settings.androidDspBufferSize.HasValue)
         {

--- a/engines/unity/Assets/Scripts/Game/Game.cs
+++ b/engines/unity/Assets/Scripts/Game/Game.cs
@@ -63,7 +63,7 @@ public class Game : MonoBehaviour
     public float EditorCompletionDelay;
     public bool EditorImmediatelyCompleteFail;
 
-    public AudioManager.Controller Music { get; protected set; }
+    public IMusicTrack Music { get; protected set; }
     private IGameContentProvider contentProvider;
     private bool preserveContentProviderOnDispose;
 
@@ -254,7 +254,7 @@ public class Game : MonoBehaviour
         if (Context.AudioManager == null) await UniTask.WaitUntil(() => Context.AudioManager != null);
         Context.AudioManager.Initialize();
         var musicClip = await contentProvider.LoadMusic();
-        Music = Context.AudioManager.Load("Level", musicClip, false, false, true);
+        Music = Context.AudioManager.LoadMusic("Level", musicClip, isResource: false);
         MusicLength = Music.Length;
 
         // Load storyboard
@@ -287,7 +287,7 @@ public class Game : MonoBehaviour
         if (Context.Player.Settings.HitSound != "none")
         {
             var resource = await Resources.LoadAsync<AudioClip>("Audio/HitSounds/" + Context.Player.Settings.HitSound);
-            Context.AudioManager.Load("HitSound", resource as AudioClip, isResource: true);
+            Context.AudioManager.LoadSfx("HitSound", resource as AudioClip, isResource: true);
         }
 
         // State & config
@@ -336,13 +336,13 @@ public class Game : MonoBehaviour
     {
         await UniTask.WhenAll(BeforeStartTasks);
 
-        MusicStartedTimestamp = Music.PlayScheduled(AudioTrackIndex.Reserved1, 1.0f);
+        MusicStartedTimestamp = Music.SchedulePlay(1.0);
 
         await UniTask.Delay(TimeSpan.FromSeconds(1));
 
         if (Application.isEditor && EditorMusicInitialPosition > 0)
         {
-            Music.PlaybackTime = EditorMusicInitialPosition;
+            Music.SourceTimeSeconds = EditorMusicInitialPosition;
             MusicStartedTimestamp -= EditorMusicInitialPosition;
         }
 
@@ -415,13 +415,14 @@ public class Game : MonoBehaviour
         }
 
         if (!State.IsFailed && State.ShouldFail) Fail();
+        // BUG: frame-rate-dependent fade, preserved during refactor
         if (State.IsFailed) Music.Volume -= 1f / 60f;
         if (State.IsPlaying)
 
         {
             if (State.ClearCount >= Chart.Model.note_list.Count) Complete();
 
-            if (!State.IsCompleted || !Music.IsFinished())
+            if (!State.IsCompleted || !Music.IsFinished)
             {
                 SynchronizeMusic();
             }
@@ -528,7 +529,7 @@ public class Game : MonoBehaviour
         }
         else
         {
-            Context.AudioManager.Get("Navigate2").Play(ignoreDsp: true);
+            Context.AudioManager.GetSfx("Navigate2").Play(ignoreListenerPause: true);
 
             Context.ScreenManager.ChangeScreen(PausedScreen.Id, ScreenTransition.None);
             Context.SetAutoRotation(true);
@@ -599,7 +600,7 @@ public class Game : MonoBehaviour
         AudioListener.pause = false;
 
         // Unload resources
-        Context.AudioManager.Unload("Level");
+        Context.AudioManager.UnloadMusic();
 
         onGameAborted.Invoke(this);
 
@@ -638,7 +639,7 @@ public class Game : MonoBehaviour
 
         Music?.Stop();
         AudioListener.pause = false;
-        Context.AudioManager.Unload("Level");
+        Context.AudioManager.UnloadMusic();
 
         onGameAborted.Invoke(this);
         if (emitCalibrationResult && shouldEmitCalibrationResult)
@@ -658,7 +659,7 @@ public class Game : MonoBehaviour
 
                 var tierPlaySession = TierPlaySession;
                 Music.Stop();
-                Context.AudioManager.Unload("Level");
+                Context.AudioManager.UnloadMusic();
                 AudioListener.pause = false;
                 onGameRetried.Invoke(this);
                 Dispose();
@@ -676,7 +677,7 @@ public class Game : MonoBehaviour
         print("Game retried");
 
         // Unload resources
-        Context.AudioManager.Unload("Level");
+        Context.AudioManager.UnloadMusic();
         AudioListener.pause = false;
 
         onGameRetried.Invoke(this);
@@ -703,7 +704,7 @@ public class Game : MonoBehaviour
         inputController.DisableInput();
 
         Context.ScreenManager.ChangeScreen(FailedScreen.Id, ScreenTransition.None);
-        Context.AudioManager.Get("LevelFailed").Play();
+        Context.AudioManager.GetSfx("LevelFailed").Play();
 
         onGameFailed.Invoke(this);
     }
@@ -728,7 +729,7 @@ public class Game : MonoBehaviour
             var volume = Music.Volume * 3f;
 
             // Wait for audio to finish
-            var remainingLength = MusicLength - Music.PlaybackTime;
+            var remainingLength = MusicLength - Music.SourceTimeSeconds;
             var startTime = DateTime.Now;
             await UniTask.WaitUntil(() =>
             {
@@ -740,11 +741,11 @@ public class Game : MonoBehaviour
                         Music.Volume = Math.Min(maxVolume, volume);
                     }
 
-                    return Music.IsFinished() || volume <= 0;
+                    return Music.IsFinished || volume <= 0;
                 }
                 else
                 {
-                    return Music.IsFinished() ||
+                    return Music.IsFinished ||
                            DateTime.Now - startTime > TimeSpan.FromSeconds(remainingLength); // Just as a fail-safe
                 }
             });
@@ -753,7 +754,7 @@ public class Game : MonoBehaviour
         State.IsReadyToExit = true;
 
         print("Audio ended");
-        Context.AudioManager.Unload("Level");
+        Context.AudioManager.UnloadMusic();
 
         try
         {

--- a/engines/unity/Assets/Scripts/Game/Notes/DragChildNote.cs
+++ b/engines/unity/Assets/Scripts/Game/Notes/DragChildNote.cs
@@ -66,9 +66,9 @@ public class DragChildNote : Note
     
     public override void PlayHitSound()
     {
-        if (Context.AudioManager.IsLoaded("HitSound"))
+        if (Context.AudioManager.IsSfxLoaded("HitSound"))
         {
-            Context.AudioManager.Get("HitSound").Play();
+            Context.AudioManager.GetSfx("HitSound").Play();
         }
         Context.Haptic(HapticTypes.Selection, false);
     }

--- a/engines/unity/Assets/Scripts/Game/Notes/DragHeadNote.cs
+++ b/engines/unity/Assets/Scripts/Game/Notes/DragHeadNote.cs
@@ -244,9 +244,9 @@ public class DragHeadNote : Note
     
     public override void PlayHitSound()
     {
-        if (Context.AudioManager.IsLoaded("HitSound"))
+        if (Context.AudioManager.IsSfxLoaded("HitSound"))
         {
-            Context.AudioManager.Get("HitSound").Play();
+            Context.AudioManager.GetSfx("HitSound").Play();
         }
         Context.Haptic(HapticTypes.Selection, false);
     }

--- a/engines/unity/Assets/Scripts/Game/Notes/Note.cs
+++ b/engines/unity/Assets/Scripts/Game/Notes/Note.cs
@@ -114,9 +114,9 @@ public abstract class Note : MonoBehaviour
 
     public virtual void PlayHitSound()
     {
-        if (Context.AudioManager.IsLoaded("HitSound"))
+        if (Context.AudioManager.IsSfxLoaded("HitSound"))
         {
-            Context.AudioManager.Get("HitSound").Play();
+            Context.AudioManager.GetSfx("HitSound").Play();
         }
         Context.Haptic(HapticTypes.LightImpact, false);
     }

--- a/engines/unity/Assets/Scripts/Navigation/Elements/HitSoundSelect.cs
+++ b/engines/unity/Assets/Scripts/Navigation/Elements/HitSoundSelect.cs
@@ -68,12 +68,12 @@ public class HitSoundSelect : MonoBehaviour, ScreenBecameActiveListener
             if (it != "none")
             {
                 var audioClip = Resources.Load<AudioClip>("Audio/HitSounds/" + it);
-                var hitSound = Context.AudioManager.Load("HitSound", audioClip, isResource: true);
+                var hitSound = Context.AudioManager.LoadSfx("HitSound", audioClip, isResource: true);
                 hitSound.Play();
             }
             else
             {
-                Context.AudioManager.Unload("HitSound");
+                Context.AudioManager.UnloadSfx("HitSound");
             }
         });
     }

--- a/engines/unity/Assets/Scripts/Player/LocalPlayerSettings.cs
+++ b/engines/unity/Assets/Scripts/Player/LocalPlayerSettings.cs
@@ -117,7 +117,7 @@ public class LocalPlayerSettings
     [JsonProperty("display_note_ids")] public bool DisplayNoteIds { get; set; } = false;
     [JsonProperty("local_level_sort")] public LevelSort LocalLevelSort { get; set; } = LevelSort.AddedDate;
 
-    [JsonProperty("use_native_audio")] public bool UseNativeAudio { get; set; } = false;
+    [JsonProperty("audio_server")] public AudioServerType AudioServer { get; set; } = AudioServerType.Unity;
 
     [JsonProperty("android_dsp_buffer_size")]
     public int AndroidDspBufferSize { get; set; } = -1;

--- a/engines/unity/Assets/Scripts/Player/Player.cs
+++ b/engines/unity/Assets/Scripts/Player/Player.cs
@@ -48,7 +48,7 @@ public class Player
 #elif UNITY_ANDROID
         if (Context.Distribution == Distribution.TapTap)
         {
-            Context.AudioManager.Get("ActionSuccess").Play();
+            Context.AudioManager.GetSfx("ActionSuccess").Play();
             Application.OpenURL("https://www.taptap.com/app/158749");
         }
 #endif


### PR DESCRIPTION
## Summary

Replaces the broken `Controller` abstraction (claimed to abstract over playback engine, but engine choice was forced by role) with an `IAudioServer` pattern where each server is a complete, user-selectable audio backend.

### Architecture

```
AudioManager (facade, 82 LOC, down from 414)
  └─ IAudioServer
       ├─ UnityAudioServer   — full Unity audio
       ├─ Exceed7AudioServer — composition: UnityAudioServer (music+clock) + NativeSfxBackend (SFX)
       └─ BassAudioServer    — (future, not implemented)
```

### Bug fixes
- **Native SFX source-index bug** (Android): `Exceed7Controller.Play` passed Unity pool indices (3-6) to `NativeAudio.GetNativeSource()` but Android only has 2 native sources (0-1). Crashed on first SFX play. Fixed: `NativeSfxBackend` maintains its own `_nextNativeSource` counter.
- **Music not playing** (all platforms): `UnityMusicTrack.SchedulePlay` was missing `source.clip = audioClip` before `PlayScheduled`. Fixed.
- **iOS SFX killed by volume change** (Exceed7): `NativeSoundEffect.Volume` setter called `source.SetVolume()` on a stale shared round-robin source, corrupting OpenAL state irrecoverably. Fixed: volume deferred to `Play()` only.
- **Dead `float.Epsilon` clamp removed**: workaround for Native Audio Android `log10(0)` bug, which was fixed in Native Audio 7.0.0 (already installed).

### What changed (8 commits)
| Commit | Description |
|--------|-------------|
| `263badaf` | T1: Contract layer (`IAudioServer`, `IMusicTrack`, `ISoundEffect`, `AudioServerType`) |
| `eaff07fe` | T2+T3: `UnityAudioServer` + `NativeSfxBackend` (with bug fix) |
| `920a637c` | T4+T5: `Exceed7AudioServer` (composition) + settings migration |
| `56d37076` | T6: AudioManager facade rewrite + all ~20 call-site migration |
| `c03ada11` | Indentation fix in ExternalGameContentProvider |
| `6f142f5c` | Fix: music clip not set before PlayScheduled |
| `0eaa2134` | Fix: defer NativeSfxBackend volume to Play() |
| `0da227fe` | Fix: remove dead volume clamp (Native Audio 7.0.0 fixed) |

### Scope boundaries
- **No host-protocol changes**: wire field `useNativeAudio: bool?` stays; translation to `AudioServerType` at C\# boundary. Dart models, fixtures, protocol doc untouched.
- **No scene/prefab migration**: `audioSources` and `preloadedAudioClips` serialized fields preserved.
- **No new automated tests**: manual QA + compile gates.
- **No `BassAudioServer`**: future work.
- `Music.Volume -= 1f/60f` preserved (pre-existing bug, commented).
- `AudioSettings.dspTime` at Game.cs:386/833 stays direct (chart clock, not audio clock).

### Verification
- Unity batchmode compile gate: **exit 0** ✅
- Old `Controller`/`UnityController`/`Exceed7Controller` types: **0 references** ✅
- Wire protocol fixtures: **unchanged** ✅
- iOS smoke test: **passed** (music + SFX + volume adjustment)
- Android smoke test: **passed**

### Migration plan
Reviewed by dual-Momus (native + Codex CLI gpt-5.5 xhigh), 3 rounds, both APPROVED. Full plan at `.omo/plans/audio-server-refactor.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added selectable audio backends (Unity/Exceed7/Bass) for music and sound effects, including fallback when native audio isn’t available.
  * Introduced a unified music-track scheduling flow and SFX handles with separate music vs SFX volume control.
* **Bug Fixes**
  * Updated gameplay and UI audio triggers to consistently use the sound-effects API (hit sounds, level splashes, store success, pause behavior).
  * Improved level music lifecycle and completion/unload handling.
* **Refactor**
  * Reworked audio playback around a backend abstraction; updated player audio settings and AudioManager public APIs accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->