### PR TITLE
feat(chart): implement C2 PositionFunction for gameplay coordinates

### DIFF
--- a/engines/unity/Assets/Scripts/Game/Chart/Chart.cs
+++ b/engines/unity/Assets/Scripts/Game/Chart/Chart.cs
@@ -322,7 +322,7 @@ public class Chart
                + verticalOffset;
     }
 
-    float PageDisplayYToScreenY(ChartModel.Page page, float yDisplay)
+    float PageDisplayYToScreenY(float yDisplay)
     {
         return verticalRatio * (yDisplay * baseSize) + verticalOffset;
     }
@@ -364,7 +364,17 @@ public class Chart
     float GetNoteScreenYAtTick(ChartModel.Page page, float tick)
     {
         var t = GetPageProgressByTick(page, tick);
-        return PageDisplayYToScreenY(page, PositionFunction.EvaluateDisplayY(page, t));
+        return PageDisplayYToScreenY(PositionFunction.EvaluateDisplayY(page, t));
+    }
+
+    /// <summary>
+    /// Legacy past-last-page extrapolation: continue from the end edge with flipped scan direction.
+    /// </summary>
+    float GetScreenYPastPageEnd(ChartModel.Page page, float chronologicalProgressPastStart)
+    {
+        var past = chronologicalProgressPastStart - 1f;
+        return PageDisplayYToScreenY(
+            PositionFunction.EvaluateDisplayY(page, past, -page.scan_line_direction));
     }
 
     float GetHoldScreenLength(ChartModel.Page page, float startTick, float endTick)
@@ -395,18 +405,29 @@ public class Chart
     public float ConvertChartTickToScreenY(float tick)
     {
         var pageId = FindPageIndexByTick(tick);
-        var page = Model.page_list[pageId == Model.page_list.Count ? pageId - 1 : pageId];
-        return GetNoteScreenYAtTick(page, tick);
+        if (pageId == Model.page_list.Count)
+            return GetScreenYPastPageEnd(Model.page_list[pageId - 1], GetPageProgressByTick(Model.page_list[pageId - 1], tick));
+
+        return GetNoteScreenYAtTick(Model.page_list[pageId], tick);
     }
 
     public float GetScannerPositionY(float time, bool useScannerSmoothing)
     {
         var pageId = FindPageIndexByTime(time);
-        var page = Model.page_list[pageId == Model.page_list.Count ? pageId - 1 : pageId];
-        var progress = useScannerSmoothing
-            ? GetPageProgressByTick(page, ConvertToTick(time))
-            : GetPageProgressByTime(page, time);
-        return PageDisplayYToScreenY(page, PositionFunction.EvaluateDisplayY(page, progress));
+        if (pageId == Model.page_list.Count)
+        {
+            var page = Model.page_list[pageId - 1];
+            var progress = useScannerSmoothing
+                ? GetPageProgressByTick(page, ConvertToTick(time))
+                : GetPageProgressByTime(page, time);
+            return GetScreenYPastPageEnd(page, progress);
+        }
+
+        var current = Model.page_list[pageId];
+        var pageProgress = useScannerSmoothing
+            ? GetPageProgressByTick(current, ConvertToTick(time))
+            : GetPageProgressByTime(current, time);
+        return PageDisplayYToScreenY(PositionFunction.EvaluateDisplayY(current, pageProgress));
     }
 
     public float GetScanlinePosition01(float percentage)
@@ -419,9 +440,13 @@ public class Chart
         pageId = Mathf.Clamp(pageId, 0, Model.page_list.Count - 1);
         var page = Model.page_list[pageId];
         PositionFunction.GetVisibleBand(page, out var low, out var high);
-        return PageDisplayYToScreenY(page, bottom ? low : high);
+        return PageDisplayYToScreenY(bottom ? low : high);
     }
 
+    /// <summary>
+    /// Full play-area top/bottom (always ±baseSize). Page-aware bands use
+    /// <see cref="GetPageBoundaryScreenY"/> instead.
+    /// </summary>
     public float GetBoundaryPosition(bool bottom)
     {
         return verticalRatio * (bottom ? 1 : -1) *

--- a/engines/unity/Assets/Scripts/Game/Chart/Chart.cs
+++ b/engines/unity/Assets/Scripts/Game/Chart/Chart.cs
@@ -119,6 +119,7 @@ public class Chart
             }
 
             if (isVerticallyInverted) page.scan_line_direction = page.scan_line_direction == 1 ? -1 : 1;
+            PositionFunction.BakeArgs(page);
         }
 
         var pageNoteCountsByType = new Dictionary<NoteType, int[]>();
@@ -192,10 +193,7 @@ public class Chart
                 ConvertChartTickToScreenY((float) (note.tick + note.hold_tick))
             );
 
-            note.holdlength = (float) (verticalRatio * 2.0f * baseSize *
-                                       note.hold_tick /
-                                       (page.end_tick -
-                                        page.start_tick));
+            note.holdlength = GetHoldScreenLength(page, (float) note.tick, (float) (note.tick + note.hold_tick));
 
             if (note.type == (int) NoteType.DragHead || note.type == (int) NoteType.DragChild || 
                 note.type == (int) NoteType.CDragHead || note.type == (int) NoteType.CDragChild)
@@ -324,18 +322,69 @@ public class Chart
                + verticalOffset;
     }
 
+    float PageDisplayYToScreenY(ChartModel.Page page, float yDisplay)
+    {
+        return verticalRatio * (yDisplay * baseSize) + verticalOffset;
+    }
+
+    static float GetPageProgressByTick(ChartModel.Page page, float tick)
+    {
+        var span = (float) (page.end_tick - page.start_tick);
+        if (span <= 0f) return 0f;
+        return (tick - (float) page.start_tick) / span;
+    }
+
+    static float GetPageProgressByTime(ChartModel.Page page, float time)
+    {
+        var span = page.end_time - page.start_time;
+        if (span <= 0f) return 0f;
+        return (time - page.start_time) / span;
+    }
+
+    public int FindPageIndexByTime(float time)
+    {
+        for (var i = 0; i < Model.page_list.Count; i++)
+        {
+            if (time < Model.page_list[i].end_time) return i;
+        }
+
+        return Model.page_list.Count;
+    }
+
+    public int FindPageIndexByTick(float tick)
+    {
+        for (var i = 0; i < Model.page_list.Count; i++)
+        {
+            if (tick <= Model.page_list[i].end_tick) return i;
+        }
+
+        return Model.page_list.Count;
+    }
+
+    float GetNoteScreenYAtTick(ChartModel.Page page, float tick)
+    {
+        var t = GetPageProgressByTick(page, tick);
+        return PageDisplayYToScreenY(page, PositionFunction.EvaluateDisplayY(page, t));
+    }
+
+    float GetHoldScreenLength(ChartModel.Page page, float startTick, float endTick)
+    {
+        var t0 = GetPageProgressByTick(page, startTick);
+        var t1 = GetPageProgressByTick(page, endTick);
+        var y0 = PositionFunction.EvaluateDisplayY(page, t0);
+        var y1 = PositionFunction.EvaluateDisplayY(page, t1);
+        return verticalRatio * baseSize * Mathf.Abs(y1 - y0);
+    }
+
     public float GetNoteScreenY(ChartModel.Note note)
     {
-        var page = Model.page_list[note.page_index];
-        return (float) (
-            verticalRatio * page.scan_line_direction *
-            (-baseSize + 2.0f *
-                baseSize *
-                (note.tick - page.start_tick) * 1.0f /
-                (page.end_tick - page.start_tick))
-            + verticalOffset);
+        return GetNoteScreenYAtTick(Model.page_list[note.page_index], (float) note.tick);
     }
-    
+
+    /// <summary>
+    /// Legacy chart Y for Storyboard overrides (<see cref="ChartModel.Note.CalculatePosition"/>).
+    /// Intentionally linear in tick progress; not PageFunction-aware.
+    /// </summary>
     public float GetNoteChartY(ChartModel.Note note)
     {
         var page = Model.page_list[note.page_index];
@@ -345,71 +394,32 @@ public class Chart
 
     public float ConvertChartTickToScreenY(float tick)
     {
-        var targetPageId = 0;
-        while (targetPageId < Model.page_list.Count && tick > Model.page_list[targetPageId].end_tick)
-            targetPageId++;
-
-        if (targetPageId == Model.page_list.Count)
-            return (float) (
-                -verticalRatio * Model.page_list[targetPageId - 1].scan_line_direction *
-                (-baseSize + 2.0f *
-                 baseSize *
-                 (tick - Model.page_list[targetPageId - 1].end_tick) *
-                 1.0f / (Model.page_list[targetPageId - 1].end_tick -
-                         Model.page_list[targetPageId - 1].start_tick))
-                + verticalOffset);
-
-        return (float) (
-            verticalRatio * Model.page_list[targetPageId].scan_line_direction *
-            (-baseSize + 2.0f *
-             baseSize * (tick - Model.page_list[targetPageId].start_tick) *
-             1.0f / (Model.page_list[targetPageId].end_tick - Model.page_list[targetPageId].start_tick))
-            + verticalOffset);
+        var pageId = FindPageIndexByTick(tick);
+        var page = Model.page_list[pageId == Model.page_list.Count ? pageId - 1 : pageId];
+        return GetNoteScreenYAtTick(page, tick);
     }
 
     public float GetScannerPositionY(float time, bool useScannerSmoothing)
     {
-        CurrentPageId = 0;
-        while (CurrentPageId < Model.page_list.Count && time > Model.page_list[CurrentPageId].end_time)
-            CurrentPageId++;
-        if (CurrentPageId == Model.page_list.Count)
-        {
-            if (useScannerSmoothing)
-                return (float) (-verticalRatio * Model.page_list[CurrentPageId - 1].scan_line_direction *
-                                (-baseSize + 2.0f *
-                                 baseSize *
-                                 (ConvertToTick(time) - Model.page_list[CurrentPageId - 1].end_tick) *
-                                 1.0f / (Model.page_list[CurrentPageId - 1].end_tick -
-                                         Model.page_list[CurrentPageId - 1].start_tick))
-                                + verticalOffset);
-            return -verticalRatio * Model.page_list[CurrentPageId - 1].scan_line_direction *
-                   (-baseSize + 2.0f *
-                    baseSize *
-                    (time - Model.page_list[CurrentPageId - 1].end_time) *
-                    1.0f / (Model.page_list[CurrentPageId - 1].end_time -
-                            Model.page_list[CurrentPageId - 1].start_time))
-                   + verticalOffset;
-        }
-
-        if (useScannerSmoothing)
-            return (float) (verticalRatio * Model.page_list[CurrentPageId].scan_line_direction *
-                            (-baseSize + 2.0f *
-                             baseSize *
-                             (ConvertToTick(time) - Model.page_list[CurrentPageId].start_tick) *
-                             1.0f / (Model.page_list[CurrentPageId].end_tick -
-                                     Model.page_list[CurrentPageId].start_tick))
-                            + verticalOffset);
-        return verticalRatio * Model.page_list[CurrentPageId].scan_line_direction *
-               (-baseSize + 2.0f *
-                baseSize *
-                (time - Model.page_list[CurrentPageId].start_time) *
-                1.0f / (Model.page_list[CurrentPageId].end_time - Model.page_list[CurrentPageId].start_time))
-               + verticalOffset;
+        var pageId = FindPageIndexByTime(time);
+        var page = Model.page_list[pageId == Model.page_list.Count ? pageId - 1 : pageId];
+        var progress = useScannerSmoothing
+            ? GetPageProgressByTick(page, ConvertToTick(time))
+            : GetPageProgressByTime(page, time);
+        return PageDisplayYToScreenY(page, PositionFunction.EvaluateDisplayY(page, progress));
     }
 
     public float GetScanlinePosition01(float percentage)
     {
         return ConvertChartYToScreenY(percentage);
+    }
+
+    public float GetPageBoundaryScreenY(int pageId, bool bottom)
+    {
+        pageId = Mathf.Clamp(pageId, 0, Model.page_list.Count - 1);
+        var page = Model.page_list[pageId];
+        PositionFunction.GetVisibleBand(page, out var low, out var high);
+        return PageDisplayYToScreenY(page, bottom ? low : high);
     }
 
     public float GetBoundaryPosition(bool bottom)

--- a/engines/unity/Assets/Scripts/Game/Chart/ChartModel.cs
+++ b/engines/unity/Assets/Scripts/Game/Chart/ChartModel.cs
@@ -28,11 +28,25 @@ public class ChartModel
     public bool? skip_music_on_completion;
     
     [Serializable]
+    public class PagePositionFunction
+    {
+        public int Type;
+        public double[] Arguments;
+    }
+
+    [Serializable]
     public class Page
     {
         public double start_tick;
         public double end_tick;
         public int scan_line_direction;
+
+        [JsonProperty("PositionFunction")]
+        public PagePositionFunction position_function;
+
+        // Resolved at chart load; not part of c2 JSON.
+        public float position_arg_a = 1f;
+        public float position_arg_b;
 
         public float start_time;
         public float end_time;

--- a/engines/unity/Assets/Scripts/Game/Chart/ChartModel.cs
+++ b/engines/unity/Assets/Scripts/Game/Chart/ChartModel.cs
@@ -45,8 +45,8 @@ public class ChartModel
         public PagePositionFunction position_function;
 
         // Resolved at chart load; not part of c2 JSON.
-        public float position_arg_a = 1f;
-        public float position_arg_b;
+        [JsonIgnore] public float position_arg_a = 1f;
+        [JsonIgnore] public float position_arg_b;
 
         public float start_time;
         public float end_time;

--- a/engines/unity/Assets/Scripts/Game/Chart/PositionFunction.cs
+++ b/engines/unity/Assets/Scripts/Game/Chart/PositionFunction.cs
@@ -1,0 +1,62 @@
+using UnityEngine;
+
+/// <summary>
+/// C2 PageFunction math (PositionFunction Arguments).
+/// Gameplay coordinates only — Storyboard continues to use legacy
+/// <see cref="Chart.ConvertChartYToScreenY"/> via <see cref="ChartModel.Note.y"/>.
+/// </summary>
+public static class PositionFunction
+{
+    public static void BakeArgs(ChartModel.Page page)
+    {
+        var pf = page.position_function;
+        page.position_arg_a = pf?.Arguments != null && pf.Arguments.Length > 0 ? (float) pf.Arguments[0] : 1f;
+        page.position_arg_b = pf?.Arguments != null && pf.Arguments.Length > 1 ? (float) pf.Arguments[1] : 0f;
+    }
+
+    public static float GetScanProgress(ChartModel.Page page, float chronologicalT)
+    {
+        return page.scan_line_direction == 1 ? chronologicalT : (1f - chronologicalT);
+    }
+
+    public static void GetVisibleBand(ChartModel.Page page, out float low, out float high)
+    {
+        var a = page.position_arg_a;
+        var b = page.position_arg_b;
+        if (Mathf.Approximately(a, 0f))
+        {
+            var y = Mathf.Clamp(b, -1f, 1f);
+            low = y;
+            high = y;
+            return;
+        }
+
+        var yLow = b - a;
+        var yHigh = b + a;
+        low = Mathf.Max(yLow, -1f);
+        high = Mathf.Min(yHigh, 1f);
+    }
+
+    /// <summary>
+    /// Normalized play-area Y in [-1, 1] (bottom = -1). Scan direction via <see cref="GetScanProgress"/>.
+    /// </summary>
+    public static float EvaluateDisplayY(ChartModel.Page page, float chronologicalT)
+    {
+        var a = page.position_arg_a;
+        var b = page.position_arg_b;
+        if (Mathf.Approximately(a, 0f))
+            return Mathf.Clamp(b, -1f, 1f);
+
+        var t = GetScanProgress(page, chronologicalT);
+        var yRaw = b + a * (2f * t - 1f);
+
+        if (t < 0f || t > 1f)
+            return yRaw;
+
+        var yLow = b - a;
+        var yHigh = b + a;
+        var low = Mathf.Max(yLow, -1f);
+        var high = Mathf.Min(yHigh, 1f);
+        return low + (high - low) * (yRaw - yLow) / (2f * a);
+    }
+}

--- a/engines/unity/Assets/Scripts/Game/Chart/PositionFunction.cs
+++ b/engines/unity/Assets/Scripts/Game/Chart/PositionFunction.cs
@@ -83,18 +83,15 @@ public static class PositionFunction
             return Mathf.Clamp(b, -1f, 1f);
 
         var t = GetScanProgress(scanLineDirection, chronologicalT);
-        var yRaw = b + a * (2f * t - 1f);
 
-        // Outside the page chronologically (or the mirrored past-end segment): raw linear.
-        if (t < 0f || t > 1f)
-            return yRaw;
-
-        // Remap the raw segment [b-a, b+a] onto its intersection with [-1, 1],
-        // preserving direction so negative a still reverses the page.
+        // Affine map of scan progress onto the visible band [d0, d1] for all t
+        // (including past-end / pre-page). Equivalent to remapping yRaw∈[b-a, b+a]
+        // onto Clamp endpoints; for unclipped a=1,b=0 this is identical to yRaw.
+        // Preserves direction so negative a still reverses the page.
         var y0 = b - a;
         var y1 = b + a;
         var d0 = Mathf.Clamp(y0, -1f, 1f);
         var d1 = Mathf.Clamp(y1, -1f, 1f);
-        return d0 + (d1 - d0) * (yRaw - y0) / (y1 - y0);
+        return d0 + (d1 - d0) * t;
     }
 }

--- a/engines/unity/Assets/Scripts/Game/Chart/PositionFunction.cs
+++ b/engines/unity/Assets/Scripts/Game/Chart/PositionFunction.cs
@@ -33,6 +33,21 @@ public static class PositionFunction
 
         var yLow = b - a;
         var yHigh = b + a;
+
+        if (yHigh < -1f)
+        {
+            low = -1f;
+            high = -1f;
+            return;
+        }
+
+        if (yLow > 1f)
+        {
+            low = 1f;
+            high = 1f;
+            return;
+        }
+
         low = Mathf.Max(yLow, -1f);
         high = Mathf.Min(yHigh, 1f);
     }
@@ -54,9 +69,7 @@ public static class PositionFunction
             return yRaw;
 
         var yLow = b - a;
-        var yHigh = b + a;
-        var low = Mathf.Max(yLow, -1f);
-        var high = Mathf.Min(yHigh, 1f);
+        GetVisibleBand(page, out var low, out var high);
         return low + (high - low) * (yRaw - yLow) / (2f * a);
     }
 }

--- a/engines/unity/Assets/Scripts/Game/Chart/PositionFunction.cs
+++ b/engines/unity/Assets/Scripts/Game/Chart/PositionFunction.cs
@@ -4,6 +4,7 @@ using UnityEngine;
 /// C2 PageFunction math (PositionFunction Arguments).
 /// Gameplay coordinates only — Storyboard continues to use legacy
 /// <see cref="Chart.ConvertChartYToScreenY"/> via <see cref="ChartModel.Note.y"/>.
+/// Negative <c>a</c> reverses the page (scan maps top↔bottom); that is intentional.
 /// </summary>
 public static class PositionFunction
 {
@@ -14,11 +15,19 @@ public static class PositionFunction
         page.position_arg_b = pf?.Arguments != null && pf.Arguments.Length > 1 ? (float) pf.Arguments[1] : 0f;
     }
 
-    public static float GetScanProgress(ChartModel.Page page, float chronologicalT)
+    public static float GetScanProgress(int scanLineDirection, float chronologicalT)
     {
-        return page.scan_line_direction == 1 ? chronologicalT : (1f - chronologicalT);
+        return scanLineDirection == 1 ? chronologicalT : (1f - chronologicalT);
     }
 
+    public static float GetScanProgress(ChartModel.Page page, float chronologicalT)
+    {
+        return GetScanProgress(page.scan_line_direction, chronologicalT);
+    }
+
+    /// <summary>
+    /// Visible play-area band in display Y (always <paramref name="low"/> ≤ <paramref name="high"/>).
+    /// </summary>
     public static void GetVisibleBand(ChartModel.Page page, out float low, out float high)
     {
         var a = page.position_arg_a;
@@ -31,45 +40,61 @@ public static class PositionFunction
             return;
         }
 
-        var yLow = b - a;
-        var yHigh = b + a;
+        var y0 = b - a;
+        var y1 = b + a;
+        var sortedLo = Mathf.Min(y0, y1);
+        var sortedHi = Mathf.Max(y0, y1);
 
-        if (yHigh < -1f)
+        if (sortedHi < -1f)
         {
             low = -1f;
             high = -1f;
             return;
         }
 
-        if (yLow > 1f)
+        if (sortedLo > 1f)
         {
             low = 1f;
             high = 1f;
             return;
         }
 
-        low = Mathf.Max(yLow, -1f);
-        high = Mathf.Min(yHigh, 1f);
+        low = Mathf.Max(sortedLo, -1f);
+        high = Mathf.Min(sortedHi, 1f);
     }
 
     /// <summary>
-    /// Normalized play-area Y in [-1, 1] (bottom = -1). Scan direction via <see cref="GetScanProgress"/>.
+    /// Normalized play-area Y in [-1, 1] (bottom = -1).
     /// </summary>
     public static float EvaluateDisplayY(ChartModel.Page page, float chronologicalT)
+    {
+        return EvaluateDisplayY(page, chronologicalT, page.scan_line_direction);
+    }
+
+    /// <summary>
+    /// Same as <see cref="EvaluateDisplayY(ChartModel.Page, float)"/> with an explicit scan direction
+    /// (used for legacy past-end extrapolation that mirrors with a flipped direction).
+    /// </summary>
+    public static float EvaluateDisplayY(ChartModel.Page page, float chronologicalT, int scanLineDirection)
     {
         var a = page.position_arg_a;
         var b = page.position_arg_b;
         if (Mathf.Approximately(a, 0f))
             return Mathf.Clamp(b, -1f, 1f);
 
-        var t = GetScanProgress(page, chronologicalT);
+        var t = GetScanProgress(scanLineDirection, chronologicalT);
         var yRaw = b + a * (2f * t - 1f);
 
+        // Outside the page chronologically (or the mirrored past-end segment): raw linear.
         if (t < 0f || t > 1f)
             return yRaw;
 
-        var yLow = b - a;
-        GetVisibleBand(page, out var low, out var high);
-        return low + (high - low) * (yRaw - yLow) / (2f * a);
+        // Remap the raw segment [b-a, b+a] onto its intersection with [-1, 1],
+        // preserving direction so negative a still reverses the page.
+        var y0 = b - a;
+        var y1 = b + a;
+        var d0 = Mathf.Clamp(y0, -1f, 1f);
+        var d1 = Mathf.Clamp(y1, -1f, 1f);
+        return d0 + (d1 - d0) * (yRaw - y0) / (y1 - y0);
     }
 }

--- a/engines/unity/Assets/Scripts/Game/Chart/PositionFunction.cs.meta
+++ b/engines/unity/Assets/Scripts/Game/Chart/PositionFunction.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 580b8c9d4732a98468ef6be2db75146b

--- a/engines/unity/Assets/Scripts/Game/Notes/GameRenderer.cs
+++ b/engines/unity/Assets/Scripts/Game/Notes/GameRenderer.cs
@@ -109,8 +109,13 @@ public class GameRenderer
             boundaryTopAnimator.speed = 1;
             boundaryBottomAnimator.speed = boundaryTopAnimator.speed;
         }
-        boundaryTop.transform.position = new Vector3(0, chart.GetBoundaryPosition(false), 0);
-        boundaryBottom.transform.position = new Vector3(0, chart.GetBoundaryPosition(true), 0);
+
+        if (chart.Model.page_list.Count > 0)
+        {
+            var pageId = Mathf.Min(chart.CurrentPageId, chart.Model.page_list.Count - 1);
+            boundaryTop.transform.position = new Vector3(0, chart.GetPageBoundaryScreenY(pageId, false), 0);
+            boundaryBottom.transform.position = new Vector3(0, chart.GetPageBoundaryScreenY(pageId, true), 0);
+        }
         if (Game.State.IsStarted && Game.State.IsPlaying && !Game.State.IsCompleted)
         {
             // Update opacity


### PR DESCRIPTION
## Summary
- Add C2 `PositionFunction` for gameplay note/hold/scanner/boundary Y mapping; default `a=1,b=0` matches legacy linear scan; negative `a` intentionally reverses the page.
- Restore legacy past-last-page extrapolation (flipped scan direction) and clamp empty/out-of-range bands.

> [!WARNING]
> Storyboard compatibility has not been verified. Gameplay coordinates use `PositionFunction`; Storyboard still relies on legacy `note.y` / `ConvertChartYToScreenY`. Charts that combine PositionFunction with storyboard Y overrides need manual QA before relying on this in production.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added page-specific note positioning and visible play-area band edge calculations.
  - Introduced per-page position functions loaded from chart data (with argument defaults) to drive direction-aware Y mapping.
  - Updated on-screen boundary rendering to follow the active page’s visible band.

- **Bug Fixes**
  - Corrected hold-length and note/screen Y mapping for charts with varying page layouts.
  - Improved scanner behavior and note rendering across page transitions, including proper extrapolation past the final page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->