### PR TITLE
fix(gameplay): stop FingerDown from consuming Hold notes

### DIFF
--- a/engines/unity/Assets/Scripts/Game/InputController.cs
+++ b/engines/unity/Assets/Scripts/Game/InputController.cs
@@ -11,7 +11,7 @@ public class InputController : MonoBehaviour
     public readonly Dictionary<int, HoldNote> HoldingNotes = new Dictionary<int, HoldNote>(); // Finger index to note
     public readonly List<Note> TouchableDragNotes = new List<Note>(); // Drag head, Drag child, CDrag child
     public readonly List<HoldNote> TouchableHoldNotes = new List<HoldNote>(); // Hold, Long hold
-    public readonly List<Note> TouchableNormalNotes = new List<Note>(); // Click, CDrag head, Hold, Long hold, Flick
+    public readonly List<Note> TouchableNormalNotes = new List<Note>(); // Click, CDrag head, Flick (Hold/LongHold: FingerUpdate only)
 
     private void Awake()
     {
@@ -66,13 +66,13 @@ public class InputController : MonoBehaviour
             var note = game.SpawnedNotes[id];
             if (!note.HasEmerged || note.IsCleared) continue;
 
-            if (note.Type != NoteType.DragHead && note.Type != NoteType.DragChild && note.Type != NoteType.CDragChild)
-            {
-                TouchableNormalNotes.Add(note);
-            }
-            else
+            if (note.Type == NoteType.DragHead || note.Type == NoteType.DragChild || note.Type == NoteType.CDragChild)
             {
                 TouchableDragNotes.Add(note);
+            }
+            else if (note.Type != NoteType.Hold && note.Type != NoteType.LongHold)
+            {
+                TouchableNormalNotes.Add(note);
             }
 
             if ((note.Type == NoteType.Hold || note.Type == NoteType.LongHold) &&


### PR DESCRIPTION
## Summary
- Exclude Hold/LongHold from `TouchableNormalNotes` so `OnFingerDown` no longer hits them.
- Hold binding stays on `OnFingerUpdate` via `TouchableHoldNotes` → `UpdateFinger` (unchanged).
- Fixes overlapping Click/Flick downs being stolen: Hold's empty `OnTouch` previously still returned and ate the press.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved note interaction handling by preventing hold and long-hold notes from being triggered as normal touch notes.
  * Hold and long-hold notes now follow the intended finger-hold interaction flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->