### PR TITLE
fix(gameplay): stop FingerDown from consuming notes that did not clear

### DIFF
--- a/engines/unity/Assets/Scripts/Game/InputController.cs
+++ b/engines/unity/Assets/Scripts/Game/InputController.cs
@@ -101,8 +101,10 @@ public class InputController : MonoBehaviour
         // Query drag notes first
         foreach (var note in TouchableDragNotes.Where(note => note != null).Where(note => note.DoesCollide(pressedPosition)))
         {
-            note.OnTouch(finger.ScreenPosition);
-            collidedDrag = true;
+            if (note.OnTouch(finger.ScreenPosition))
+            {
+                collidedDrag = true;
+            }
             break; // Query other notes too!
         }
 
@@ -121,7 +123,7 @@ public class InputController : MonoBehaviour
                 if (note.Model.page_index > game.Chart.CurrentPageId &&
                     note.Model.start_time - game.Time >
                     game.Chart.Model.page_list[game.Chart.CurrentPageId].Duration * 0.5f) continue;
-                note.OnTouch(finger.ScreenPosition);
+                if (!note.OnTouch(finger.ScreenPosition)) continue;
             }
 
             return;

--- a/engines/unity/Assets/Scripts/Game/InputController.cs
+++ b/engines/unity/Assets/Scripts/Game/InputController.cs
@@ -101,11 +101,9 @@ public class InputController : MonoBehaviour
         // Query drag notes first
         foreach (var note in TouchableDragNotes.Where(note => note != null).Where(note => note.DoesCollide(pressedPosition)))
         {
-            if (note.OnTouch(finger.ScreenPosition))
-            {
-                collidedDrag = true;
-            }
-            break; // Query other notes too!
+            if (!note.OnTouch(finger.ScreenPosition)) continue;
+            collidedDrag = true;
+            break;
         }
 
         foreach (var note in TouchableNormalNotes.Where(note => note != null).Where(note => note.DoesCollide(pressedPosition)))
@@ -148,11 +146,9 @@ public class InputController : MonoBehaviour
         foreach (var note in TouchableDragNotes)
         {
             if (note == null) continue;
-            if (note.DoesCollide(pos))
-            {
-                note.OnTouch(finger.ScreenPosition);
-                break; // Query other notes too!
-            }
+            if (!note.DoesCollide(pos)) continue;
+            if (!note.OnTouch(finger.ScreenPosition)) continue;
+            break;
         }
 
         // If this is a new finger

--- a/engines/unity/Assets/Scripts/Game/InputController.cs
+++ b/engines/unity/Assets/Scripts/Game/InputController.cs
@@ -11,7 +11,7 @@ public class InputController : MonoBehaviour
     public readonly Dictionary<int, HoldNote> HoldingNotes = new Dictionary<int, HoldNote>(); // Finger index to note
     public readonly List<Note> TouchableDragNotes = new List<Note>(); // Drag head, Drag child, CDrag child
     public readonly List<HoldNote> TouchableHoldNotes = new List<HoldNote>(); // Hold, Long hold
-    public readonly List<Note> TouchableNormalNotes = new List<Note>(); // Click, CDrag head, Hold, Long hold, Flick
+    public readonly List<Note> TouchableNormalNotes = new List<Note>(); // Click, CDrag head, Flick (Hold/LongHold: FingerUpdate only)
 
     private void Awake()
     {
@@ -66,13 +66,13 @@ public class InputController : MonoBehaviour
             var note = game.SpawnedNotes[id];
             if (!note.HasEmerged || note.IsCleared) continue;
 
-            if (note.Type != NoteType.DragHead && note.Type != NoteType.DragChild && note.Type != NoteType.CDragChild)
-            {
-                TouchableNormalNotes.Add(note);
-            }
-            else
+            if (note.Type == NoteType.DragHead || note.Type == NoteType.DragChild || note.Type == NoteType.CDragChild)
             {
                 TouchableDragNotes.Add(note);
+            }
+            else if (note.Type != NoteType.Hold && note.Type != NoteType.LongHold)
+            {
+                TouchableNormalNotes.Add(note);
             }
 
             if ((note.Type == NoteType.Hold || note.Type == NoteType.LongHold) &&

--- a/engines/unity/Assets/Scripts/Game/Notes/DragChildNote.cs
+++ b/engines/unity/Assets/Scripts/Game/Notes/DragChildNote.cs
@@ -12,13 +12,13 @@ public class DragChildNote : Note
             : throw new NotSupportedException();
     }
 
-    public override void OnTouch(Vector2 screenPos)
+    public override bool OnTouch(Vector2 screenPos)
     {
         // Do not handle touch event if touched too ahead of scanner
-        if (Model.start_time - Game.Time > 0.31f) return;
+        if (Model.start_time - Game.Time > 0.31f) return false;
         // Do not handle touch event if in a later page, unless the timing is close (half a screen)
-        if (Model.page_index > Game.Chart.CurrentPageId && Model.start_time - Game.Time > Page.Duration / 2f) return;
-        base.OnTouch(screenPos);
+        if (Model.page_index > Game.Chart.CurrentPageId && Model.start_time - Game.Time > Page.Duration / 2f) return false;
+        return base.OnTouch(screenPos);
     }
 
     public override NoteGrade CalculateGrade()

--- a/engines/unity/Assets/Scripts/Game/Notes/DragHeadNote.cs
+++ b/engines/unity/Assets/Scripts/Game/Notes/DragHeadNote.cs
@@ -162,17 +162,17 @@ public class DragHeadNote : Note
         }
     }
 
-    public override void OnTouch(Vector2 screenPos)
+    public override bool OnTouch(Vector2 screenPos)
     {
         if (!IsCDrag)
         {
             // Do not handle touch event if touched too ahead of scanner
-            if (Model.start_time - Game.Time > 0.31f) return;
+            if (Model.start_time - Game.Time > 0.31f) return false;
             // Do not handle touch event if in a later page, unless the timing is close (half a screen) TODO: Fix inaccurate algorithm
             if (Model.page_index > Game.Chart.CurrentPageId &&
-                Model.start_time - Game.Time > Page.Duration / 2f) return;
+                Model.start_time - Game.Time > Page.Duration / 2f) return false;
         }
-        base.OnTouch(screenPos);
+        return base.OnTouch(screenPos);
     }
 
     public override async void Collect()

--- a/engines/unity/Assets/Scripts/Game/Notes/FlickNote.cs
+++ b/engines/unity/Assets/Scripts/Game/Notes/FlickNote.cs
@@ -16,7 +16,7 @@ public class FlickNote : Note
             : throw new NotSupportedException();
     }
 
-    public override void OnTouch(Vector2 screenPos)
+    public override bool OnTouch(Vector2 screenPos)
     {
         // This method should never be invoked!
         throw new InvalidOperationException();

--- a/engines/unity/Assets/Scripts/Game/Notes/HoldNote.cs
+++ b/engines/unity/Assets/Scripts/Game/Notes/HoldNote.cs
@@ -74,9 +74,10 @@ public class HoldNote : Note
         return !IsHolding && base.ShouldMiss();
     }
     
-    public override void OnTouch(Vector2 screenPos)
+    public override bool OnTouch(Vector2 screenPos)
     {
-        // Do nothing
+        // Hold binds via InputController.UpdateFinger, not OnTouch.
+        return false;
     }
 
     public void UpdateFinger(int finger, bool isHolding)

--- a/engines/unity/Assets/Scripts/Game/Notes/Note.cs
+++ b/engines/unity/Assets/Scripts/Game/Notes/Note.cs
@@ -215,18 +215,21 @@ public abstract class Note : MonoBehaviour
         Renderer?.Dispose();
     }
 
-    public virtual void OnTouch(Vector2 screenPos)
+    /// <returns>True if this note took the touch (cleared or otherwise handled).</returns>
+    public virtual bool OnTouch(Vector2 screenPos)
     {
-        if (!Game.IsLoaded || !Game.State.IsPlaying) return;
-        TryClear();
+        if (!Game.IsLoaded || !Game.State.IsPlaying) return false;
+        return TryClear();
     }
 
-    public virtual void TryClear()
+    /// <returns>True if a grade was applied and the note was cleared.</returns>
+    public virtual bool TryClear()
     {
         if (IsAutoEnabled()) Clear(NoteGrade.Perfect);
         if (ShouldMiss()) Clear(NoteGrade.Miss);
         var grade = CalculateGrade();
         if (grade != NoteGrade.None) Clear(grade);
+        return IsCleared;
     }
 
     public virtual NoteGrade CalculateGrade()


### PR DESCRIPTION
## Summary
- Exclude Hold/LongHold from `TouchableNormalNotes` so FingerDown never routes through their empty `OnTouch`.
- Make `OnTouch`/`TryClear` return whether a note actually cleared; FingerDown only stops scanning when consumed.
- Ineffective early Drag hits no longer set `collidedDrag`, so far Click notes are not spuriously suppressed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved touch recognition for drag notes, ensuring only valid interactions are registered based on whether a note accepts the touch.
  * Prevented Hold and LongHold notes from being treated as ordinary tap targets.
  * Reduced unintended note clearing by only processing touches when the game is actively being played and note logic allows it.
  * Improved handling of overlapping notes so unsuccessful touch attempts no longer block other valid interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->