### PR TITLE
fix(gameplay): anchor Drop note hitbox at landing scanline point

### DIFF
--- a/engines/unity/Assets/Scripts/Game/Notes/Drop/DropClickNoteRenderer.cs
+++ b/engines/unity/Assets/Scripts/Game/Notes/Drop/DropClickNoteRenderer.cs
@@ -4,7 +4,10 @@ using Object = UnityEngine.Object;
 // Drop note renderer for DropClick. Inherits ClassicClickNoteRenderer (which is currently a
 // pass-through to ClassicNoteRenderer) and adds:
 //   1. A Core child SpriteRenderer (added to the prefab in T7) that sits above Fill, always white.
-//   2. The drop "falling" Y offset ported faithfully from Cylheim.
+//   2. The drop "falling" Y offset ported faithfully from Cylheim, applied ONLY to visual
+//      children (Ring / Fill / Core / NoteId). Note.transform itself is left at the landing
+//      scanline point so the CircleCollider2D — and therefore hit detection — stays anchored
+//      where the player should tap, regardless of the falling animation.
 // Drop notes do NOT use the approach scale/fill animations — they are full-size from intro_time
 // and reach the scanline via the Y offset alone, so UpdateTransformScale / UpdateFillScale are
 // overridden to set fixed values.
@@ -12,11 +15,33 @@ public class DropClickNoteRenderer : ClassicClickNoteRenderer
 {
     protected SpriteRenderer Core;
 
+    // Base localPosition of each visual child, snapshotted ONCE in the constructor when the
+    // Note GameObject is freshly created from its prefab. Capturing the pristine prefab
+    // positions is pool-reuse safe: a Drop note that is cleared mid-fall leaves residual
+    // offsets on its children, and snapshotting at every OnNoteLoaded would bake those in.
+    // Each frame we write localPosition = baseLocal + localOffset so the offset never
+    // compounds across frames.
+    private Vector3 ringBaseLocal;
+    private Vector3 fillBaseLocal;
+    private Vector3 coreBaseLocal;
+    private Vector3 noteIdBaseLocal;
+    private bool hasCore;
+    private bool hasNoteId;
+
     public DropClickNoteRenderer(ClickNote clickNote) : base(clickNote)
     {
         // The Core child is added to the prefab in T7; null-check until then.
         var coreTransform = Note.transform.Find("NoteCore");
         if (coreTransform != null) Core = coreTransform.GetComponent<SpriteRenderer>();
+
+        // Snapshot base localPosition once. base() has already instantiated Ring, Fill, and
+        // (when DisplayNoteId) NoteId, so all visual children are available here.
+        ringBaseLocal = Ring.transform.localPosition;
+        fillBaseLocal = Fill.transform.localPosition;
+        hasCore = Core != null;
+        if (hasCore) coreBaseLocal = Core.transform.localPosition;
+        hasNoteId = DisplayNoteId && NoteId != null;
+        if (hasNoteId) noteIdBaseLocal = NoteId.transform.localPosition;
     }
 
     public override void OnNoteLoaded()
@@ -28,38 +53,76 @@ public class DropClickNoteRenderer : ClassicClickNoteRenderer
         if (Core != null) Core.sortingOrder = Fill.sortingOrder + 1;
     }
 
+    public override void OnCollect()
+    {
+        base.OnCollect();
+        // Restore prefab-local positions so a Note GameObject pulled from the pool starts the
+        // next cycle from a clean visual state. ApplyDropOffset would correct this on the
+        // first frame anyway, but this keeps the lifecycle explicit and prevents any brief
+        // pre-first-frame visibility of stale offsets.
+        Ring.transform.localPosition = ringBaseLocal;
+        Fill.transform.localPosition = fillBaseLocal;
+        if (hasCore) Core.transform.localPosition = coreBaseLocal;
+        if (hasNoteId) NoteId.transform.localPosition = noteIdBaseLocal;
+    }
+
     protected override void Render()
     {
         base.Render();
         ApplyDropOffset();
     }
 
-    // Faithful port of Cylheim pixi-playback-note-layer.ts:524-540 getPlaybackDropSpriteOffsetY.
+    // Faithful port of Cylheim pixi-playback-note-layer.ts:524-540 getPlaybackDropSpriteOffsetY,
+    // then applied only to visual children so the collider stays at the landing scanline point.
     // Verified: durationTick=500, timeDiff=0.1s, height=540 -> 800px; height=1080 -> 1600px.
     private void ApplyDropOffset()
     {
         var page = Note.Page;
         double durationTick = (page.end_tick - page.start_tick) * 5.0;
-        if (durationTick <= 0 || !double.IsFinite(durationTick)) return; // Cylheim guard
 
-        // Cylheim uses screen coords (Y down): Up=+1, Down=-1.
-        // Unity uses world coords (Y up): flip the sign so Down falls from above (+Y), Up rises from below (-Y).
-        float dirSign = Note.Model.NoteDirection == 1 ? -1f : 1f; // Up -> -1, Down -> +1
-        float timeDiffSeconds = (float) (Note.Model.start_time - Note.Game.Time);
+        Vector3 localOffset = Vector3.zero;
+        // Cylheim guard: skip when chart is malformed. timeDiff<=0 means "at or past landing";
+        // localOffset stays zero and children snap back to base localPosition.
+        if (durationTick > 0 && double.IsFinite(durationTick))
+        {
+            // Cylheim uses screen coords (Y down): Up=+1, Down=-1.
+            // Unity uses world coords (Y up): flip the sign so Down falls from above (+Y),
+            // Up rises from below (-Y).
+            float dirSign = Note.Model.NoteDirection == 1 ? -1f : 1f; // Up -> -1, Down -> +1
+            float timeDiffSeconds = (float) (Note.Model.start_time - Note.Game.Time);
 
-        // At or past landing: no offset, note rests at scanline.
-        if (timeDiffSeconds <= 0f) return;
+            if (timeDiffSeconds > 0f)
+            {
+                // Cylheim formula in screen-heights (resolution-independent):
+                //   offsetY_screen_heights = dir * (8_000_000 / durationTick) * timeDiff / 1080
+                // Translate to Unity world units via visible camera height (2 * orthographicSize):
+                float screenHeightWorld = 2f * Note.Game.camera.orthographicSize;
+                float offsetYWorld = dirSign * (8_000_000f / (float) durationTick) * timeDiffSeconds
+                                     / 1080f * screenHeightWorld;
+                // Translate the world-space vertical offset into Note's local space so the
+                // visual amplitude is correct under any combination of rotation AND scale.
+                // InverseTransformVector accounts for both. Guard against singular (zero) or
+                // non-finite scale to avoid NaN from the matrix inversion — a zero-scale note
+                // is invisible anyway, so the offset is irrelevant.
+                Vector3 s = Note.transform.localScale;
+                if (s.x != 0f && s.y != 0f && s.z != 0f
+                    && float.IsFinite(s.x) && float.IsFinite(s.y) && float.IsFinite(s.z))
+                {
+                    localOffset = Note.transform.InverseTransformVector(
+                        new Vector3(0f, offsetYWorld, 0f));
+                }
+            }
+        }
 
-        // Cylheim formula in screen-heights (resolution-independent):
-        //   offsetY_screen_heights = dir * (8_000_000 / durationTick) * timeDiff / 1080
-        // Translate to Unity world units via visible camera height (2 * orthographicSize):
-        float screenHeightWorld = 2f * Note.Game.camera.orthographicSize;
-        float offsetYWorld = dirSign * (8_000_000f / (float) durationTick) * timeDiffSeconds / 1080f *
-                             screenHeightWorld;
+        ApplyChildOffset(Ring.transform, ringBaseLocal, localOffset);
+        ApplyChildOffset(Fill.transform, fillBaseLocal, localOffset);
+        if (hasCore) ApplyChildOffset(Core.transform, coreBaseLocal, localOffset);
+        if (hasNoteId) ApplyChildOffset(NoteId.transform, noteIdBaseLocal, localOffset);
+    }
 
-        var pos = Note.transform.localPosition;
-        pos.y += offsetYWorld;
-        Note.transform.localPosition = pos;
+    private static void ApplyChildOffset(Transform t, Vector3 baseLocal, Vector3 offset)
+    {
+        t.localPosition = baseLocal + offset;
     }
 
     // Drop notes ignore the approach-scale animation: always full BaseTransformSize.

--- a/engines/unity/Assets/Scripts/Game/Notes/Drop/DropClickNoteRenderer.cs
+++ b/engines/unity/Assets/Scripts/Game/Notes/Drop/DropClickNoteRenderer.cs
@@ -72,57 +72,15 @@ public class DropClickNoteRenderer : ClassicClickNoteRenderer
         ApplyDropOffset();
     }
 
-    // Faithful port of Cylheim pixi-playback-note-layer.ts:524-540 getPlaybackDropSpriteOffsetY,
-    // then applied only to visual children so the collider stays at the landing scanline point.
-    // Verified: durationTick=500, timeDiff=0.1s, height=540 -> 800px; height=1080 -> 1600px.
+    // Drives the falling animation by offsetting only the visual children — see
+    // DropNoteOffset.ComputeLocalOffset for the math and rationale.
     private void ApplyDropOffset()
     {
-        var page = Note.Page;
-        double durationTick = (page.end_tick - page.start_tick) * 5.0;
-
-        Vector3 localOffset = Vector3.zero;
-        // Cylheim guard: skip when chart is malformed. timeDiff<=0 means "at or past landing";
-        // localOffset stays zero and children snap back to base localPosition.
-        if (durationTick > 0 && double.IsFinite(durationTick))
-        {
-            // Cylheim uses screen coords (Y down): Up=+1, Down=-1.
-            // Unity uses world coords (Y up): flip the sign so Down falls from above (+Y),
-            // Up rises from below (-Y).
-            float dirSign = Note.Model.NoteDirection == 1 ? -1f : 1f; // Up -> -1, Down -> +1
-            float timeDiffSeconds = (float) (Note.Model.start_time - Note.Game.Time);
-
-            if (timeDiffSeconds > 0f)
-            {
-                // Cylheim formula in screen-heights (resolution-independent):
-                //   offsetY_screen_heights = dir * (8_000_000 / durationTick) * timeDiff / 1080
-                // Translate to Unity world units via visible camera height (2 * orthographicSize):
-                float screenHeightWorld = 2f * Note.Game.camera.orthographicSize;
-                float offsetYWorld = dirSign * (8_000_000f / (float) durationTick) * timeDiffSeconds
-                                     / 1080f * screenHeightWorld;
-                // Translate the world-space vertical offset into Note's local space so the
-                // visual amplitude is correct under any combination of rotation AND scale.
-                // InverseTransformVector accounts for both. Guard against singular (zero) or
-                // non-finite scale to avoid NaN from the matrix inversion — a zero-scale note
-                // is invisible anyway, so the offset is irrelevant.
-                Vector3 s = Note.transform.localScale;
-                if (s.x != 0f && s.y != 0f && s.z != 0f
-                    && float.IsFinite(s.x) && float.IsFinite(s.y) && float.IsFinite(s.z))
-                {
-                    localOffset = Note.transform.InverseTransformVector(
-                        new Vector3(0f, offsetYWorld, 0f));
-                }
-            }
-        }
-
-        ApplyChildOffset(Ring.transform, ringBaseLocal, localOffset);
-        ApplyChildOffset(Fill.transform, fillBaseLocal, localOffset);
-        if (hasCore) ApplyChildOffset(Core.transform, coreBaseLocal, localOffset);
-        if (hasNoteId) ApplyChildOffset(NoteId.transform, noteIdBaseLocal, localOffset);
-    }
-
-    private static void ApplyChildOffset(Transform t, Vector3 baseLocal, Vector3 offset)
-    {
-        t.localPosition = baseLocal + offset;
+        Vector3 localOffset = DropNoteOffset.ComputeLocalOffset(Note);
+        DropNoteOffset.ApplyToChild(Ring.transform, ringBaseLocal, localOffset);
+        DropNoteOffset.ApplyToChild(Fill.transform, fillBaseLocal, localOffset);
+        if (hasCore) DropNoteOffset.ApplyToChild(Core.transform, coreBaseLocal, localOffset);
+        if (hasNoteId) DropNoteOffset.ApplyToChild(NoteId.transform, noteIdBaseLocal, localOffset);
     }
 
     // Drop notes ignore the approach-scale animation: always full BaseTransformSize.

--- a/engines/unity/Assets/Scripts/Game/Notes/Drop/DropDragNoteRenderer.cs
+++ b/engines/unity/Assets/Scripts/Game/Notes/Drop/DropDragNoteRenderer.cs
@@ -3,11 +3,25 @@ using UnityEngine;
 // Drop note renderer for DropDrag. Inherits ClassicNoteRenderer directly (DropDrag does not
 // extend ClickNote, and DropDrag has no Core layer). Behaves like DropClickNoteRenderer minus
 // the Core handling: drop notes ignore approach scale/fill animations and reach the scanline
-// via the Y offset alone.
+// via the Y offset alone, applied only to visual children so the CircleCollider2D stays
+// anchored at the landing scanline point.
 public class DropDragNoteRenderer : ClassicNoteRenderer
 {
+    // Base localPosition of each visual child, snapshotted ONCE in the constructor when the
+    // Note GameObject is freshly created from its prefab. Pool-reuse safe — see DropClickNoteRenderer.
+    private Vector3 ringBaseLocal;
+    private Vector3 fillBaseLocal;
+    private Vector3 noteIdBaseLocal;
+    private bool hasNoteId;
+
     public DropDragNoteRenderer(Note note) : base(note)
     {
+        // Snapshot base localPosition once. base() has already instantiated Ring, Fill, and
+        // (when DisplayNoteId) NoteId, so all visual children are available here.
+        ringBaseLocal = Ring.transform.localPosition;
+        fillBaseLocal = Fill.transform.localPosition;
+        hasNoteId = DisplayNoteId && NoteId != null;
+        if (hasNoteId) noteIdBaseLocal = NoteId.transform.localPosition;
     }
 
     public override void OnNoteLoaded()
@@ -18,38 +32,68 @@ public class DropDragNoteRenderer : ClassicNoteRenderer
         Fill.sortingOrder = Ring.sortingOrder + 1;
     }
 
+    public override void OnCollect()
+    {
+        base.OnCollect();
+        // Restore prefab-local positions so a Note GameObject pulled from the pool starts the
+        // next cycle from a clean visual state.
+        Ring.transform.localPosition = ringBaseLocal;
+        Fill.transform.localPosition = fillBaseLocal;
+        if (hasNoteId) NoteId.transform.localPosition = noteIdBaseLocal;
+    }
+
     protected override void Render()
     {
         base.Render();
         ApplyDropOffset();
     }
 
-    // Faithful port of Cylheim pixi-playback-note-layer.ts:524-540 getPlaybackDropSpriteOffsetY.
+    // Faithful port of Cylheim pixi-playback-note-layer.ts:524-540 getPlaybackDropSpriteOffsetY,
+    // applied only to visual children so the collider stays at the landing scanline point.
     // Verified: durationTick=500, timeDiff=0.1s, height=540 -> 800px; height=1080 -> 1600px.
     private void ApplyDropOffset()
     {
         var page = Note.Page;
         double durationTick = (page.end_tick - page.start_tick) * 5.0;
-        if (durationTick <= 0 || !double.IsFinite(durationTick)) return; // Cylheim guard
 
-        // Cylheim uses screen coords (Y down): Up=+1, Down=-1.
-        // Unity uses world coords (Y up): flip the sign so Down falls from above (+Y), Up rises from below (-Y).
-        float dirSign = Note.Model.NoteDirection == 1 ? -1f : 1f; // Up -> -1, Down -> +1
-        float timeDiffSeconds = (float) (Note.Model.start_time - Note.Game.Time);
+        Vector3 localOffset = Vector3.zero;
+        if (durationTick > 0 && double.IsFinite(durationTick))
+        {
+            // Cylheim uses screen coords (Y down): Up=+1, Down=-1.
+            // Unity uses world coords (Y up): flip the sign so Down falls from above (+Y),
+            // Up rises from below (-Y).
+            float dirSign = Note.Model.NoteDirection == 1 ? -1f : 1f; // Up -> -1, Down -> +1
+            float timeDiffSeconds = (float) (Note.Model.start_time - Note.Game.Time);
 
-        // At or past landing: no offset, note rests at scanline.
-        if (timeDiffSeconds <= 0f) return;
+            if (timeDiffSeconds > 0f)
+            {
+                // Cylheim formula in screen-heights (resolution-independent):
+                //   offsetY_screen_heights = dir * (8_000_000 / durationTick) * timeDiff / 1080
+                float screenHeightWorld = 2f * Note.Game.camera.orthographicSize;
+                float offsetYWorld = dirSign * (8_000_000f / (float) durationTick) * timeDiffSeconds
+                                     / 1080f * screenHeightWorld;
+                // Translate the world-space vertical offset into Note's local space so the
+                // visual amplitude is correct under any combination of rotation AND scale.
+                // Guard against singular (zero) or non-finite scale to avoid NaN — see
+                // DropClickNoteRenderer.ApplyDropOffset for full rationale.
+                Vector3 s = Note.transform.localScale;
+                if (s.x != 0f && s.y != 0f && s.z != 0f
+                    && float.IsFinite(s.x) && float.IsFinite(s.y) && float.IsFinite(s.z))
+                {
+                    localOffset = Note.transform.InverseTransformVector(
+                        new Vector3(0f, offsetYWorld, 0f));
+                }
+            }
+        }
 
-        // Cylheim formula in screen-heights (resolution-independent):
-        //   offsetY_screen_heights = dir * (8_000_000 / durationTick) * timeDiff / 1080
-        // Translate to Unity world units via visible camera height (2 * orthographicSize):
-        float screenHeightWorld = 2f * Note.Game.camera.orthographicSize;
-        float offsetYWorld = dirSign * (8_000_000f / (float) durationTick) * timeDiffSeconds / 1080f *
-                             screenHeightWorld;
+        ApplyChildOffset(Ring.transform, ringBaseLocal, localOffset);
+        ApplyChildOffset(Fill.transform, fillBaseLocal, localOffset);
+        if (hasNoteId) ApplyChildOffset(NoteId.transform, noteIdBaseLocal, localOffset);
+    }
 
-        var pos = Note.transform.localPosition;
-        pos.y += offsetYWorld;
-        Note.transform.localPosition = pos;
+    private static void ApplyChildOffset(Transform t, Vector3 baseLocal, Vector3 offset)
+    {
+        t.localPosition = baseLocal + offset;
     }
 
     // Drop notes ignore the approach-scale animation: always full BaseTransformSize.

--- a/engines/unity/Assets/Scripts/Game/Notes/Drop/DropDragNoteRenderer.cs
+++ b/engines/unity/Assets/Scripts/Game/Notes/Drop/DropDragNoteRenderer.cs
@@ -48,52 +48,14 @@ public class DropDragNoteRenderer : ClassicNoteRenderer
         ApplyDropOffset();
     }
 
-    // Faithful port of Cylheim pixi-playback-note-layer.ts:524-540 getPlaybackDropSpriteOffsetY,
-    // applied only to visual children so the collider stays at the landing scanline point.
-    // Verified: durationTick=500, timeDiff=0.1s, height=540 -> 800px; height=1080 -> 1600px.
+    // Drives the falling animation by offsetting only the visual children — see
+    // DropNoteOffset.ComputeLocalOffset for the math and rationale.
     private void ApplyDropOffset()
     {
-        var page = Note.Page;
-        double durationTick = (page.end_tick - page.start_tick) * 5.0;
-
-        Vector3 localOffset = Vector3.zero;
-        if (durationTick > 0 && double.IsFinite(durationTick))
-        {
-            // Cylheim uses screen coords (Y down): Up=+1, Down=-1.
-            // Unity uses world coords (Y up): flip the sign so Down falls from above (+Y),
-            // Up rises from below (-Y).
-            float dirSign = Note.Model.NoteDirection == 1 ? -1f : 1f; // Up -> -1, Down -> +1
-            float timeDiffSeconds = (float) (Note.Model.start_time - Note.Game.Time);
-
-            if (timeDiffSeconds > 0f)
-            {
-                // Cylheim formula in screen-heights (resolution-independent):
-                //   offsetY_screen_heights = dir * (8_000_000 / durationTick) * timeDiff / 1080
-                float screenHeightWorld = 2f * Note.Game.camera.orthographicSize;
-                float offsetYWorld = dirSign * (8_000_000f / (float) durationTick) * timeDiffSeconds
-                                     / 1080f * screenHeightWorld;
-                // Translate the world-space vertical offset into Note's local space so the
-                // visual amplitude is correct under any combination of rotation AND scale.
-                // Guard against singular (zero) or non-finite scale to avoid NaN — see
-                // DropClickNoteRenderer.ApplyDropOffset for full rationale.
-                Vector3 s = Note.transform.localScale;
-                if (s.x != 0f && s.y != 0f && s.z != 0f
-                    && float.IsFinite(s.x) && float.IsFinite(s.y) && float.IsFinite(s.z))
-                {
-                    localOffset = Note.transform.InverseTransformVector(
-                        new Vector3(0f, offsetYWorld, 0f));
-                }
-            }
-        }
-
-        ApplyChildOffset(Ring.transform, ringBaseLocal, localOffset);
-        ApplyChildOffset(Fill.transform, fillBaseLocal, localOffset);
-        if (hasNoteId) ApplyChildOffset(NoteId.transform, noteIdBaseLocal, localOffset);
-    }
-
-    private static void ApplyChildOffset(Transform t, Vector3 baseLocal, Vector3 offset)
-    {
-        t.localPosition = baseLocal + offset;
+        Vector3 localOffset = DropNoteOffset.ComputeLocalOffset(Note);
+        DropNoteOffset.ApplyToChild(Ring.transform, ringBaseLocal, localOffset);
+        DropNoteOffset.ApplyToChild(Fill.transform, fillBaseLocal, localOffset);
+        if (hasNoteId) DropNoteOffset.ApplyToChild(NoteId.transform, noteIdBaseLocal, localOffset);
     }
 
     // Drop notes ignore the approach-scale animation: always full BaseTransformSize.

--- a/engines/unity/Assets/Scripts/Game/Notes/Drop/DropNoteOffset.cs
+++ b/engines/unity/Assets/Scripts/Game/Notes/Drop/DropNoteOffset.cs
@@ -12,7 +12,8 @@ internal static class DropNoteOffset
     // itself is left untouched so the CircleCollider2D stays anchored at the landing point.
     //
     // Returns Vector3.zero when the offset should be skipped: malformed chart (durationTick<=0),
-    // already landed (timeDiff<=0), or singular/non-finite local scale (note is invisible anyway).
+    // already landed (timeDiff<=0), non-finite inputs (NaN/Infinity in timeDiff or scale), or
+    // singular local scale (note is invisible anyway).
     public static Vector3 ComputeLocalOffset(Note note)
     {
         var page = note.Page;
@@ -24,7 +25,7 @@ internal static class DropNoteOffset
         // Up rises from below (-Y).
         float dirSign = note.Model.NoteDirection == 1 ? -1f : 1f; // Up -> -1, Down -> +1
         float timeDiffSeconds = (float) (note.Model.start_time - note.Game.Time);
-        if (timeDiffSeconds <= 0f) return Vector3.zero;
+        if (timeDiffSeconds <= 0f || !float.IsFinite(timeDiffSeconds)) return Vector3.zero;
 
         // Cylheim formula in screen-heights (resolution-independent):
         //   offsetY_screen_heights = dir * (8_000_000 / durationTick) * timeDiff / 1080

--- a/engines/unity/Assets/Scripts/Game/Notes/Drop/DropNoteOffset.cs
+++ b/engines/unity/Assets/Scripts/Game/Notes/Drop/DropNoteOffset.cs
@@ -1,0 +1,56 @@
+using UnityEngine;
+
+// Shared drop-offset math for DropClickNoteRenderer and DropDragNoteRenderer.
+// Faithful port of Cylheim pixi-playback-note-layer.ts:524-540 getPlaybackDropSpriteOffsetY,
+// then translated into Note local space so the on-screen amplitude stays correct under any
+// combination of rotation and scale.
+// Verified: durationTick=500, timeDiff=0.1s, height=540 -> 800px; height=1080 -> 1600px.
+internal static class DropNoteOffset
+{
+    // Per-frame visual-only offset to apply to each child of a Drop note so the note appears
+    // to fall from above (Down direction) or below (Up direction) into the scanline. Note.transform
+    // itself is left untouched so the CircleCollider2D stays anchored at the landing point.
+    //
+    // Returns Vector3.zero when the offset should be skipped: malformed chart (durationTick<=0),
+    // already landed (timeDiff<=0), or singular/non-finite local scale (note is invisible anyway).
+    public static Vector3 ComputeLocalOffset(Note note)
+    {
+        var page = note.Page;
+        double durationTick = (page.end_tick - page.start_tick) * 5.0;
+        if (durationTick <= 0 || !double.IsFinite(durationTick)) return Vector3.zero;
+
+        // Cylheim uses screen coords (Y down): Up=+1, Down=-1.
+        // Unity uses world coords (Y up): flip the sign so Down falls from above (+Y),
+        // Up rises from below (-Y).
+        float dirSign = note.Model.NoteDirection == 1 ? -1f : 1f; // Up -> -1, Down -> +1
+        float timeDiffSeconds = (float) (note.Model.start_time - note.Game.Time);
+        if (timeDiffSeconds <= 0f) return Vector3.zero;
+
+        // Cylheim formula in screen-heights (resolution-independent):
+        //   offsetY_screen_heights = dir * (8_000_000 / durationTick) * timeDiff / 1080
+        // Translate to Unity world units via visible camera height (2 * orthographicSize):
+        float screenHeightWorld = 2f * note.Game.camera.orthographicSize;
+        float offsetYWorld = dirSign * (8_000_000f / (float) durationTick) * timeDiffSeconds
+                             / 1080f * screenHeightWorld;
+
+        // Translate the world-space vertical offset into Note's local space so the visual
+        // amplitude is correct under any combination of rotation AND scale. Guard against
+        // singular (zero) or non-finite scale to avoid NaN from the matrix inversion — a
+        // zero-scale note is invisible anyway, so the offset is irrelevant.
+        Vector3 s = note.transform.localScale;
+        if (s.x == 0f || s.y == 0f || s.z == 0f
+            || !float.IsFinite(s.x) || !float.IsFinite(s.y) || !float.IsFinite(s.z))
+        {
+            return Vector3.zero;
+        }
+
+        return note.transform.InverseTransformVector(new Vector3(0f, offsetYWorld, 0f));
+    }
+
+    // Sets t.localPosition = baseLocal + offset. Kept as a named helper so the per-frame
+    // iteration contract lives in one place across both Drop renderers.
+    public static void ApplyToChild(Transform t, Vector3 baseLocal, Vector3 offset)
+    {
+        t.localPosition = baseLocal + offset;
+    }
+}

--- a/engines/unity/Assets/Scripts/Game/Notes/Drop/DropNoteOffset.cs.meta
+++ b/engines/unity/Assets/Scripts/Game/Notes/Drop/DropNoteOffset.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 1a50329a945348a6a6837bc88e7126ec


### PR DESCRIPTION
## Problem

Drop notes (`DropClick`, `DropDrag`) are supposed to be hit by tapping the **predicted landing point** on the scanline. Instead, the hitbox was **moving with the visual** during the falling animation — players had to chase the falling sprite rather than tap the fixed landing point.

## Root cause

`ApplyDropOffset` (in both `DropClickNoteRenderer.cs` and `DropDragNoteRenderer.cs`) was lifting `Note.transform.localPosition.y` to drive the falling animation. Since the `CircleCollider2D` lives on the same GameObject, the collider was dragged along, so `DoesCollide` / `OverlapPoint` (called from `InputController.OnFingerDown` / `OnFingerUpdate`) tested against the **visual position** rather than the landing position.

Introduced in #193 (drop note support).

## Fix

Decouple visual offset from collider position: leave `Note.transform` at the landing scanline point set by `Note.OnGameUpdate` (`CalculatePosition`), and apply the drop offset only to the **visual children** (Ring / Fill / Core / NoteId). The collider follows `Note.transform` and stays anchored where the player should tap.

The Cylheim falling formula (`offsetYWorld`) is preserved exactly — only the **target** of the offset changes (parent transform → visual children).

### Two sub-fixes (self-review)

- **P1 (pool reuse)**: snapshotting base child positions in `OnNoteLoaded` baked in residual offsets from previously-cleared notes. Moved snapshot to the **constructor** (runs once per GameObject lifetime, captures pristine prefab positions), and added an `OnCollect` override to restore prefab-local positions as a defensive measure.
- **P2 (rotation / zero scale)**: dividing by `localScale.y` only works for unrotated notes; storyboard `RotZ/RotX/RotY` would make the note fall along its own local Y axis (slanted) instead of screen-vertical, and `SizeMultiplier == 0` caused division by zero. Switched to `Note.transform.InverseTransformVector(worldOffset)` which correctly handles rotation AND scale, with an explicit guard against singular / non-finite scale.

## Changes

- `engines/unity/Assets/Scripts/Game/Notes/Drop/DropClickNoteRenderer.cs`
- `engines/unity/Assets/Scripts/Game/Notes/Drop/DropDragNoteRenderer.cs`

## Verification

- Unity 6000.0.75f1 batchmode compile: **exit 0**, zero `error CS*`
- No warnings in either Drop file (all pre-existing warnings are in unrelated files)
- Visual parity: world-space offset `(0, offsetYWorld, 0)` translated to local via `InverseTransformVector` produces identical on-screen amplitude to the previous "move Note.transform" implementation
- Logic: `Note.transform` no longer touched by `ApplyDropOffset`, so collider and `DoesCollide` always test against the landing scanline point

Play-mode sanity check (rotated Drop note + a chart with Drop notes) still recommended.

## Risk

Low. Change is isolated to Drop renderers; no public API change; no impact on other note types. The math is provably equivalent for the unrotated/identity-scale case (which is what shipped in #193), and strictly more correct for rotated/scaled cases.

---

Port of Cytoid-private#44.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved drop-note visual positioning while keeping colliders correctly anchored.
  * Prevented visual offsets from accumulating when notes are reused.
  * Added safer handling for invalid timing, rotation, scaling, and optional note visuals.
  * Ensured note visuals return to their original positions after collection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->