### PR TITLE
feat(audio): add IMusicTrack.PlayFrom for seek/resync

### DIFF
--- a/engines/unity/Assets/Scripts/Audio/IMusicTrack.cs
+++ b/engines/unity/Assets/Scripts/Audio/IMusicTrack.cs
@@ -6,7 +6,20 @@ public interface IMusicTrack
     /// <summary>Schedules playback after a delay. Returns the scheduled start time on the audio clock.</summary>
     double SchedulePlay(double delaySeconds);
 
-    /// <summary>The scheduled start time on the audio clock, from SchedulePlay's return value.</summary>
+    /// <summary>
+    /// Stop, seek to <paramref name="sourceTimeSeconds"/>, and resume playback.
+    /// Equivalent to Stop + SourceTimeSeconds = value + SchedulePlay, but atomic.
+    /// Returns the effective audio clock start time (scheduledStart - sourceTimeSeconds),
+    /// so that <c>AudioSettings.dspTime - returnValue</c> yields correct logical elapsed time.
+    /// Used by Lab timeline seek/resync.
+    /// </summary>
+    double PlayFrom(float sourceTimeSeconds, double delaySeconds = 0);
+
+    /// <summary>
+    /// The logical music start time on the audio clock, from SchedulePlay or PlayFrom's return value.
+    /// For PlayFrom, this is <c>scheduledStart - sourceTimeSeconds</c> so that
+    /// <c>AudioSettings.dspTime - ScheduledStartTime</c> yields correct logical elapsed time.
+    /// </summary>
     double ScheduledStartTime { get; }
 
     /// <summary>Current playback position in seconds. For editor scrubbing and completion detection only — NOT the game clock.</summary>

--- a/engines/unity/Assets/Scripts/Audio/Internal/UnityMusicTrack.cs
+++ b/engines/unity/Assets/Scripts/Audio/Internal/UnityMusicTrack.cs
@@ -30,6 +30,18 @@ public class UnityMusicTrack : IMusicTrack
         return time;
     }
 
+    public double PlayFrom(float sourceTimeSeconds, double delaySeconds = 0)
+    {
+        source.Stop();
+        source.clip = audioClip;
+        source.volume = Volume;
+        source.time = sourceTimeSeconds;
+        var time = AudioSettings.dspTime + delaySeconds;
+        source.PlayScheduled(time);
+        scheduledStartTime = time - sourceTimeSeconds;
+        return scheduledStartTime;
+    }
+
     public double ScheduledStartTime => scheduledStartTime;
 
     public float SourceTimeSeconds

--- a/engines/unity/Assets/Scripts/Game/Game.cs
+++ b/engines/unity/Assets/Scripts/Game/Game.cs
@@ -336,15 +336,12 @@ public class Game : MonoBehaviour
     {
         await UniTask.WhenAll(BeforeStartTasks);
 
-        MusicStartedTimestamp = Music.SchedulePlay(1.0);
+        if (Application.isEditor && EditorMusicInitialPosition > 0)
+            MusicStartedTimestamp = Music.PlayFrom(EditorMusicInitialPosition, 1.0);
+        else
+            MusicStartedTimestamp = Music.SchedulePlay(1.0);
 
         await UniTask.Delay(TimeSpan.FromSeconds(1));
-
-        if (Application.isEditor && EditorMusicInitialPosition > 0)
-        {
-            Music.SourceTimeSeconds = EditorMusicInitialPosition;
-            MusicStartedTimestamp -= EditorMusicInitialPosition;
-        }
 
         GameStartedOrResumedTimestamp = UnityEngine.Time.realtimeSinceStartup;
         State.IsStarted = true;


### PR DESCRIPTION
## Summary

Adds `IMusicTrack.PlayFrom(float sourceTimeSeconds, double delaySeconds = 0)` — an atomic Stop + seek + Play contract for Lab timeline seek/resync.

The old controller hierarchy exposed this as separate steps (`Stop(); PlaybackTime = target; Play(delay);`), but `IMusicTrack` had no equivalent. Callers had to manually combine Stop + SourceTimeSeconds + SchedulePlay and adjust the timestamp.

## Changes

- **`IMusicTrack.cs`** — new `PlayFrom` method on the interface; `ScheduledStartTime` docstring updated to reflect dual semantics (logical start time under both SchedulePlay and PlayFrom)
- **`UnityMusicTrack.cs`** — implementation: `Stop()` → set `source.time` → `PlayScheduled()` → returns `scheduledStart - sourceTimeSeconds`
- **`Game.cs`** — replaces the editor seek hack (lines 339-346) with `PlayFrom`, eliminating the "play from 0 then jump" intermediate state

## Return value semantics

`PlayFrom(pos, delay)` returns `scheduledStart - pos`, so `AudioSettings.dspTime - returnValue` yields correct logical elapsed time. This matches the existing manual adjustment that was in `Game.cs:346`.

Requested by @ky_reflection for Lab timeline seek/resync.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Music can now start playing from a chosen position instead of always beginning at the start.
  * Start timing is handled consistently so playback remains in sync after seeking.

* **Bug Fixes**
  * Improved music start behavior to better preserve elapsed-time tracking when launching from a non-zero point.
  * Updated startup logic so delayed playback works smoothly whether music starts from the beginning or a later timestamp.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->