### PR TITLE
feat(chart): support C2 UI and message events

### DIFF
--- a/engines/unity/Assets/Editor.meta
+++ b/engines/unity/Assets/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d2593a97ec88e46a791aba293520f229
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/engines/unity/Assets/Editor/Tests.meta
+++ b/engines/unity/Assets/Editor/Tests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 04eb5b6e164d245df8091faa505f635a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/engines/unity/Assets/Editor/Tests/ChartEventPresentationTimelineTests.cs
+++ b/engines/unity/Assets/Editor/Tests/ChartEventPresentationTimelineTests.cs
@@ -18,7 +18,27 @@ public class ChartEventPresentationTimelineTests
     }
 
     [Test]
-    public void InvalidOrMissingColorWarnsAndFallsBackToWhite()
+    public void MessageNormalizesQuotedUnityColorTagsForTmp()
+    {
+        var timeline = Timeline(Order(
+            0,
+            Event(
+                ChartEventType.Message,
+                "Status: <color=\"#12AB34\">ready</color> " +
+                "<COLOR='#A1B2C3'>now</COLOR>,#FFFFFF")));
+
+        var state = timeline.Evaluate(1);
+
+        Assert.That(
+            state.Content,
+            Is.EqualTo(
+                    "Status: <color=#12AB34>ready</color> <color=#A1B2C3>now</color>")
+                .IgnoreCase);
+        AssertColor(state.TextColor, Color.white);
+    }
+
+    [Test]
+    public void InvalidColorWarnsAndFallsBackToWhite()
     {
         var warnings = new List<string>();
         var timeline = new ChartEventPresentationTimeline(
@@ -26,6 +46,18 @@ public class ChartEventPresentationTimelineTests
             warnings.Add);
 
         Assert.That(warnings, Has.Count.EqualTo(1));
+        AssertColor(timeline.Evaluate(1).ScanlineColor, Color.white);
+    }
+
+    [Test]
+    public void MissingColorSilentlyFallsBackToWhite()
+    {
+        var warnings = new List<string>();
+        var timeline = new ChartEventPresentationTimeline(
+            Model(Order(0, Event(ChartEventType.Message, "Hello"))),
+            warnings.Add);
+
+        Assert.That(warnings, Is.Empty);
         AssertColor(timeline.Evaluate(1).ScanlineColor, Color.white);
     }
 
@@ -80,6 +112,70 @@ public class ChartEventPresentationTimelineTests
         Assert.That(speedDown.Evaluate(0.75f).LetterSpacing,
             Is.EqualTo(ChartEventPresentationTimeline.MaxLetterSpacing -
                        speedUp.Evaluate(0.75f).LetterSpacing).Within(0.0001f));
+    }
+
+    [Test]
+    public void OverlappingMessagesShareOpacityButKeepSpacingEventLocal()
+    {
+        var timeline = Timeline(
+            Order(0, Event(ChartEventType.Message, "Frame A,#FFFFFF")),
+            Order(0.3f, Event(ChartEventType.Message, "Frame B,#FFFFFF")));
+
+        var state = timeline.Evaluate(0.3f);
+
+        Assert.That(state.Content, Is.EqualTo("Frame B"));
+        Assert.That(state.TextAlpha, Is.EqualTo(0.984375f).Within(0.0001f));
+        Assert.That(state.LetterSpacing, Is.EqualTo(0).Within(0.0001f));
+
+        state = timeline.Evaluate(0.45f);
+        Assert.That(state.TextAlpha, Is.EqualTo(1).Within(0.0001f));
+        Assert.That(state.LetterSpacing, Is.EqualTo(
+            ChartEventPresentationTimeline.MaxLetterSpacing * 0.00001f).Within(0.0001f));
+    }
+
+    [Test]
+    public void MergedOpacityRunDoesNotDipInTheFormerFadeOverlapWindow()
+    {
+        var timeline = Timeline(
+            Order(0, Event(ChartEventType.Message, "First,#FFFFFF")),
+            Order(1.1f, Event(ChartEventType.Message, "Second,#FFFFFF")));
+
+        Assert.That(timeline.Evaluate(1.1f).TextAlpha, Is.EqualTo(1).Within(0.0001f));
+        Assert.That(timeline.Evaluate(1.3f).TextAlpha, Is.EqualTo(1).Within(0.0001f));
+        Assert.That(timeline.Evaluate(1.8f).TextAlpha, Is.EqualTo(1).Within(0.0001f));
+        Assert.That(timeline.Evaluate(2).TextAlpha, Is.EqualTo(0.125f).Within(0.001f));
+        Assert.That(timeline.Evaluate(2.2f).TextAlpha, Is.EqualTo(0).Within(0.0001f));
+    }
+
+    [Test]
+    public void NonOverlappingMessageStartsANewOpacityRun()
+    {
+        var timeline = Timeline(
+            Order(0, Event(ChartEventType.Message, "First,#FFFFFF")),
+            Order(1.5f, Event(ChartEventType.Message, "Second,#FFFFFF")));
+
+        Assert.That(timeline.Evaluate(1.5f).Content, Is.EqualTo("Second"));
+        Assert.That(timeline.Evaluate(1.5f).TextAlpha, Is.EqualTo(0).Within(0.0001f));
+        Assert.That(timeline.Evaluate(1.7f).TextAlpha, Is.EqualTo(0.875f).Within(0.001f));
+    }
+
+    [Test]
+    public void SpeedAndEmptyMessageEventsBreakMessageOpacityRuns()
+    {
+        var interruptedBySpeed = Timeline(
+            Order(0, Event(ChartEventType.Message, "First,#FFFFFF")),
+            Order(0.5f, Event(ChartEventType.SpeedUp, "R")),
+            Order(0.6f, Event(ChartEventType.Message, "Second,#FFFFFF")));
+        var interruptedByEmptyMessage = Timeline(
+            Order(0, Event(ChartEventType.Message, "First,#FFFFFF")),
+            Order(0.5f, Event(ChartEventType.Message, ",#FFFFFF")),
+            Order(0.6f, Event(ChartEventType.Message, "Second,#FFFFFF")));
+
+        Assert.That(interruptedBySpeed.Evaluate(0.6f).TextAlpha,
+            Is.EqualTo(0).Within(0.0001f));
+        Assert.That(interruptedByEmptyMessage.Evaluate(0.5f).IsTextVisible, Is.False);
+        Assert.That(interruptedByEmptyMessage.Evaluate(0.6f).TextAlpha,
+            Is.EqualTo(0).Within(0.0001f));
     }
 
     [Test]

--- a/engines/unity/Assets/Editor/Tests/ChartEventPresentationTimelineTests.cs
+++ b/engines/unity/Assets/Editor/Tests/ChartEventPresentationTimelineTests.cs
@@ -38,15 +38,29 @@ public class ChartEventPresentationTimelineTests
     }
 
     [Test]
-    public void InvalidColorWarnsAndFallsBackToWhite()
+    public void InvalidColorSuffixUsesTheFirstUnescapedCommaAndWarns()
     {
         var warnings = new List<string>();
         var timeline = new ChartEventPresentationTimeline(
             Model(Order(0, Event(ChartEventType.Message, "Hello,not-a-color"))),
             warnings.Add);
 
+        var state = timeline.Evaluate(1);
         Assert.That(warnings, Has.Count.EqualTo(1));
-        AssertColor(timeline.Evaluate(1).ScanlineColor, Color.white);
+        Assert.That(state.Content, Is.EqualTo("Hello"));
+        AssertColor(state.ScanlineColor, Color.white);
+    }
+
+    [Test]
+    public void MessageSupportsEscapedCommasBackslashesAndRgbaColor()
+    {
+        var state = Timeline(Order(
+            0,
+            Event(ChartEventType.Message, "Hello\\, world\\\\path,#0A141E80"))).Evaluate(1);
+
+        Assert.That(state.Content, Is.EqualTo("Hello, world\\path"));
+        AssertColor(state.TextColor, new Color32(10, 20, 30, 128));
+        AssertColor(state.ScanlineColor, new Color32(10, 20, 30, 128));
     }
 
     [Test]

--- a/engines/unity/Assets/Editor/Tests/ChartEventPresentationTimelineTests.cs
+++ b/engines/unity/Assets/Editor/Tests/ChartEventPresentationTimelineTests.cs
@@ -1,0 +1,162 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEngine;
+
+public class ChartEventPresentationTimelineTests
+{
+    [Test]
+    public void MessageParsesContentAndRgbColor()
+    {
+        var timeline = Timeline(Order(0, Event(ChartEventType.Message, "Hello,#0A141E")));
+
+        var state = timeline.Evaluate(1);
+
+        Assert.That(state.Kind, Is.EqualTo(ChartEventPresentationKind.Message));
+        Assert.That(state.Content, Is.EqualTo("Hello"));
+        AssertColor(state.TextColor, new Color32(10, 20, 30, 255));
+        AssertColor(state.ScanlineColor, new Color32(10, 20, 30, 255));
+    }
+
+    [Test]
+    public void InvalidOrMissingColorWarnsAndFallsBackToWhite()
+    {
+        var warnings = new List<string>();
+        var timeline = new ChartEventPresentationTimeline(
+            Model(Order(0, Event(ChartEventType.Message, "Hello,not-a-color"))),
+            warnings.Add);
+
+        Assert.That(warnings, Has.Count.EqualTo(1));
+        AssertColor(timeline.Evaluate(1).ScanlineColor, Color.white);
+    }
+
+    [Test]
+    public void EmptyMessageStillColorsScanlineWithoutShowingText()
+    {
+        var state = Timeline(Order(0, Event(ChartEventType.Message, ",#FF0000"))).Evaluate(1);
+
+        Assert.That(state.IsActive, Is.True);
+        Assert.That(state.IsTextVisible, Is.False);
+        AssertColor(state.ScanlineColor, Color.red);
+    }
+
+    [Test]
+    public void SamplesCytoidTextAnimationAndFiveSecondColorCurve()
+    {
+        var timeline = Timeline(Order(10, Event(ChartEventType.Message, "Hello,#000000")));
+
+        Assert.That(timeline.Evaluate(10).TextAlpha, Is.EqualTo(0).Within(0.0001f));
+        AssertColor(timeline.Evaluate(10).TextColor, Color.black);
+        AssertColor(timeline.Evaluate(10).ScanlineColor, Color.white);
+        Assert.That(timeline.Evaluate(10.2f).TextAlpha, Is.EqualTo(0.875f).Within(0.001f));
+        Assert.That(timeline.Evaluate(10.4f).TextAlpha, Is.EqualTo(1).Within(0.0001f));
+        Assert.That(timeline.Evaluate(11).TextAlpha, Is.EqualTo(1).Within(0.0001f));
+        Assert.That(timeline.Evaluate(11.3f).TextAlpha, Is.EqualTo(0.125f).Within(0.001f));
+        Assert.That(timeline.Evaluate(11.5f).TextAlpha, Is.EqualTo(0).Within(0.0001f));
+        Assert.That(timeline.Evaluate(11.5f).LetterSpacing,
+            Is.EqualTo(ChartEventPresentationTimeline.MaxLetterSpacing).Within(0.0001f));
+        AssertColor(timeline.Evaluate(10.5f).ScanlineColor, Color.gray);
+        AssertColor(timeline.Evaluate(12).ScanlineColor, Color.black);
+        AssertColor(timeline.Evaluate(14.5f).ScanlineColor, Color.gray);
+        Assert.That(timeline.Evaluate(15).IsActive, Is.False);
+        AssertColor(timeline.Evaluate(15).ScanlineColor, Color.white);
+    }
+
+    [Test]
+    public void MessageUsesIndependentInQuintSpacingWhileSpeedEventsKeepOutCirc()
+    {
+        var message = Timeline(Order(0, Event(ChartEventType.Message, "Custom,#FFFFFF")));
+        var speedUp = Timeline(Order(0, Event(ChartEventType.SpeedUp, "R")));
+        var speedDown = Timeline(Order(0, Event(ChartEventType.SpeedDown, "G")));
+
+        Assert.That(message.Evaluate(0).LetterSpacing, Is.EqualTo(0).Within(0.0001f));
+        Assert.That(speedUp.Evaluate(0).LetterSpacing, Is.EqualTo(0).Within(0.0001f));
+        Assert.That(speedDown.Evaluate(0).LetterSpacing,
+            Is.EqualTo(ChartEventPresentationTimeline.MaxLetterSpacing).Within(0.0001f));
+
+        Assert.That(message.Evaluate(0.75f).LetterSpacing,
+            Is.EqualTo(ChartEventPresentationTimeline.MaxLetterSpacing / 32).Within(0.0001f));
+        Assert.That(message.Evaluate(0.75f).LetterSpacing,
+            Is.LessThan(speedUp.Evaluate(0.75f).LetterSpacing));
+        Assert.That(speedDown.Evaluate(0.75f).LetterSpacing,
+            Is.EqualTo(ChartEventPresentationTimeline.MaxLetterSpacing -
+                       speedUp.Evaluate(0.75f).LetterSpacing).Within(0.0001f));
+    }
+
+    [Test]
+    public void InterruptedEventStartsFromPreviouslySampledColor()
+    {
+        var timeline = Timeline(
+            Order(0, Event(ChartEventType.Message, "First,#FF0000")),
+            Order(0.5f, Event(ChartEventType.Message, "Second,#0000FF")));
+
+        var atInterruption = timeline.Evaluate(0.5f);
+        Assert.That(atInterruption.Content, Is.EqualTo("Second"));
+        AssertColor(atInterruption.ScanlineColor, new Color(1, 0.5f, 0.5f));
+        AssertColor(timeline.Evaluate(1).ScanlineColor, new Color(0.5f, 0.25f, 0.75f));
+    }
+
+    [Test]
+    public void SameTimeLastAuthoredEventWinsWithoutResettingTransition()
+    {
+        var timeline = Timeline(Order(
+            0,
+            Event(ChartEventType.Message, "First,#FF0000"),
+            Event(ChartEventType.Message, "Second,#0000FF")));
+
+        var state = timeline.Evaluate(0);
+        Assert.That(state.Content, Is.EqualTo("Second"));
+        AssertColor(state.ScanlineColor, Color.white);
+        AssertColor(timeline.Evaluate(1).ScanlineColor, Color.blue);
+    }
+
+    [Test]
+    public void SpeedAndMessageEventsShareOneInterruptibleTrack()
+    {
+        var timeline = Timeline(
+            Order(0, Event(ChartEventType.SpeedUp, "R")),
+            Order(0.25f, Event(ChartEventType.SpeedDown, "G")),
+            Order(0.5f, Event(ChartEventType.Message, "Custom,#FFFFFF")));
+
+        Assert.That(timeline.Evaluate(0).Kind, Is.EqualTo(ChartEventPresentationKind.SpeedUp));
+        Assert.That(timeline.Evaluate(0.25f).Kind, Is.EqualTo(ChartEventPresentationKind.SpeedDown));
+        Assert.That(timeline.Evaluate(0.5f).Kind, Is.EqualTo(ChartEventPresentationKind.Message));
+    }
+
+    [Test]
+    public void BackwardSeekResamplesTheEarlierEvent()
+    {
+        var timeline = Timeline(
+            Order(1, Event(ChartEventType.Message, "First,#FF0000")),
+            Order(3, Event(ChartEventType.Message, "Second,#0000FF")));
+
+        Assert.That(timeline.Evaluate(3).Content, Is.EqualTo("Second"));
+        Assert.That(timeline.Evaluate(1.5f).Content, Is.EqualTo("First"));
+        Assert.That(timeline.Evaluate(0).IsActive, Is.False);
+    }
+
+    private static ChartEventPresentationTimeline Timeline(params ChartModel.EventOrder[] orders) =>
+        new ChartEventPresentationTimeline(Model(orders));
+
+    private static ChartModel Model(params ChartModel.EventOrder[] orders) => new ChartModel
+    {
+        event_order_list = new List<ChartModel.EventOrder>(orders)
+    };
+
+    private static ChartModel.EventOrder Order(float time, params ChartModel.ChartEvent[] events) =>
+        new ChartModel.EventOrder
+        {
+            time = time,
+            event_list = new List<ChartModel.ChartEvent>(events)
+        };
+
+    private static ChartModel.ChartEvent Event(ChartEventType type, string args) =>
+        new ChartModel.ChartEvent {type = (int) type, args = args};
+
+    private static void AssertColor(Color actual, Color expected)
+    {
+        Assert.That(actual.r, Is.EqualTo(expected.r).Within(0.001f));
+        Assert.That(actual.g, Is.EqualTo(expected.g).Within(0.001f));
+        Assert.That(actual.b, Is.EqualTo(expected.b).Within(0.001f));
+        Assert.That(actual.a, Is.EqualTo(expected.a).Within(0.001f));
+    }
+}

--- a/engines/unity/Assets/Editor/Tests/ChartEventPresentationTimelineTests.cs.meta
+++ b/engines/unity/Assets/Editor/Tests/ChartEventPresentationTimelineTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cd79c96cf6e34283a98e7f4c9c56572f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/engines/unity/Assets/Editor/Tests/ChartUiEventTimelineTests.cs
+++ b/engines/unity/Assets/Editor/Tests/ChartUiEventTimelineTests.cs
@@ -1,0 +1,180 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+
+public class ChartUiEventTimelineTests
+{
+    [Test]
+    public void InitialVisibilityAndCytoidSideTargetsAreResolvedIndependently()
+    {
+        var model = Model(true,
+            Order(1, Event(ChartEventType.ShowUi, "2")),
+            Order(2, Event(ChartEventType.ShowUi, "3")));
+        var timeline = new ChartUiEventTimeline(model);
+
+        Assert.That(timeline.Evaluate(ChartUiTarget.LeftUi, 0).Alpha, Is.EqualTo(0));
+        Assert.That(timeline.Evaluate(ChartUiTarget.LeftUi, 1).Alpha, Is.EqualTo(1));
+        Assert.That(timeline.Evaluate(ChartUiTarget.RightUi, 1).Alpha, Is.EqualTo(0));
+        Assert.That(timeline.Evaluate(ChartUiTarget.RightUi, 2).Alpha, Is.EqualTo(1));
+    }
+
+    [Test]
+    public void TickZeroEventsDoNotChangeThePreSongState()
+    {
+        var model = Model(true, Order(0, Event(ChartEventType.ShowUi, "0")));
+        var timeline = new ChartUiEventTimeline(model);
+
+        Assert.That(timeline.Evaluate(ChartUiTarget.Combo, -0.001f).Alpha, Is.EqualTo(0));
+        Assert.That(timeline.Evaluate(ChartUiTarget.Combo, 0).Alpha, Is.EqualTo(1));
+    }
+
+    [Test]
+    public void FadeInterruptionStartsFromTheCurrentCylheimAlpha()
+    {
+        var model = Model(false,
+            Order(0, Event(ChartEventType.FadeOutUi, "0")),
+            Order(0.65f, Event(ChartEventType.FadeInUi, "0")));
+        var timeline = new ChartUiEventTimeline(model);
+
+        Assert.That(timeline.Evaluate(ChartUiTarget.Combo, 0.65f).Alpha, Is.EqualTo(0.5f).Within(0.0001f));
+        Assert.That(timeline.Evaluate(ChartUiTarget.Combo, 1.3f).Alpha, Is.EqualTo(0.75f).Within(0.0001f));
+    }
+
+    [Test]
+    public void SameTimeEventsUseTheirOriginalSequence()
+    {
+        var model = Model(false,
+            Order(1,
+                Event(ChartEventType.HideUi, "1"),
+                Event(ChartEventType.ShowUi, "1")));
+        var timeline = new ChartUiEventTimeline(model);
+
+        Assert.That(timeline.Evaluate(ChartUiTarget.Score, 1).Alpha, Is.EqualTo(1));
+    }
+
+    [Test]
+    public void AnimationOutKeepsItsDelayedHideAfterAnIntermediateShow()
+    {
+        var model = Model(false,
+            Order(0, Event(ChartEventType.AnimationOutUi, "7")),
+            Order(0.2f, Event(ChartEventType.ShowUi, "7")));
+        var timeline = new ChartUiEventTimeline(model);
+
+        var during = timeline.Evaluate(ChartUiTarget.ProgressBar, 0.3f);
+        Assert.That(during.Alpha, Is.EqualTo(1));
+        Assert.That(during.AnimationKind, Is.EqualTo(ChartUiAnimationKind.Out));
+        Assert.That(timeline.Evaluate(ChartUiTarget.ProgressBar, 0.5f).Alpha, Is.EqualTo(0));
+    }
+
+    [Test]
+    public void LaterShowWinsWhenItMatchesAnimationOutsDelayedHideTime()
+    {
+        var model = Model(false,
+            Order(0, Event(ChartEventType.AnimationOutUi, "7")),
+            Order(0.5f, Event(ChartEventType.ShowUi, "7")));
+        var timeline = new ChartUiEventTimeline(model);
+
+        Assert.That(timeline.Evaluate(ChartUiTarget.ProgressBar, 0.5f).Alpha, Is.EqualTo(1));
+    }
+
+    [Test]
+    public void NewAnimationImmediatelyOverridesAndRestartsThePreviousAnimation()
+    {
+        var model = Model(false,
+            Order(0, Event(ChartEventType.AnimationInUi, "4")),
+            Order(0.2f, Event(ChartEventType.AnimationOutUi, "4")));
+        var timeline = new ChartUiEventTimeline(model);
+
+        var state = timeline.Evaluate(ChartUiTarget.Scanline, 0.2f);
+        Assert.That(state.AnimationKind, Is.EqualTo(ChartUiAnimationKind.Out));
+        Assert.That(state.AnimationProgress, Is.EqualTo(0));
+        Assert.That(state.AnimationAlpha, Is.EqualTo(1));
+
+        state = timeline.Evaluate(ChartUiTarget.Scanline, 0.7f);
+        Assert.That(state.AnimationProgress, Is.EqualTo(0.5f).Within(0.0001f));
+        Assert.That(state.AnimationAlpha, Is.EqualTo(1));
+    }
+
+    [Test]
+    public void AnimationLayersUseTargetSpecificSampling()
+    {
+        var model = Model(false,
+            Order(0,
+                Event(ChartEventType.AnimationInUi, "0"),
+                Event(ChartEventType.AnimationOutUi, "4"),
+                Event(ChartEventType.AnimationInUi, "5")));
+        var timeline = new ChartUiEventTimeline(model);
+
+        Assert.That(timeline.Evaluate(ChartUiTarget.Combo, 0).AnimationAlpha, Is.EqualTo(0));
+        Assert.That(timeline.Evaluate(ChartUiTarget.Combo, 0.033f).AnimationAlpha, Is.EqualTo(1));
+        Assert.That(timeline.Evaluate(ChartUiTarget.Combo, 0.066f).AnimationAlpha, Is.EqualTo(0));
+        Assert.That(timeline.Evaluate(ChartUiTarget.Scanline, 0.5f).AnimationAlpha, Is.EqualTo(1));
+        Assert.That(timeline.Evaluate(ChartUiTarget.BoundaryLine, 0.06665f).AnimationAlpha,
+            Is.EqualTo(0.5f).Within(0.0001f));
+        Assert.That(timeline.Evaluate(ChartUiTarget.BoundaryLine, 0.1333f).AnimationAlpha, Is.EqualTo(1));
+    }
+
+    [Test]
+    public void EventCursorCanMoveBackwardAndSkipsEventsAtTheSeekTime()
+    {
+        var events = new List<ChartModel.EventOrder>
+        {
+            Order(1),
+            Order(2),
+            Order(3)
+        };
+
+        Assert.That(ChartEventCursor.FindFirstAfter(events, 2), Is.EqualTo(2));
+        Assert.That(ChartEventCursor.FindFirstAfter(events, 0.5f), Is.EqualTo(0));
+        Assert.That(ChartEventCursor.FindFirstAfter(events, 4), Is.EqualTo(3));
+    }
+
+    [Test]
+    public void EmptyTargetsApplyToAllSupportedTargetsButSpectrumRemainsIgnored()
+    {
+        var model = Model(true, Order(0, Event(ChartEventType.ShowUi, "")));
+        var timeline = new ChartUiEventTimeline(model);
+
+        foreach (var target in new[]
+                 {
+                     ChartUiTarget.Combo, ChartUiTarget.Score, ChartUiTarget.LeftUi,
+                     ChartUiTarget.RightUi, ChartUiTarget.Scanline, ChartUiTarget.BoundaryLine,
+                     ChartUiTarget.ProgressBar
+                 })
+            Assert.That(timeline.Evaluate(target, 0).Alpha, Is.EqualTo(1), target.ToString());
+
+        Assert.That(timeline.Evaluate(ChartUiTarget.Spectrum, 0).Alpha, Is.EqualTo(1));
+    }
+
+    [Test]
+    public void InvalidTargetsWarnWhileSpectrumIsSilent()
+    {
+        var warnings = new List<string>();
+        var model = Model(false, Order(0, Event(ChartEventType.HideUi, "6,nope,9")));
+        _ = new ChartUiEventTimeline(model, warnings.Add);
+
+        Assert.That(warnings, Has.Count.EqualTo(2));
+    }
+
+    private static ChartModel Model(bool startsWithoutUi, params ChartModel.EventOrder[] orders)
+    {
+        return new ChartModel
+        {
+            is_start_without_ui = startsWithoutUi,
+            event_order_list = new List<ChartModel.EventOrder>(orders)
+        };
+    }
+
+    private static ChartModel.EventOrder Order(float time, params ChartModel.ChartEvent[] events)
+    {
+        return new ChartModel.EventOrder
+        {
+            time = time,
+            event_list = new List<ChartModel.ChartEvent>(events)
+        };
+    }
+
+    private static ChartModel.ChartEvent Event(ChartEventType type, string args)
+    {
+        return new ChartModel.ChartEvent {type = (int) type, args = args};
+    }
+}

--- a/engines/unity/Assets/Editor/Tests/ChartUiEventTimelineTests.cs
+++ b/engines/unity/Assets/Editor/Tests/ChartUiEventTimelineTests.cs
@@ -4,6 +4,20 @@ using NUnit.Framework;
 public class ChartUiEventTimelineTests
 {
     [Test]
+    public void MissingModelOrEventListPreservesInitializedTargetAlpha()
+    {
+        var missingModel = new ChartUiEventTimeline(null);
+        var missingEvents = new ChartUiEventTimeline(new ChartModel
+        {
+            is_start_without_ui = true,
+            event_order_list = null
+        });
+
+        Assert.That(missingModel.Evaluate(ChartUiTarget.Combo, 0).Alpha, Is.EqualTo(1));
+        Assert.That(missingEvents.Evaluate(ChartUiTarget.Combo, 0).Alpha, Is.EqualTo(0));
+    }
+
+    [Test]
     public void InitialVisibilityAndCytoidSideTargetsAreResolvedIndependently()
     {
         var model = Model(true,

--- a/engines/unity/Assets/Editor/Tests/ChartUiEventTimelineTests.cs.meta
+++ b/engines/unity/Assets/Editor/Tests/ChartUiEventTimelineTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 58a94b2d4f26444983fe17b60c723b77

--- a/engines/unity/Assets/Editor/Tests/ChartUiEventTimelineTests.cs.meta
+++ b/engines/unity/Assets/Editor/Tests/ChartUiEventTimelineTests.cs.meta
@@ -1,2 +1,11 @@
 fileFormatVersion: 2
 guid: 58a94b2d4f26444983fe17b60c723b77
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/engines/unity/Assets/Editor/Tests/TmpRichTextSanitizerTests.cs
+++ b/engines/unity/Assets/Editor/Tests/TmpRichTextSanitizerTests.cs
@@ -1,0 +1,63 @@
+using System.Linq;
+using NUnit.Framework;
+
+public class TmpRichTextSanitizerTests
+{
+    [Test]
+    public void KeepsOnlyWhitelistedTagsAndNormalizesQuotedValues()
+    {
+        var result = TmpRichTextSanitizer.Sanitize(
+            "<b>B</b><i>I</i><u>U</u><s>S</s>" +
+            "<size=\"150%\">Size</size><color='#3366CC'>Color</color>");
+
+        Assert.That(result, Is.EqualTo(
+            "<b>B</b><i>I</i><u>U</u><s>S</s>" +
+            "<size=42>Size</size><color=#3366CC>Color</color>"));
+    }
+
+    [Test]
+    public void NormalizesAndClampsEverySupportedSizeForm()
+    {
+        var result = TmpRichTextSanitizer.Sanitize(
+            "<size=1000>A</size>|<size=10%>B</size>|<size=9em>C</size>|" +
+            "<size=+100>D</size>|<size=-10>E</size>");
+
+        Assert.That(result, Is.EqualTo(
+            "<size=72>A</size>|<size=14>B</size>|<size=70>C</size>|" +
+            "<size=72>D</size>|<size=18>E</size>"));
+    }
+
+    [Test]
+    public void RemovesInvalidSizeWrappersButKeepsTheirText()
+    {
+        var result = TmpRichTextSanitizer.Sanitize(
+            "<size=0>Zero</size><size=-100>Negative</size><size=NaN>Nan</size>");
+
+        Assert.That(result, Is.EqualTo("ZeroNegativeNan"));
+    }
+
+    [Test]
+    public void RemovesUnsupportedAndMalformedTagsButKeepsText()
+    {
+        var result = TmpRichTextSanitizer.Sanitize(
+            "<sprite=1><link=unsafe>Text</link><b class=x>Bold</b>");
+
+        Assert.That(result, Is.EqualTo("TextBold"));
+    }
+
+    [Test]
+    public void LimitsNestingAndTextLengthAndBalancesOutput()
+    {
+        var nested = string.Concat(Enumerable.Repeat("<b>", 10)) +
+                     new string('x', TmpRichTextSanitizer.MaxTextLength + 20) +
+                     string.Concat(Enumerable.Repeat("</b>", 10));
+
+        var result = TmpRichTextSanitizer.Sanitize(nested);
+
+        Assert.That(result.Count(c => c == '<'),
+            Is.EqualTo(TmpRichTextSanitizer.MaxNestingDepth * 2));
+        Assert.That(result.Count(c => c == 'x'), Is.EqualTo(TmpRichTextSanitizer.MaxTextLength));
+        Assert.That(result, Does.EndWith(string.Concat(
+            Enumerable.Repeat("</b>", TmpRichTextSanitizer.MaxNestingDepth))));
+    }
+}

--- a/engines/unity/Assets/Editor/Tests/TmpRichTextSanitizerTests.cs.meta
+++ b/engines/unity/Assets/Editor/Tests/TmpRichTextSanitizerTests.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 72655bf044064fca8bfa5e2e1410e078
+guid: 5caa943d539c472d8ed9415ea9d26c08
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/engines/unity/Assets/Editor/Tests/UiEventRuntimeTests.cs
+++ b/engines/unity/Assets/Editor/Tests/UiEventRuntimeTests.cs
@@ -218,6 +218,39 @@ public class UiEventRuntimeTests
         }
     }
 
+    [Test]
+    public void TooltipReleaseForceClearsAnActiveSystemMessage()
+    {
+        var scene = EditorSceneManager.OpenScene(GameScenePath, OpenSceneMode.Additive);
+        try
+        {
+            var tooltip = scene.GetRootGameObjects()
+                .SelectMany(root => root.GetComponentsInChildren<GameTooltipText>(true))
+                .Single();
+            var message = new GameMessage
+            {
+                Type = GameMessage.AnimationType.Expand,
+                Color = Color.white,
+                TextFunction = () => "System message"
+            };
+            tooltip.Animate(message, 10);
+
+            tooltip.ApplyChartEventState(ChartEventPresentationState.Empty);
+            Assert.That(tooltip.CurrentMessage, Is.SameAs(message));
+            Assert.That(tooltip.tmp.text, Is.EqualTo("System message"));
+
+            tooltip.ClearChartEventState();
+            Assert.That(tooltip.CurrentMessage, Is.Null);
+            Assert.That(tooltip.tmp.text, Is.Empty);
+            Assert.That(tooltip.tmp.color, Is.EqualTo(Color.clear));
+            Assert.That(tooltip.tmp.characterSpacing, Is.EqualTo(0));
+        }
+        finally
+        {
+            EditorSceneManager.CloseScene(scene, true);
+        }
+    }
+
     private static Scanner FindScanner(Scene scene)
     {
         var scanner = scene.GetRootGameObjects()

--- a/engines/unity/Assets/Editor/Tests/UiEventRuntimeTests.cs
+++ b/engines/unity/Assets/Editor/Tests/UiEventRuntimeTests.cs
@@ -70,6 +70,25 @@ public class UiEventRuntimeTests
     }
 
     [Test]
+    public void ChartEventColorAlphaComposesWithScannerOpacity()
+    {
+        var scene = EditorSceneManager.OpenScene(GameScenePath, OpenSceneMode.Additive);
+        try
+        {
+            var scanner = FindScanner(scene);
+            scanner.opacity = 0.5f;
+            scanner.SetUiEventState(1, 1, ChartUiAnimationKind.None, 1, false);
+            scanner.SetChartEventColor(new Color(1, 0, 0, 0.4f));
+
+            Assert.That(scanner.lineRenderer.startColor.a, Is.EqualTo(0.2f).Within(0.0001f));
+        }
+        finally
+        {
+            EditorSceneManager.CloseScene(scene, true);
+        }
+    }
+
+    [Test]
     public void BoundaryOpacityMultipliesStoryboardAndBothUiEventLayers()
     {
         Assert.That(GameRenderer.ComposeBoundaryOpacity(0.5f, 0.4f, 0.25f),
@@ -89,8 +108,9 @@ public class UiEventRuntimeTests
             var method = typeof(GameUiEventController).GetMethod(
                 "FindPerformanceTarget",
                 BindingFlags.Static | BindingFlags.NonPublic);
+            Assert.That(method, Is.Not.Null);
 
-            var target = (Transform) method?.Invoke(null, new object[] {overlay});
+            var target = (Transform) method.Invoke(null, new object[] {overlay});
 
             Assert.That(target, Is.Not.Null);
             Assert.That(target.name, Is.EqualTo("Performance"));
@@ -144,7 +164,7 @@ public class UiEventRuntimeTests
                 true,
                 ChartEventPresentationKind.Message,
                 "<b>Hello</b>",
-                new Color(0.25f, 0.5f, 0.75f),
+                new Color(0.25f, 0.5f, 0.75f, 0.5f),
                 Color.white,
                 0.75f,
                 21));
@@ -153,7 +173,7 @@ public class UiEventRuntimeTests
             Assert.That(tooltip.tmp.color.r, Is.EqualTo(0.25f).Within(0.0001f));
             Assert.That(tooltip.tmp.color.g, Is.EqualTo(0.5f).Within(0.0001f));
             Assert.That(tooltip.tmp.color.b, Is.EqualTo(0.75f).Within(0.0001f));
-            Assert.That(tooltip.tmp.color.a, Is.EqualTo(0.75f).Within(0.0001f));
+            Assert.That(tooltip.tmp.color.a, Is.EqualTo(0.375f).Within(0.0001f));
             Assert.That(tooltip.tmp.characterSpacing, Is.EqualTo(21).Within(0.0001f));
             Assert.That(tooltip.tmp.textWrappingMode,
                 Is.EqualTo(TextWrappingModes.PreserveWhitespaceNoWrap));

--- a/engines/unity/Assets/Editor/Tests/UiEventRuntimeTests.cs
+++ b/engines/unity/Assets/Editor/Tests/UiEventRuntimeTests.cs
@@ -15,7 +15,8 @@ public class UiEventRuntimeTests
     {
         Completion,
         Failure,
-        Exit
+        Exit,
+        Disposal
     }
 
     [Test]
@@ -229,6 +230,7 @@ public class UiEventRuntimeTests
     [TestCase(PresentationReleaseTrigger.Completion)]
     [TestCase(PresentationReleaseTrigger.Failure)]
     [TestCase(PresentationReleaseTrigger.Exit)]
+    [TestCase(PresentationReleaseTrigger.Disposal)]
     public void ControllerReleaseEventsForceClearAnActiveSystemMessage(
         PresentationReleaseTrigger trigger)
     {
@@ -282,6 +284,9 @@ public class UiEventRuntimeTests
                 break;
             case PresentationReleaseTrigger.Exit:
                 game.onGameBeforeExit.Invoke(game);
+                break;
+            case PresentationReleaseTrigger.Disposal:
+                game.onGameDisposed.Invoke(game);
                 break;
         }
     }

--- a/engines/unity/Assets/Editor/Tests/UiEventRuntimeTests.cs
+++ b/engines/unity/Assets/Editor/Tests/UiEventRuntimeTests.cs
@@ -1,0 +1,155 @@
+using System.Linq;
+using System.Reflection;
+using NUnit.Framework;
+using UnityEditor.SceneManagement;
+using UnityEngine;
+using UnityEngine.SceneManagement;
+
+public class UiEventRuntimeTests
+{
+    private const string GameScenePath = "Assets/Scenes/Game.unity";
+
+    [Test]
+    public void ScanlineRestoresGeometryAfterSeekingBeforeAnAnimation()
+    {
+        var scene = EditorSceneManager.OpenScene(GameScenePath, OpenSceneMode.Additive);
+        try
+        {
+            var scanner = FindScanner(scene);
+            scanner.SetUiEventState(1, 1, ChartUiAnimationKind.Out, 1, false);
+            Assert.That(scanner.lineRenderer.positionCount, Is.EqualTo(100));
+            Assert.That(scanner.lineRenderer.GetPosition(0), Is.EqualTo(scanner.lineRenderer.GetPosition(99)));
+
+            scanner.SetUiEventState(1, 1, ChartUiAnimationKind.None, 1, false);
+            Assert.That(scanner.lineRenderer.positionCount, Is.EqualTo(2));
+            Assert.That(scanner.lineRenderer.GetPosition(0).x,
+                Is.LessThan(scanner.lineRenderer.GetPosition(1).x));
+        }
+        finally
+        {
+            EditorSceneManager.CloseScene(scene, true);
+        }
+    }
+
+    [Test]
+    public void ScannerAndTriangleReceiveTheSameComposedOpacity()
+    {
+        var scene = EditorSceneManager.OpenScene(GameScenePath, OpenSceneMode.Additive);
+        GameObject triangleObject = null;
+        Material material = null;
+        try
+        {
+            var scanner = FindScanner(scene);
+            scanner.opacity = 0.4f;
+
+            triangleObject = new GameObject("UiEventRuntimeTriangle");
+            triangleObject.SetActive(false);
+            triangleObject.AddComponent<MeshFilter>();
+            var meshRenderer = triangleObject.AddComponent<MeshRenderer>();
+            material = new Material(Shader.Find("Sprites/Default"));
+            meshRenderer.sharedMaterial = material;
+            var triangle = triangleObject.AddComponent<MeshTriangle>();
+            triangleObject.SetActive(true);
+            SetPrivateField(triangle, "meshRenderer", meshRenderer);
+            SetPrivateField(triangle, "material", material);
+            SetPrivateField(triangle, "scanner", scanner);
+            scanner.RegisterTriangle(triangle);
+
+            scanner.SetUiEventState(0.5f, 0.25f, ChartUiAnimationKind.None, 1, false);
+
+            Assert.That(scanner.EffectiveOpacity, Is.EqualTo(0.05f).Within(0.0001f));
+            Assert.That(meshRenderer.sharedMaterial.color.a, Is.EqualTo(0.005f).Within(0.0001f));
+        }
+        finally
+        {
+            if (triangleObject != null) Object.DestroyImmediate(triangleObject);
+            if (material != null) Object.DestroyImmediate(material);
+            EditorSceneManager.CloseScene(scene, true);
+        }
+    }
+
+    [Test]
+    public void BoundaryOpacityMultipliesStoryboardAndBothUiEventLayers()
+    {
+        Assert.That(GameRenderer.ComposeBoundaryOpacity(0.5f, 0.4f, 0.25f),
+            Is.EqualTo(0.01f).Within(0.0001f));
+    }
+
+    [Test]
+    public void StoryboardColorOverrideWinsOverChartEventColor()
+    {
+        var scene = EditorSceneManager.OpenScene(GameScenePath, OpenSceneMode.Additive);
+        try
+        {
+            var scanner = FindScanner(scene);
+            scanner.opacity = 0.5f;
+            scanner.colorOverride = Color.green;
+            scanner.SetChartEventColor(Color.red);
+
+            Assert.That(scanner.lineRenderer.startColor.r, Is.EqualTo(0).Within(0.0001f));
+            Assert.That(scanner.lineRenderer.startColor.g, Is.EqualTo(1).Within(0.0001f));
+            Assert.That(scanner.lineRenderer.startColor.a, Is.EqualTo(0.5f).Within(0.002f));
+
+            scanner.colorOverride = Color.clear;
+            scanner.SetChartEventColor(Color.red);
+            Assert.That(scanner.lineRenderer.startColor.r, Is.EqualTo(1).Within(0.0001f));
+            Assert.That(scanner.lineRenderer.startColor.g, Is.EqualTo(0).Within(0.0001f));
+            Assert.That(scanner.lineRenderer.startColor.a, Is.EqualTo(0.5f).Within(0.002f));
+        }
+        finally
+        {
+            EditorSceneManager.CloseScene(scene, true);
+        }
+    }
+
+    [Test]
+    public void TooltipAppliesSeekSampledMessageRichTextAndSpacing()
+    {
+        var scene = EditorSceneManager.OpenScene(GameScenePath, OpenSceneMode.Additive);
+        try
+        {
+            var tooltip = scene.GetRootGameObjects()
+                .SelectMany(root => root.GetComponentsInChildren<GameTooltipText>(true))
+                .Single();
+            tooltip.ApplyChartEventState(new ChartEventPresentationState(
+                true,
+                ChartEventPresentationKind.Message,
+                "<b>Hello</b>",
+                new Color(0.25f, 0.5f, 0.75f),
+                Color.white,
+                0.75f,
+                21));
+
+            Assert.That(tooltip.tmp.text, Is.EqualTo("<b>Hello</b>"));
+            Assert.That(tooltip.tmp.color.r, Is.EqualTo(0.25f).Within(0.0001f));
+            Assert.That(tooltip.tmp.color.g, Is.EqualTo(0.5f).Within(0.0001f));
+            Assert.That(tooltip.tmp.color.b, Is.EqualTo(0.75f).Within(0.0001f));
+            Assert.That(tooltip.tmp.color.a, Is.EqualTo(0.75f).Within(0.0001f));
+            Assert.That(tooltip.tmp.characterSpacing, Is.EqualTo(21).Within(0.0001f));
+        }
+        finally
+        {
+            EditorSceneManager.CloseScene(scene, true);
+        }
+    }
+
+    private static Scanner FindScanner(Scene scene)
+    {
+        var scanner = scene.GetRootGameObjects()
+            .SelectMany(root => root.GetComponentsInChildren<Scanner>(true))
+            .Single();
+        Assert.That(scanner.game, Is.Not.Null);
+        Assert.That(scanner.game.camera, Is.Not.Null);
+        Assert.That(scanner.lineRenderer, Is.Not.Null);
+        return scanner;
+    }
+
+    private static void SetPrivateField<T>(MeshTriangle triangle, string name, T value) =>
+        typeof(MeshTriangle).GetField(name, BindingFlags.Instance | BindingFlags.NonPublic)
+            ?.SetValue(triangle, value);
+
+    private static void SetPrivateField<T>(Scanner scanner, string name, T value) =>
+        typeof(Scanner).GetField(name, BindingFlags.Instance | BindingFlags.NonPublic)
+            ?.SetValue(scanner, value);
+
+}

--- a/engines/unity/Assets/Editor/Tests/UiEventRuntimeTests.cs
+++ b/engines/unity/Assets/Editor/Tests/UiEventRuntimeTests.cs
@@ -1,5 +1,6 @@
 using System.Linq;
 using System.Reflection;
+using System.Runtime.Serialization;
 using NUnit.Framework;
 using TMPro;
 using UnityEditor.SceneManagement;
@@ -9,6 +10,13 @@ using UnityEngine.SceneManagement;
 public class UiEventRuntimeTests
 {
     private const string GameScenePath = "Assets/Scenes/Game.unity";
+
+    public enum PresentationReleaseTrigger
+    {
+        Completion,
+        Failure,
+        Exit
+    }
 
     [Test]
     public void ScanlineRestoresGeometryAfterSeekingBeforeAnAnimation()
@@ -218,15 +226,26 @@ public class UiEventRuntimeTests
         }
     }
 
-    [Test]
-    public void TooltipReleaseForceClearsAnActiveSystemMessage()
+    [TestCase(PresentationReleaseTrigger.Completion)]
+    [TestCase(PresentationReleaseTrigger.Failure)]
+    [TestCase(PresentationReleaseTrigger.Exit)]
+    public void ControllerReleaseEventsForceClearAnActiveSystemMessage(
+        PresentationReleaseTrigger trigger)
     {
         var scene = EditorSceneManager.OpenScene(GameScenePath, OpenSceneMode.Additive);
         try
         {
+            var game = scene.GetRootGameObjects()
+                .SelectMany(root => root.GetComponentsInChildren<Game>(true))
+                .Single();
             var tooltip = scene.GetRootGameObjects()
                 .SelectMany(root => root.GetComponentsInChildren<GameTooltipText>(true))
                 .Single();
+            var chart = (Chart) FormatterServices.GetUninitializedObject(typeof(Chart));
+            chart.Model = new ChartModel();
+            SetPrivateField(game, "<Chart>k__BackingField", chart);
+            _ = new GameEventPresentationController(game);
+
             var message = new GameMessage
             {
                 Type = GameMessage.AnimationType.Expand,
@@ -239,7 +258,7 @@ public class UiEventRuntimeTests
             Assert.That(tooltip.CurrentMessage, Is.SameAs(message));
             Assert.That(tooltip.tmp.text, Is.EqualTo("System message"));
 
-            tooltip.ClearChartEventState();
+            InvokeReleaseEvent(game, trigger);
             Assert.That(tooltip.CurrentMessage, Is.Null);
             Assert.That(tooltip.tmp.text, Is.Empty);
             Assert.That(tooltip.tmp.color, Is.EqualTo(Color.clear));
@@ -248,6 +267,22 @@ public class UiEventRuntimeTests
         finally
         {
             EditorSceneManager.CloseScene(scene, true);
+        }
+    }
+
+    private static void InvokeReleaseEvent(Game game, PresentationReleaseTrigger trigger)
+    {
+        switch (trigger)
+        {
+            case PresentationReleaseTrigger.Completion:
+                game.onGameCompleted.Invoke(game);
+                break;
+            case PresentationReleaseTrigger.Failure:
+                game.onGameFailed.Invoke(game);
+                break;
+            case PresentationReleaseTrigger.Exit:
+                game.onGameBeforeExit.Invoke(game);
+                break;
         }
     }
 

--- a/engines/unity/Assets/Editor/Tests/UiEventRuntimeTests.cs
+++ b/engines/unity/Assets/Editor/Tests/UiEventRuntimeTests.cs
@@ -1,6 +1,7 @@
 using System.Linq;
 using System.Reflection;
 using NUnit.Framework;
+using TMPro;
 using UnityEditor.SceneManagement;
 using UnityEngine;
 using UnityEngine.SceneManagement;
@@ -76,6 +77,34 @@ public class UiEventRuntimeTests
     }
 
     [Test]
+    public void ScoreUiTargetIncludesAccuracyThroughTheirSharedPerformanceContainer()
+    {
+        var scene = EditorSceneManager.OpenScene(GameScenePath, OpenSceneMode.Additive);
+        try
+        {
+            var game = scene.GetRootGameObjects()
+                .SelectMany(root => root.GetComponentsInChildren<Game>(true))
+                .Single();
+            var overlay = game.levelInfoParent.transform.parent;
+            var method = typeof(GameUiEventController).GetMethod(
+                "FindPerformanceTarget",
+                BindingFlags.Static | BindingFlags.NonPublic);
+
+            var target = (Transform) method?.Invoke(null, new object[] {overlay});
+
+            Assert.That(target, Is.Not.Null);
+            Assert.That(target.name, Is.EqualTo("Performance"));
+            Assert.That(target.Find("Score"), Is.Not.Null);
+            Assert.That(target.Find("Accuracy"), Is.Not.Null);
+            Assert.That(target.GetComponent<CanvasGroup>(), Is.Not.Null);
+        }
+        finally
+        {
+            EditorSceneManager.CloseScene(scene, true);
+        }
+    }
+
+    [Test]
     public void StoryboardColorOverrideWinsOverChartEventColor()
     {
         var scene = EditorSceneManager.OpenScene(GameScenePath, OpenSceneMode.Additive);
@@ -126,6 +155,42 @@ public class UiEventRuntimeTests
             Assert.That(tooltip.tmp.color.b, Is.EqualTo(0.75f).Within(0.0001f));
             Assert.That(tooltip.tmp.color.a, Is.EqualTo(0.75f).Within(0.0001f));
             Assert.That(tooltip.tmp.characterSpacing, Is.EqualTo(21).Within(0.0001f));
+            Assert.That(tooltip.tmp.textWrappingMode,
+                Is.EqualTo(TextWrappingModes.PreserveWhitespaceNoWrap));
+
+            tooltip.ApplyChartEventState(new ChartEventPresentationState(
+                true,
+                ChartEventPresentationKind.SpeedUp,
+                string.Empty,
+                Color.white,
+                Color.white,
+                1,
+                0));
+            Assert.That(tooltip.tmp.textWrappingMode,
+                Is.EqualTo(TextWrappingModes.PreserveWhitespaceNoWrap));
+        }
+        finally
+        {
+            EditorSceneManager.CloseScene(scene, true);
+        }
+    }
+
+    [Test]
+    public void TooltipDoesNotExecuteUnsupportedTags()
+    {
+        var scene = EditorSceneManager.OpenScene(GameScenePath, OpenSceneMode.Additive);
+        try
+        {
+            var tooltip = scene.GetRootGameObjects()
+                .SelectMany(root => root.GetComponentsInChildren<GameTooltipText>(true))
+                .Single();
+            var sanitized = TmpRichTextSanitizer.Sanitize(
+                "<mark=#FFFFFF80>Visible</mark>");
+            tooltip.tmp.text = sanitized;
+            tooltip.tmp.ForceMeshUpdate();
+
+            Assert.That(sanitized, Is.EqualTo("Visible"));
+            Assert.That(tooltip.tmp.GetParsedText(), Is.EqualTo("Visible"));
         }
         finally
         {
@@ -144,12 +209,11 @@ public class UiEventRuntimeTests
         return scanner;
     }
 
-    private static void SetPrivateField<T>(MeshTriangle triangle, string name, T value) =>
-        typeof(MeshTriangle).GetField(name, BindingFlags.Instance | BindingFlags.NonPublic)
-            ?.SetValue(triangle, value);
-
-    private static void SetPrivateField<T>(Scanner scanner, string name, T value) =>
-        typeof(Scanner).GetField(name, BindingFlags.Instance | BindingFlags.NonPublic)
-            ?.SetValue(scanner, value);
+    private static void SetPrivateField<TOwner, TValue>(TOwner owner, string name, TValue value)
+    {
+        var field = typeof(TOwner).GetField(name, BindingFlags.Instance | BindingFlags.NonPublic);
+        Assert.That(field, Is.Not.Null, $"{typeof(TOwner).Name} has no private field '{name}'.");
+        field.SetValue(owner, value);
+    }
 
 }

--- a/engines/unity/Assets/Editor/Tests/UiEventRuntimeTests.cs.meta
+++ b/engines/unity/Assets/Editor/Tests/UiEventRuntimeTests.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 72655bf044064fca8bfa5e2e1410e078

--- a/engines/unity/Assets/Scenes/Game.unity
+++ b/engines/unity/Assets/Scenes/Game.unity
@@ -13878,7 +13878,7 @@ MonoBehaviour:
   m_lineSpacingMax: 0
   m_paragraphSpacing: 0
   m_charWidthMaxAdj: 0
-  m_TextWrappingMode: 1
+  m_TextWrappingMode: 3
   m_wordWrappingRatios: 0.4
   m_overflowMode: 0
   m_linkedTextComponent: {fileID: 0}

--- a/engines/unity/Assets/Scripts/Game/Chart/ChartEventPresentationTimeline.cs
+++ b/engines/unity/Assets/Scripts/Game/Chart/ChartEventPresentationTimeline.cs
@@ -52,7 +52,9 @@ public readonly struct ChartEventPresentationState
 /// <summary>
 /// Seek-safe presentation track shared by C2 speed-change and custom-message events.
 /// Later events interrupt the previous text and continue the scanline transition from the
-/// previously sampled color. Events at the same time use their authored source order.
+/// previously sampled color. Overlapping non-empty message lifetimes share one opacity run,
+/// while their content, color, and letter-spacing animations remain event-local. Events at
+/// the same time use their authored source order.
 /// </summary>
 public sealed class ChartEventPresentationTimeline
 {
@@ -62,6 +64,7 @@ public sealed class ChartEventPresentationTimeline
     public const float TotalDuration = FadeInDuration + HoldDuration + FadeOutDuration;
     public const float TextDuration = 1.5f;
     public const float TextFadeDuration = 0.4f;
+    public const float TextHoldDuration = TextDuration - TextFadeDuration * 2;
     public const float MaxLetterSpacing = 192f;
 
     private readonly List<Snapshot> snapshots = new List<Snapshot>();
@@ -145,6 +148,8 @@ public sealed class ChartEventPresentationTimeline
                 startColor,
                 draft.TargetColor));
         }
+
+        BuildMessageOpacityRuns();
     }
 
     public ChartEventPresentationState Evaluate(float time)
@@ -164,9 +169,39 @@ public sealed class ChartEventPresentationTimeline
             snapshot.Content,
             snapshot.TargetColor,
             ResolveScanlineColor(snapshot, time),
-            hasText ? ResolveTextAlpha(elapsed) : 0,
+            hasText ? ResolveTextAlpha(snapshot, time) : 0,
             ResolveLetterSpacing(snapshot.Kind, elapsed));
     }
+
+    private void BuildMessageOpacityRuns()
+    {
+        for (var startIndex = 0; startIndex < snapshots.Count;)
+        {
+            if (!HasMessageText(snapshots[startIndex]))
+            {
+                startIndex++;
+                continue;
+            }
+
+            var endIndex = startIndex;
+            while (endIndex + 1 < snapshots.Count &&
+                   HasMessageText(snapshots[endIndex + 1]) &&
+                   snapshots[endIndex + 1].Time < snapshots[endIndex].Time + TextDuration)
+                endIndex++;
+
+            var runStart = snapshots[startIndex].Time;
+            var holdStart = Mathf.Max(runStart + TextFadeDuration, snapshots[endIndex].Time);
+            var runEnd = holdStart + TextHoldDuration + TextFadeDuration;
+            for (var index = startIndex; index <= endIndex; index++)
+                snapshots[index] = snapshots[index].WithTextOpacityRun(runStart, runEnd);
+
+            startIndex = endIndex + 1;
+        }
+    }
+
+    private static bool HasMessageText(Snapshot snapshot) =>
+        snapshot.Kind == ChartEventPresentationKind.Message &&
+        !string.IsNullOrEmpty(snapshot.Content);
 
     private int FindLastAtOrBefore(float time)
     {
@@ -202,13 +237,23 @@ public sealed class ChartEventPresentationTimeline
             (elapsed - FadeInDuration - HoldDuration) / FadeOutDuration);
     }
 
-    private static float ResolveTextAlpha(float elapsed)
+    private static float ResolveTextAlpha(Snapshot snapshot, float time)
     {
-        if (elapsed <= 0 || elapsed >= TextDuration) return 0;
+        if (snapshot.Kind != ChartEventPresentationKind.Message)
+            return ResolveEventTextAlpha(time - snapshot.Time);
+
+        var elapsed = time - snapshot.TextOpacityRunStart;
+        var duration = snapshot.TextOpacityRunEnd - snapshot.TextOpacityRunStart;
+        return ResolveEventTextAlpha(elapsed, duration);
+    }
+
+    private static float ResolveEventTextAlpha(float elapsed, float duration = TextDuration)
+    {
+        if (elapsed <= 0 || elapsed >= duration) return 0;
         if (elapsed < TextFadeDuration)
             return EaseOutCubic(elapsed / TextFadeDuration);
 
-        var fadeOutStart = TextDuration - TextFadeDuration;
+        var fadeOutStart = duration - TextFadeDuration;
         if (elapsed < fadeOutStart) return 1;
         return 1 - EaseOutCubic((elapsed - fadeOutStart) / TextFadeDuration);
     }
@@ -240,12 +285,14 @@ public sealed class ChartEventPresentationTimeline
     {
         args = args ?? string.Empty;
         var separator = args.IndexOf(',');
-        content = separator < 0 ? args : args.Substring(0, separator);
+        content = TmpRichTextSanitizer.Sanitize(
+            separator < 0 ? args : args.Substring(0, separator));
         var colorText = separator < 0 ? string.Empty : args.Substring(separator + 1).Trim();
 
         if (IsRgbHexColor(colorText) && ColorUtility.TryParseHtmlString(colorText, out color)) return;
 
         color = Color.white;
+        if (colorText.Length == 0) return;
         warningLogger?.Invoke(
             $"Invalid C2 message color '{colorText}'. Expected #RRGGBB; using white.");
     }
@@ -293,6 +340,8 @@ public sealed class ChartEventPresentationTimeline
         public string Content { get; }
         public Color StartColor { get; }
         public Color TargetColor { get; }
+        public float TextOpacityRunStart { get; }
+        public float TextOpacityRunEnd { get; }
 
         public Snapshot(
             float time,
@@ -306,6 +355,35 @@ public sealed class ChartEventPresentationTimeline
             Content = content;
             StartColor = startColor;
             TargetColor = targetColor;
+            TextOpacityRunStart = time;
+            TextOpacityRunEnd = time + TextDuration;
         }
+
+        private Snapshot(
+            float time,
+            ChartEventPresentationKind kind,
+            string content,
+            Color startColor,
+            Color targetColor,
+            float textOpacityRunStart,
+            float textOpacityRunEnd)
+        {
+            Time = time;
+            Kind = kind;
+            Content = content;
+            StartColor = startColor;
+            TargetColor = targetColor;
+            TextOpacityRunStart = textOpacityRunStart;
+            TextOpacityRunEnd = textOpacityRunEnd;
+        }
+
+        public Snapshot WithTextOpacityRun(float start, float end) => new Snapshot(
+            Time,
+            Kind,
+            Content,
+            StartColor,
+            TargetColor,
+            start,
+            end);
     }
 }

--- a/engines/unity/Assets/Scripts/Game/Chart/ChartEventPresentationTimeline.cs
+++ b/engines/unity/Assets/Scripts/Game/Chart/ChartEventPresentationTimeline.cs
@@ -1,0 +1,311 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+public enum ChartEventPresentationKind
+{
+    None,
+    SpeedUp,
+    SpeedDown,
+    Message
+}
+
+public readonly struct ChartEventPresentationState
+{
+    public static readonly ChartEventPresentationState Empty = new ChartEventPresentationState(
+        false,
+        ChartEventPresentationKind.None,
+        string.Empty,
+        Color.white,
+        Color.white,
+        0,
+        0);
+
+    public bool IsActive { get; }
+    public ChartEventPresentationKind Kind { get; }
+    public string Content { get; }
+    public Color TextColor { get; }
+    public Color ScanlineColor { get; }
+    public float TextAlpha { get; }
+    public bool IsTextVisible => TextAlpha > 0;
+    public float LetterSpacing { get; }
+
+    public ChartEventPresentationState(
+        bool isActive,
+        ChartEventPresentationKind kind,
+        string content,
+        Color textColor,
+        Color scanlineColor,
+        float textAlpha,
+        float letterSpacing)
+    {
+        IsActive = isActive;
+        Kind = kind;
+        Content = content;
+        TextColor = textColor;
+        ScanlineColor = scanlineColor;
+        TextAlpha = textAlpha;
+        LetterSpacing = letterSpacing;
+    }
+}
+
+/// <summary>
+/// Seek-safe presentation track shared by C2 speed-change and custom-message events.
+/// Later events interrupt the previous text and continue the scanline transition from the
+/// previously sampled color. Events at the same time use their authored source order.
+/// </summary>
+public sealed class ChartEventPresentationTimeline
+{
+    public const float FadeInDuration = 1f;
+    public const float HoldDuration = 3f;
+    public const float FadeOutDuration = 1f;
+    public const float TotalDuration = FadeInDuration + HoldDuration + FadeOutDuration;
+    public const float TextDuration = 1.5f;
+    public const float TextFadeDuration = 0.4f;
+    public const float MaxLetterSpacing = 192f;
+
+    private readonly List<Snapshot> snapshots = new List<Snapshot>();
+
+    public ChartEventPresentationTimeline(ChartModel model, Action<string> warningLogger = null)
+    {
+        var drafts = new List<Draft>();
+        var sequence = 0;
+        if (model?.event_order_list == null) return;
+
+        foreach (var order in model.event_order_list)
+        {
+            if (order?.event_list == null) continue;
+            foreach (var chartEvent in order.event_list)
+            {
+                var currentSequence = sequence++;
+                if (chartEvent == null) continue;
+
+                switch ((ChartEventType) chartEvent.type)
+                {
+                    case ChartEventType.SpeedUp:
+                        drafts.Add(new Draft(
+                            order.time,
+                            ChartEventPresentationKind.SpeedUp,
+                            string.Empty,
+                            Scanner.SpeedUpColor,
+                            currentSequence));
+                        break;
+                    case ChartEventType.SpeedDown:
+                        drafts.Add(new Draft(
+                            order.time,
+                            ChartEventPresentationKind.SpeedDown,
+                            string.Empty,
+                            Scanner.SpeedDownColor,
+                            currentSequence));
+                        break;
+                    case ChartEventType.Message:
+                        ParseMessage(
+                            chartEvent.args,
+                            warningLogger,
+                            out var content,
+                            out var color);
+                        drafts.Add(new Draft(
+                            order.time,
+                            ChartEventPresentationKind.Message,
+                            content,
+                            color,
+                            currentSequence));
+                        break;
+                }
+            }
+        }
+
+        drafts.Sort((left, right) =>
+        {
+            var timeComparison = left.Time.CompareTo(right.Time);
+            return timeComparison != 0 ? timeComparison : left.Sequence.CompareTo(right.Sequence);
+        });
+
+        foreach (var draft in drafts)
+        {
+            if (snapshots.Count > 0 && snapshots[snapshots.Count - 1].Time == draft.Time)
+            {
+                var previous = snapshots[snapshots.Count - 1];
+                snapshots[snapshots.Count - 1] = new Snapshot(
+                    draft.Time,
+                    draft.Kind,
+                    draft.Content,
+                    previous.StartColor,
+                    draft.TargetColor);
+                continue;
+            }
+
+            var startColor = snapshots.Count == 0
+                ? Color.white
+                : ResolveScanlineColor(snapshots[snapshots.Count - 1], draft.Time);
+            snapshots.Add(new Snapshot(
+                draft.Time,
+                draft.Kind,
+                draft.Content,
+                startColor,
+                draft.TargetColor));
+        }
+    }
+
+    public ChartEventPresentationState Evaluate(float time)
+    {
+        var index = FindLastAtOrBefore(time);
+        if (index < 0) return ChartEventPresentationState.Empty;
+
+        var snapshot = snapshots[index];
+        var elapsed = time - snapshot.Time;
+        if (elapsed < 0 || elapsed >= TotalDuration) return ChartEventPresentationState.Empty;
+
+        var hasText = snapshot.Kind != ChartEventPresentationKind.Message ||
+                      !string.IsNullOrEmpty(snapshot.Content);
+        return new ChartEventPresentationState(
+            true,
+            snapshot.Kind,
+            snapshot.Content,
+            snapshot.TargetColor,
+            ResolveScanlineColor(snapshot, time),
+            hasText ? ResolveTextAlpha(elapsed) : 0,
+            ResolveLetterSpacing(snapshot.Kind, elapsed));
+    }
+
+    private int FindLastAtOrBefore(float time)
+    {
+        var low = 0;
+        var high = snapshots.Count - 1;
+        var result = -1;
+        while (low <= high)
+        {
+            var middle = (low + high) / 2;
+            if (snapshots[middle].Time <= time)
+            {
+                result = middle;
+                low = middle + 1;
+            }
+            else
+            {
+                high = middle - 1;
+            }
+        }
+        return result;
+    }
+
+    private static Color ResolveScanlineColor(Snapshot snapshot, float time)
+    {
+        var elapsed = time - snapshot.Time;
+        if (elapsed < 0 || elapsed >= TotalDuration) return Color.white;
+        if (elapsed < FadeInDuration)
+            return Color.Lerp(snapshot.StartColor, snapshot.TargetColor, elapsed / FadeInDuration);
+        if (elapsed < FadeInDuration + HoldDuration) return snapshot.TargetColor;
+        return Color.Lerp(
+            snapshot.TargetColor,
+            Color.white,
+            (elapsed - FadeInDuration - HoldDuration) / FadeOutDuration);
+    }
+
+    private static float ResolveTextAlpha(float elapsed)
+    {
+        if (elapsed <= 0 || elapsed >= TextDuration) return 0;
+        if (elapsed < TextFadeDuration)
+            return EaseOutCubic(elapsed / TextFadeDuration);
+
+        var fadeOutStart = TextDuration - TextFadeDuration;
+        if (elapsed < fadeOutStart) return 1;
+        return 1 - EaseOutCubic((elapsed - fadeOutStart) / TextFadeDuration);
+    }
+
+    private static float ResolveLetterSpacing(ChartEventPresentationKind kind, float elapsed)
+    {
+        var progress = Mathf.Clamp01(elapsed / TextDuration);
+        if (kind == ChartEventPresentationKind.Message)
+            return MaxLetterSpacing * progress * progress * progress * progress * progress; // InQuint
+
+        var eased = Mathf.Sqrt(1 - (progress - 1) * (progress - 1)); // OutCirc
+        return kind == ChartEventPresentationKind.SpeedDown
+            ? Mathf.Lerp(MaxLetterSpacing, 0, eased)
+            : Mathf.Lerp(0, MaxLetterSpacing, eased);
+    }
+
+    private static float EaseOutCubic(float progress)
+    {
+        progress = Mathf.Clamp01(progress);
+        var inverse = 1 - progress;
+        return 1 - inverse * inverse * inverse;
+    }
+
+    private static void ParseMessage(
+        string args,
+        Action<string> warningLogger,
+        out string content,
+        out Color color)
+    {
+        args = args ?? string.Empty;
+        var separator = args.IndexOf(',');
+        content = separator < 0 ? args : args.Substring(0, separator);
+        var colorText = separator < 0 ? string.Empty : args.Substring(separator + 1).Trim();
+
+        if (IsRgbHexColor(colorText) && ColorUtility.TryParseHtmlString(colorText, out color)) return;
+
+        color = Color.white;
+        warningLogger?.Invoke(
+            $"Invalid C2 message color '{colorText}'. Expected #RRGGBB; using white.");
+    }
+
+    private static bool IsRgbHexColor(string value)
+    {
+        if (value == null || value.Length != 7 || value[0] != '#') return false;
+        for (var i = 1; i < value.Length; i++)
+        {
+            var c = value[i];
+            if (!((c >= '0' && c <= '9') ||
+                  (c >= 'a' && c <= 'f') ||
+                  (c >= 'A' && c <= 'F'))) return false;
+        }
+        return true;
+    }
+
+    private readonly struct Draft
+    {
+        public float Time { get; }
+        public ChartEventPresentationKind Kind { get; }
+        public string Content { get; }
+        public Color TargetColor { get; }
+        public int Sequence { get; }
+
+        public Draft(
+            float time,
+            ChartEventPresentationKind kind,
+            string content,
+            Color targetColor,
+            int sequence)
+        {
+            Time = time;
+            Kind = kind;
+            Content = content;
+            TargetColor = targetColor;
+            Sequence = sequence;
+        }
+    }
+
+    private readonly struct Snapshot
+    {
+        public float Time { get; }
+        public ChartEventPresentationKind Kind { get; }
+        public string Content { get; }
+        public Color StartColor { get; }
+        public Color TargetColor { get; }
+
+        public Snapshot(
+            float time,
+            ChartEventPresentationKind kind,
+            string content,
+            Color startColor,
+            Color targetColor)
+        {
+            Time = time;
+            Kind = kind;
+            Content = content;
+            StartColor = startColor;
+            TargetColor = targetColor;
+        }
+    }
+}

--- a/engines/unity/Assets/Scripts/Game/Chart/ChartEventPresentationTimeline.cs
+++ b/engines/unity/Assets/Scripts/Game/Chart/ChartEventPresentationTimeline.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Text;
 using UnityEngine;
 
 public enum ChartEventPresentationKind
@@ -284,22 +285,55 @@ public sealed class ChartEventPresentationTimeline
         out Color color)
     {
         args = args ?? string.Empty;
-        var separator = args.IndexOf(',');
-        content = TmpRichTextSanitizer.Sanitize(
-            separator < 0 ? args : args.Substring(0, separator));
+        var separator = FindMessageSeparator(args);
+        var contentText = separator < 0 ? args : args.Substring(0, separator);
         var colorText = separator < 0 ? string.Empty : args.Substring(separator + 1).Trim();
+        content = TmpRichTextSanitizer.Sanitize(UnescapeMessageContent(contentText));
 
-        if (IsRgbHexColor(colorText) && ColorUtility.TryParseHtmlString(colorText, out color)) return;
+        if (IsRgbHexColor(colorText) &&
+            ColorUtility.TryParseHtmlString(colorText, out color))
+            return;
 
         color = Color.white;
         if (colorText.Length == 0) return;
         warningLogger?.Invoke(
-            $"Invalid C2 message color '{colorText}'. Expected #RRGGBB; using white.");
+            $"Invalid C2 message color '{colorText}'. Expected #RRGGBB or #RRGGBBAA; using white.");
+    }
+
+    private static int FindMessageSeparator(string value)
+    {
+        for (var i = 0; i < value.Length; i++)
+        {
+            if (value[i] == '\\' && i + 1 < value.Length &&
+                (value[i + 1] == ',' || value[i + 1] == '\\'))
+            {
+                i++;
+                continue;
+            }
+            if (value[i] == ',') return i;
+        }
+        return -1;
+    }
+
+    private static string UnescapeMessageContent(string value)
+    {
+        var result = new StringBuilder(value.Length);
+        for (var i = 0; i < value.Length; i++)
+        {
+            if (value[i] == '\\' && i + 1 < value.Length &&
+                (value[i + 1] == ',' || value[i + 1] == '\\'))
+                result.Append(value[++i]);
+            else
+                result.Append(value[i]);
+        }
+        return result.ToString();
     }
 
     private static bool IsRgbHexColor(string value)
     {
-        if (value == null || value.Length != 7 || value[0] != '#') return false;
+        if (value == null ||
+            (value.Length != 7 && value.Length != 9) ||
+            value[0] != '#') return false;
         for (var i = 1; i < value.Length; i++)
         {
             var c = value[i];

--- a/engines/unity/Assets/Scripts/Game/Chart/ChartEventPresentationTimeline.cs.meta
+++ b/engines/unity/Assets/Scripts/Game/Chart/ChartEventPresentationTimeline.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d227eeb2f5574afcaef42e8f9bb20986
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/engines/unity/Assets/Scripts/Game/Chart/ChartModel.cs
+++ b/engines/unity/Assets/Scripts/Game/Chart/ChartModel.cs
@@ -15,6 +15,8 @@ public class ChartModel
     public Dictionary<int, Note> note_map = new Dictionary<int, Note>();
     public List<EventOrder> event_order_list = new List<EventOrder>();
 
+    public bool is_start_without_ui;
+
     public double music_offset;
     public double size = 1.0;
     public double opacity = 1.0;

--- a/engines/unity/Assets/Scripts/Game/Chart/ChartUiEventTimeline.cs
+++ b/engines/unity/Assets/Scripts/Game/Chart/ChartUiEventTimeline.cs
@@ -1,0 +1,400 @@
+using System;
+using System.Collections.Generic;
+
+public enum ChartEventType
+{
+    SpeedUp = 0,
+    SpeedDown = 1,
+    ShowUi = 2,
+    HideUi = 3,
+    FadeInUi = 4,
+    FadeOutUi = 5,
+    AnimationInUi = 6,
+    AnimationOutUi = 7,
+    Message = 8
+}
+
+public enum ChartUiTarget
+{
+    Combo = 0,
+    Score = 1,
+    LeftUi = 2,
+    RightUi = 3,
+    Scanline = 4,
+    BoundaryLine = 5,
+    Spectrum = 6,
+    ProgressBar = 7
+}
+
+public enum ChartUiAnimationKind
+{
+    None,
+    In,
+    Out
+}
+
+public readonly struct ChartUiTargetState
+{
+    public float Alpha { get; }
+    public float AnimationAlpha { get; }
+    public float AnimationProgress { get; }
+    public ChartUiAnimationKind AnimationKind { get; }
+
+    public ChartUiTargetState(
+        float alpha,
+        float animationAlpha,
+        float animationProgress,
+        ChartUiAnimationKind animationKind)
+    {
+        Alpha = alpha;
+        AnimationAlpha = animationAlpha;
+        AnimationProgress = animationProgress;
+        AnimationKind = animationKind;
+    }
+}
+
+public static class ChartEventCursor
+{
+    public static int FindFirstAfter(IReadOnlyList<ChartModel.EventOrder> events, float time)
+    {
+        var low = 0;
+        var high = events.Count;
+        while (low < high)
+        {
+            var middle = (low + high) / 2;
+            if (events[middle].time <= time) low = middle + 1;
+            else high = middle;
+        }
+        return low;
+    }
+}
+
+/// <summary>
+/// Precomputed, seek-safe C2 UI event tracks. Conflict behavior intentionally mirrors Cylheim:
+/// every new alpha event starts at its authored time using the value of the previous snapshot at
+/// that time, while animation-out contributes a delayed hide at the end of its animation.
+/// </summary>
+public sealed class ChartUiEventTimeline
+{
+    public const float FadeDuration = 1.3f;
+    private const float BlinkStepDuration = 0.033f;
+
+    private static readonly ChartUiTarget[] SupportedTargets =
+    {
+        ChartUiTarget.Combo,
+        ChartUiTarget.Score,
+        ChartUiTarget.LeftUi,
+        ChartUiTarget.RightUi,
+        ChartUiTarget.Scanline,
+        ChartUiTarget.BoundaryLine,
+        ChartUiTarget.ProgressBar
+    };
+
+    private readonly Dictionary<ChartUiTarget, float> initialAlpha = new Dictionary<ChartUiTarget, float>();
+    private readonly Dictionary<ChartUiTarget, List<AlphaSnapshot>> alphaSnapshots =
+        new Dictionary<ChartUiTarget, List<AlphaSnapshot>>();
+    private readonly Dictionary<ChartUiTarget, List<AnimationSnapshot>> animationSnapshots =
+        new Dictionary<ChartUiTarget, List<AnimationSnapshot>>();
+
+    public ChartUiEventTimeline(ChartModel model, Action<string> warningLogger = null)
+    {
+        var initial = model.is_start_without_ui ? 0f : 1f;
+        var alphaDrafts = new Dictionary<ChartUiTarget, List<AlphaDraft>>();
+        var animationDrafts = new Dictionary<ChartUiTarget, List<AnimationSnapshot>>();
+        foreach (var target in SupportedTargets)
+        {
+            initialAlpha[target] = initial;
+            alphaDrafts[target] = new List<AlphaDraft>();
+            animationDrafts[target] = new List<AnimationSnapshot>();
+        }
+
+        var sequence = 0;
+        foreach (var order in model.event_order_list)
+        {
+            if (order?.event_list == null) continue;
+            foreach (var chartEvent in order.event_list)
+            {
+                var currentSequence = sequence++;
+                if (chartEvent == null || chartEvent.type < (int) ChartEventType.ShowUi ||
+                    chartEvent.type > (int) ChartEventType.AnimationOutUi)
+                    continue;
+
+                var type = (ChartEventType) chartEvent.type;
+                foreach (var target in ParseTargets(chartEvent.args, warningLogger))
+                {
+                    switch (type)
+                    {
+                        case ChartEventType.ShowUi:
+                            alphaDrafts[target].Add(new AlphaDraft(order.time, 0, 1, currentSequence));
+                            break;
+                        case ChartEventType.HideUi:
+                            alphaDrafts[target].Add(new AlphaDraft(order.time, 0, 0, currentSequence));
+                            break;
+                        case ChartEventType.FadeInUi:
+                            alphaDrafts[target].Add(new AlphaDraft(order.time, FadeDuration, 1, currentSequence));
+                            break;
+                        case ChartEventType.FadeOutUi:
+                            alphaDrafts[target].Add(new AlphaDraft(order.time, FadeDuration, 0, currentSequence));
+                            break;
+                        case ChartEventType.AnimationInUi:
+                            alphaDrafts[target].Add(new AlphaDraft(order.time, 0, 1, currentSequence));
+                            animationDrafts[target].Add(
+                                new AnimationSnapshot(
+                                    order.time,
+                                    GetAnimationDuration(target, ChartUiAnimationKind.In),
+                                    ChartUiAnimationKind.In,
+                                    currentSequence));
+                            break;
+                        case ChartEventType.AnimationOutUi:
+                            var duration = GetAnimationDuration(target, ChartUiAnimationKind.Out);
+                            alphaDrafts[target].Add(
+                                new AlphaDraft(order.time + duration, 0, 0, currentSequence));
+                            animationDrafts[target].Add(
+                                new AnimationSnapshot(
+                                    order.time,
+                                    duration,
+                                    ChartUiAnimationKind.Out,
+                                    currentSequence));
+                            break;
+                    }
+                }
+            }
+        }
+
+        foreach (var target in SupportedTargets)
+        {
+            var drafts = alphaDrafts[target];
+            drafts.Sort(CompareDrafts);
+            var snapshots = new List<AlphaSnapshot>(drafts.Count);
+            AlphaSnapshot previous = null;
+            foreach (var draft in drafts)
+            {
+                var startAlpha = previous == null
+                    ? initialAlpha[target]
+                    : ResolveAlpha(previous, draft.Time);
+                previous = new AlphaSnapshot(
+                    draft.Time,
+                    draft.Duration,
+                    startAlpha,
+                    draft.TargetAlpha,
+                    draft.Sequence);
+                snapshots.Add(previous);
+            }
+            alphaSnapshots[target] = snapshots;
+
+            var animations = animationDrafts[target];
+            animations.Sort(CompareAnimations);
+            animationSnapshots[target] = animations;
+        }
+    }
+
+    public ChartUiTargetState Evaluate(ChartUiTarget target, float time)
+    {
+        if (!initialAlpha.ContainsKey(target)) return new ChartUiTargetState(1, 1, 1, ChartUiAnimationKind.None);
+
+        var alpha = initialAlpha[target];
+        var alphaIndex = FindLastAtOrBefore(alphaSnapshots[target], time, snapshot => snapshot.Time);
+        if (alphaIndex >= 0) alpha = ResolveAlpha(alphaSnapshots[target][alphaIndex], time);
+
+        var animationAlpha = 1f;
+        var animationProgress = 1f;
+        var animationKind = ChartUiAnimationKind.None;
+        var animationIndex = FindLastAtOrBefore(animationSnapshots[target], time, snapshot => snapshot.Time);
+        if (animationIndex >= 0)
+        {
+            var snapshot = animationSnapshots[target][animationIndex];
+            animationKind = snapshot.Kind;
+            animationProgress = snapshot.Duration <= 0
+                ? 1
+                : Clamp01((time - snapshot.Time) / snapshot.Duration);
+            animationAlpha = ResolveAnimationAlpha(
+                target,
+                animationKind,
+                Math.Max(0, time - snapshot.Time),
+                snapshot.Duration);
+        }
+
+        return new ChartUiTargetState(Clamp01(alpha), Clamp01(animationAlpha), animationProgress, animationKind);
+    }
+
+    private static IEnumerable<ChartUiTarget> ParseTargets(string args, Action<string> warningLogger)
+    {
+        if (string.IsNullOrWhiteSpace(args)) return SupportedTargets;
+
+        var result = new List<ChartUiTarget>();
+        var seen = new HashSet<ChartUiTarget>();
+        foreach (var raw in args.Split(','))
+        {
+            if (!int.TryParse(raw.Trim(), out var value) || value < 0 || value > 7)
+            {
+                warningLogger?.Invoke($"Ignoring invalid C2 UI target '{raw}'.");
+                continue;
+            }
+
+            var target = (ChartUiTarget) value;
+            if (target == ChartUiTarget.Spectrum) continue;
+            if (seen.Add(target)) result.Add(target);
+        }
+        return result;
+    }
+
+    private static int CompareDrafts(AlphaDraft left, AlphaDraft right)
+    {
+        var time = left.Time.CompareTo(right.Time);
+        return time != 0 ? time : left.Sequence.CompareTo(right.Sequence);
+    }
+
+    private static int CompareAnimations(AnimationSnapshot left, AnimationSnapshot right)
+    {
+        var time = left.Time.CompareTo(right.Time);
+        return time != 0 ? time : left.Sequence.CompareTo(right.Sequence);
+    }
+
+    private static float GetAnimationDuration(ChartUiTarget target, ChartUiAnimationKind kind)
+    {
+        switch (target)
+        {
+            case ChartUiTarget.Combo:
+                return 0.198f;
+            case ChartUiTarget.Score:
+                return 1.198f;
+            case ChartUiTarget.LeftUi:
+                return 1f;
+            case ChartUiTarget.RightUi:
+                return kind == ChartUiAnimationKind.In ? 0.5f : 2f / 3f;
+            case ChartUiTarget.Scanline:
+                return 1f;
+            case ChartUiTarget.BoundaryLine:
+                return 0.1333f;
+            case ChartUiTarget.ProgressBar:
+                return 0.5f;
+            default:
+                return 0;
+        }
+    }
+
+    private static float ResolveAnimationAlpha(
+        ChartUiTarget target,
+        ChartUiAnimationKind kind,
+        float elapsed,
+        float duration)
+    {
+        switch (target)
+        {
+            case ChartUiTarget.Combo:
+                return SampleBlink(elapsed, kind == ChartUiAnimationKind.In, false);
+            case ChartUiTarget.Score:
+                if (kind == ChartUiAnimationKind.In)
+                    return SampleBlink(elapsed, true, true);
+                if (elapsed < 1f) return 1f;
+                return SampleBlink(elapsed - 1f, false, false);
+            case ChartUiTarget.LeftUi:
+            case ChartUiTarget.RightUi:
+            case ChartUiTarget.ProgressBar:
+            case ChartUiTarget.BoundaryLine:
+                var progress = duration <= 0 ? 1f : Clamp01(elapsed / duration);
+                return kind == ChartUiAnimationKind.In ? progress : 1f - progress;
+            case ChartUiTarget.Scanline:
+                // Cytus animates scanline geometry without fading it. The delayed alpha snapshot
+                // still hides it once animation-out has completed.
+                return 1f;
+            default:
+                return 1f;
+        }
+    }
+
+    private static float SampleBlink(
+        float elapsed,
+        bool terminalVisible,
+        bool startsVisible)
+    {
+        var step = (int) Math.Floor(elapsed / BlinkStepDuration);
+        if (step >= 6) return terminalVisible ? 1f : 0f;
+        var visible = startsVisible ? step % 2 == 0 : step % 2 == 1;
+        return visible ? 1f : 0f;
+    }
+
+    private static float ResolveAlpha(AlphaSnapshot snapshot, float time)
+    {
+        if (time < snapshot.Time) return snapshot.StartAlpha;
+        if (snapshot.Duration <= 0 || time >= snapshot.Time + snapshot.Duration) return snapshot.TargetAlpha;
+        var progress = Clamp01((time - snapshot.Time) / snapshot.Duration);
+        return snapshot.StartAlpha + (snapshot.TargetAlpha - snapshot.StartAlpha) * progress;
+    }
+
+    private static int FindLastAtOrBefore<T>(IReadOnlyList<T> snapshots, float time, Func<T, float> getTime)
+    {
+        var low = 0;
+        var high = snapshots.Count - 1;
+        var match = -1;
+        while (low <= high)
+        {
+            var middle = (low + high) / 2;
+            if (getTime(snapshots[middle]) <= time)
+            {
+                match = middle;
+                low = middle + 1;
+            }
+            else
+            {
+                high = middle - 1;
+            }
+        }
+        return match;
+    }
+
+    private static float Clamp01(float value)
+    {
+        return Math.Max(0, Math.Min(1, value));
+    }
+
+    private sealed class AlphaDraft
+    {
+        public float Time { get; }
+        public float Duration { get; }
+        public float TargetAlpha { get; }
+        public int Sequence { get; }
+
+        public AlphaDraft(float time, float duration, float targetAlpha, int sequence)
+        {
+            Time = time;
+            Duration = duration;
+            TargetAlpha = targetAlpha;
+            Sequence = sequence;
+        }
+    }
+
+    private sealed class AlphaSnapshot
+    {
+        public float Time { get; }
+        public float Duration { get; }
+        public float StartAlpha { get; }
+        public float TargetAlpha { get; }
+        public int Sequence { get; }
+
+        public AlphaSnapshot(float time, float duration, float startAlpha, float targetAlpha, int sequence)
+        {
+            Time = time;
+            Duration = duration;
+            StartAlpha = startAlpha;
+            TargetAlpha = targetAlpha;
+            Sequence = sequence;
+        }
+    }
+
+    private sealed class AnimationSnapshot
+    {
+        public float Time { get; }
+        public float Duration { get; }
+        public ChartUiAnimationKind Kind { get; }
+        public int Sequence { get; }
+
+        public AnimationSnapshot(float time, float duration, ChartUiAnimationKind kind, int sequence)
+        {
+            Time = time;
+            Duration = duration;
+            Kind = kind;
+            Sequence = sequence;
+        }
+    }
+}

--- a/engines/unity/Assets/Scripts/Game/Chart/ChartUiEventTimeline.cs
+++ b/engines/unity/Assets/Scripts/Game/Chart/ChartUiEventTimeline.cs
@@ -98,7 +98,7 @@ public sealed class ChartUiEventTimeline
 
     public ChartUiEventTimeline(ChartModel model, Action<string> warningLogger = null)
     {
-        var initial = model.is_start_without_ui ? 0f : 1f;
+        var initial = model != null && model.is_start_without_ui ? 0f : 1f;
         var alphaDrafts = new Dictionary<ChartUiTarget, List<AlphaDraft>>();
         var animationDrafts = new Dictionary<ChartUiTarget, List<AnimationSnapshot>>();
         foreach (var target in SupportedTargets)
@@ -106,7 +106,11 @@ public sealed class ChartUiEventTimeline
             initialAlpha[target] = initial;
             alphaDrafts[target] = new List<AlphaDraft>();
             animationDrafts[target] = new List<AnimationSnapshot>();
+            alphaSnapshots[target] = new List<AlphaSnapshot>();
+            animationSnapshots[target] = new List<AnimationSnapshot>();
         }
+
+        if (model?.event_order_list == null) return;
 
         var sequence = 0;
         foreach (var order in model.event_order_list)
@@ -190,19 +194,21 @@ public sealed class ChartUiEventTimeline
 
     public ChartUiTargetState Evaluate(ChartUiTarget target, float time)
     {
-        if (!initialAlpha.ContainsKey(target)) return new ChartUiTargetState(1, 1, 1, ChartUiAnimationKind.None);
+        if (!initialAlpha.TryGetValue(target, out var alpha) ||
+            !alphaSnapshots.TryGetValue(target, out var targetAlphaSnapshots) ||
+            !animationSnapshots.TryGetValue(target, out var targetAnimationSnapshots))
+            return new ChartUiTargetState(1, 1, 1, ChartUiAnimationKind.None);
 
-        var alpha = initialAlpha[target];
-        var alphaIndex = FindLastAtOrBefore(alphaSnapshots[target], time, snapshot => snapshot.Time);
-        if (alphaIndex >= 0) alpha = ResolveAlpha(alphaSnapshots[target][alphaIndex], time);
+        var alphaIndex = FindLastAtOrBefore(targetAlphaSnapshots, time, snapshot => snapshot.Time);
+        if (alphaIndex >= 0) alpha = ResolveAlpha(targetAlphaSnapshots[alphaIndex], time);
 
         var animationAlpha = 1f;
         var animationProgress = 1f;
         var animationKind = ChartUiAnimationKind.None;
-        var animationIndex = FindLastAtOrBefore(animationSnapshots[target], time, snapshot => snapshot.Time);
+        var animationIndex = FindLastAtOrBefore(targetAnimationSnapshots, time, snapshot => snapshot.Time);
         if (animationIndex >= 0)
         {
-            var snapshot = animationSnapshots[target][animationIndex];
+            var snapshot = targetAnimationSnapshots[animationIndex];
             animationKind = snapshot.Kind;
             animationProgress = snapshot.Duration <= 0
                 ? 1

--- a/engines/unity/Assets/Scripts/Game/Chart/ChartUiEventTimeline.cs.meta
+++ b/engines/unity/Assets/Scripts/Game/Chart/ChartUiEventTimeline.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 8e397eb192c24573b7b29c9f13009ca5

--- a/engines/unity/Assets/Scripts/Game/Elements/GameEventPresentationController.cs
+++ b/engines/unity/Assets/Scripts/Game/Elements/GameEventPresentationController.cs
@@ -43,7 +43,7 @@ public sealed class GameEventPresentationController
     {
         if (!active) return;
         active = false;
-        tooltip?.ApplyChartEventState(ChartEventPresentationState.Empty);
+        tooltip?.ClearChartEventState();
         if (Scanner.Instance != null) Scanner.Instance.SetChartEventColor(Color.white);
     }
 }

--- a/engines/unity/Assets/Scripts/Game/Elements/GameEventPresentationController.cs
+++ b/engines/unity/Assets/Scripts/Game/Elements/GameEventPresentationController.cs
@@ -1,0 +1,47 @@
+using UnityEngine;
+
+/// <summary>
+/// Applies the seek-safe C2 event presentation after storyboard updates for the frame.
+/// Storyboard scanline color remains the final override inside Scanner.
+/// </summary>
+public sealed class GameEventPresentationController
+{
+    private readonly Game game;
+    private readonly ChartEventPresentationTimeline timeline;
+    private readonly GameTooltipText tooltip;
+    private bool active = true;
+
+    public GameEventPresentationController(Game game)
+    {
+        this.game = game;
+        timeline = new ChartEventPresentationTimeline(game.Chart.Model, Debug.LogWarning);
+
+        foreach (var candidate in Object.FindObjectsOfType<GameTooltipText>(true))
+        {
+            if (candidate.game != game) continue;
+            tooltip = candidate;
+            break;
+        }
+
+        game.onGameCompleted.AddListener(_ => Release());
+        game.onGameFailed.AddListener(_ => Release());
+        game.onGameBeforeExit.AddListener(_ => Release());
+        game.onGameDisposed.AddListener(_ => Release());
+    }
+
+    public void Apply(float time)
+    {
+        if (!active) return;
+        var state = timeline.Evaluate(time);
+        tooltip?.ApplyChartEventState(state);
+        if (Scanner.Instance != null) Scanner.Instance.SetChartEventColor(state.ScanlineColor);
+    }
+
+    public void Release()
+    {
+        if (!active) return;
+        active = false;
+        tooltip?.ApplyChartEventState(ChartEventPresentationState.Empty);
+        if (Scanner.Instance != null) Scanner.Instance.SetChartEventColor(Color.white);
+    }
+}

--- a/engines/unity/Assets/Scripts/Game/Elements/GameEventPresentationController.cs
+++ b/engines/unity/Assets/Scripts/Game/Elements/GameEventPresentationController.cs
@@ -16,7 +16,9 @@ public sealed class GameEventPresentationController
         this.game = game;
         timeline = new ChartEventPresentationTimeline(game.Chart.Model, Debug.LogWarning);
 
-        foreach (var candidate in Object.FindObjectsOfType<GameTooltipText>(true))
+        foreach (var candidate in Object.FindObjectsByType<GameTooltipText>(
+                     FindObjectsInactive.Include,
+                     FindObjectsSortMode.None))
         {
             if (candidate.game != game) continue;
             tooltip = candidate;

--- a/engines/unity/Assets/Scripts/Game/Elements/GameEventPresentationController.cs.meta
+++ b/engines/unity/Assets/Scripts/Game/Elements/GameEventPresentationController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7a201fcf93c7418b89d89370530f01bd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/engines/unity/Assets/Scripts/Game/Elements/GameTooltipText.cs
+++ b/engines/unity/Assets/Scripts/Game/Elements/GameTooltipText.cs
@@ -17,21 +17,11 @@ public class GameTooltipText : MonoBehaviour
     public GameMessage CurrentMessage { get; protected set; }
 
     private readonly List<Sequence> sequences = new List<Sequence>();
+    private ChartEventPresentationState chartEventState = ChartEventPresentationState.Empty;
+    private int messageVersion;
 
     protected void Awake()
     {
-        game.onGameSpeedUp.AddListener(_ => Animate(new GameMessage
-        {
-            Type = GameMessage.AnimationType.Expand,
-            Color = Scanner.SpeedUpColor,
-            TextFunction = () => "GAME_SPEED_UP".Get()
-        }));
-        game.onGameSpeedDown.AddListener(_ => Animate(new GameMessage
-        {
-            Type = GameMessage.AnimationType.Shrink,
-            Color = Scanner.SpeedDownColor,
-            TextFunction = () => "GAME_SLOW_DOWN".Get()
-        }));
         game.onGameWillUnpause.AddListener(async _ =>
         {
             await UniTask.Delay(TimeSpan.FromSeconds(1.4f));
@@ -49,6 +39,7 @@ public class GameTooltipText : MonoBehaviour
 
     public async void Animate(GameMessage message, float duration = 1.5f)
     {
+        var version = ++messageVersion;
         CurrentMessage = message;
         tmp.color = message.Color.WithAlpha(0);
         tmp.text = message.TextFunction();
@@ -90,7 +81,45 @@ public class GameTooltipText : MonoBehaviour
             .Also(it => sequences.Add(it));
 
         await UniTask.Delay(TimeSpan.FromSeconds(duration));
+        if (version != messageVersion) return;
         CurrentMessage = null;
+        RenderChartEventState();
+    }
+
+    public void ApplyChartEventState(ChartEventPresentationState state)
+    {
+        chartEventState = state;
+        if (CurrentMessage == null) RenderChartEventState();
+    }
+
+    private void RenderChartEventState()
+    {
+        if (!chartEventState.IsActive)
+        {
+            tmp.text = string.Empty;
+            tmp.color = Color.clear;
+            tmp.characterSpacing = 0;
+            return;
+        }
+
+        switch (chartEventState.Kind)
+        {
+            case ChartEventPresentationKind.SpeedUp:
+                tmp.text = "GAME_SPEED_UP".Get();
+                break;
+            case ChartEventPresentationKind.SpeedDown:
+                tmp.text = "GAME_SLOW_DOWN".Get();
+                break;
+            case ChartEventPresentationKind.Message:
+                tmp.text = chartEventState.Content;
+                break;
+            default:
+                tmp.text = string.Empty;
+                break;
+        }
+
+        tmp.color = chartEventState.TextColor.WithAlpha(chartEventState.TextAlpha);
+        tmp.characterSpacing = chartEventState.LetterSpacing;
     }
 
     public void Update()

--- a/engines/unity/Assets/Scripts/Game/Elements/GameTooltipText.cs
+++ b/engines/unity/Assets/Scripts/Game/Elements/GameTooltipText.cs
@@ -93,6 +93,16 @@ public class GameTooltipText : MonoBehaviour
         if (CurrentMessage == null) RenderChartEventState();
     }
 
+    public void ClearChartEventState()
+    {
+        messageVersion++;
+        sequences.ForEach(it => it.Kill());
+        sequences.Clear();
+        CurrentMessage = null;
+        chartEventState = ChartEventPresentationState.Empty;
+        RenderChartEventState();
+    }
+
     private void RenderChartEventState()
     {
         if (!chartEventState.IsActive)

--- a/engines/unity/Assets/Scripts/Game/Elements/GameTooltipText.cs
+++ b/engines/unity/Assets/Scripts/Game/Elements/GameTooltipText.cs
@@ -22,6 +22,7 @@ public class GameTooltipText : MonoBehaviour
 
     protected void Awake()
     {
+        tmp.textWrappingMode = TextWrappingModes.PreserveWhitespaceNoWrap;
         game.onGameWillUnpause.AddListener(async _ =>
         {
             await UniTask.Delay(TimeSpan.FromSeconds(1.4f));

--- a/engines/unity/Assets/Scripts/Game/Elements/GameTooltipText.cs
+++ b/engines/unity/Assets/Scripts/Game/Elements/GameTooltipText.cs
@@ -119,7 +119,8 @@ public class GameTooltipText : MonoBehaviour
                 break;
         }
 
-        tmp.color = chartEventState.TextColor.WithAlpha(chartEventState.TextAlpha);
+        tmp.color = chartEventState.TextColor.WithAlpha(
+            chartEventState.TextColor.a * chartEventState.TextAlpha);
         tmp.characterSpacing = chartEventState.LetterSpacing;
     }
 

--- a/engines/unity/Assets/Scripts/Game/Elements/GameUiEventController.cs
+++ b/engines/unity/Assets/Scripts/Game/Elements/GameUiEventController.cs
@@ -1,0 +1,190 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+/// <summary>
+/// Applies seek-safe C2 UI event state after storyboard has updated for the frame.
+/// Canvas targets are deliberately below the storyboard UI canvas, so their alpha values multiply.
+/// </summary>
+public sealed class GameUiEventController
+{
+    private readonly Game game;
+    private readonly ChartUiEventTimeline timeline;
+    private readonly Dictionary<ChartUiTarget, CanvasTarget> canvasTargets =
+        new Dictionary<ChartUiTarget, CanvasTarget>();
+
+    private bool active = true;
+
+    public GameUiEventController(Game game)
+    {
+        this.game = game;
+        timeline = new ChartUiEventTimeline(game.Chart.Model, Debug.LogWarning);
+        ResolveTargets();
+
+        // Establish only the initial state before the overlay enters. Events authored at tick zero
+        // must not become visible during the pre-song countdown.
+        ApplyCanvasTargets(float.NegativeInfinity, false);
+
+        var boundary = timeline.Evaluate(ChartUiTarget.BoundaryLine, float.NegativeInfinity);
+        game.Renderer.SetUiEventOpacity(boundary.Alpha, boundary.AnimationAlpha);
+
+        var scanner = Scanner.Instance;
+        if (scanner != null)
+        {
+            var scanline = timeline.Evaluate(ChartUiTarget.Scanline, float.NegativeInfinity);
+            scanner.SetUiEventState(
+                scanline.Alpha,
+                scanline.AnimationAlpha,
+                scanline.AnimationKind,
+                EaseScanlineProgress(scanline.AnimationProgress),
+                false);
+        }
+
+        game.onGameCompleted.AddListener(_ => Release());
+        game.onGameFailed.AddListener(_ => Release());
+        game.onGameBeforeExit.AddListener(_ => Release());
+        game.onGameDisposed.AddListener(_ => Release());
+    }
+
+    public void Apply(float time)
+    {
+        if (!active) return;
+
+        ApplyCanvasTargets(time, game.State != null && game.State.IsStarted);
+
+        var boundary = timeline.Evaluate(ChartUiTarget.BoundaryLine, time);
+        game.Renderer.SetUiEventOpacity(boundary.Alpha, boundary.AnimationAlpha);
+
+        var scanner = Scanner.Instance;
+        if (scanner != null)
+        {
+            var scanline = timeline.Evaluate(ChartUiTarget.Scanline, time);
+            scanner.SetUiEventState(
+                scanline.Alpha,
+                scanline.AnimationAlpha,
+                scanline.AnimationKind,
+                EaseScanlineProgress(scanline.AnimationProgress));
+        }
+    }
+
+    public void ApplyBeforeGameUpdate(float time)
+    {
+        if (!active) return;
+        var scanner = Scanner.Instance;
+        if (scanner == null) return;
+        var scanline = timeline.Evaluate(ChartUiTarget.Scanline, time);
+        scanner.SetUiEventOpacity(scanline.Alpha, scanline.AnimationAlpha);
+    }
+
+    public void Release()
+    {
+        if (!active) return;
+        active = false;
+    }
+
+    private void ResolveTargets()
+    {
+        var overlay = game.levelInfoParent != null ? game.levelInfoParent.transform.parent : null;
+        if (overlay == null) return;
+
+        AddCanvasTarget(ChartUiTarget.Combo, FindDescendant(overlay, "Combo"), Vector2.zero);
+        AddCanvasTarget(ChartUiTarget.Score, FindDescendant(overlay, "Score"), Vector2.zero);
+
+        var left = game.levelInfoParent != null
+            ? FindDescendant(game.levelInfoParent.transform, "LevelInfo") ?? game.levelInfoParent.transform
+            : null;
+        AddCanvasTarget(ChartUiTarget.LeftUi, left, Vector2.left);
+
+        var right = game.modHolderParent != null
+            ? FindDescendant(game.modHolderParent.transform, "Mods") ?? game.modHolderParent.transform
+            : null;
+        AddCanvasTarget(ChartUiTarget.RightUi, right, Vector2.right);
+
+        AddCanvasTarget(ChartUiTarget.ProgressBar, FindDescendant(overlay, "ProgressIndicator"), Vector2.zero);
+    }
+
+    private void AddCanvasTarget(ChartUiTarget target, Transform transform, Vector2 animationDirection)
+    {
+        if (!(transform is RectTransform rectTransform)) return;
+        var canvasGroup = transform.GetComponent<CanvasGroup>();
+        if (canvasGroup == null) canvasGroup = transform.gameObject.AddComponent<CanvasGroup>();
+        canvasTargets[target] = new CanvasTarget(canvasGroup, rectTransform, animationDirection);
+    }
+
+    private void ApplyCanvasTargets(float time, bool capturePosition)
+    {
+        foreach (var pair in canvasTargets)
+        {
+            var state = timeline.Evaluate(pair.Key, time);
+            pair.Value.Apply(state, EaseSlideProgress(state), capturePosition);
+        }
+    }
+
+    private static float EaseSlideProgress(ChartUiTargetState state)
+    {
+        var progress = Mathf.Clamp01(state.AnimationProgress);
+        if (state.AnimationKind == ChartUiAnimationKind.In)
+        {
+            var inverse = 1 - progress;
+            return 1 - inverse * inverse * inverse; // OutCubic
+        }
+        if (state.AnimationKind == ChartUiAnimationKind.Out) return progress * progress * progress; // InCubic
+        return 1;
+    }
+
+    private static float EaseScanlineProgress(float progress)
+    {
+        progress = Mathf.Clamp01(progress);
+        return progress * progress * progress * (progress * (progress * 6 - 15) + 10);
+    }
+
+    private static Transform FindDescendant(Transform parent, string name)
+    {
+        if (parent == null) return null;
+        for (var i = 0; i < parent.childCount; i++)
+        {
+            var child = parent.GetChild(i);
+            if (child.name == name) return child;
+            var nested = FindDescendant(child, name);
+            if (nested != null) return nested;
+        }
+        return null;
+    }
+
+    private sealed class CanvasTarget
+    {
+        private const float SlideDistance = 128f;
+
+        private readonly CanvasGroup canvasGroup;
+        private readonly RectTransform rectTransform;
+        private readonly float baseAlpha;
+        private readonly Vector2 animationDirection;
+
+        private Vector2 basePosition;
+        private bool positionCaptured;
+
+        public CanvasTarget(CanvasGroup canvasGroup, RectTransform rectTransform, Vector2 animationDirection)
+        {
+            this.canvasGroup = canvasGroup;
+            this.rectTransform = rectTransform;
+            this.animationDirection = animationDirection;
+            baseAlpha = canvasGroup.alpha;
+        }
+
+        public void Apply(ChartUiTargetState state, float easedProgress, bool capturePosition)
+        {
+            canvasGroup.alpha = baseAlpha * state.Alpha * state.AnimationAlpha;
+
+            if (!positionCaptured && capturePosition)
+            {
+                basePosition = rectTransform.anchoredPosition;
+                positionCaptured = true;
+            }
+            if (!positionCaptured) return;
+
+            var offsetProgress = 0f;
+            if (state.AnimationKind == ChartUiAnimationKind.In) offsetProgress = 1 - easedProgress;
+            else if (state.AnimationKind == ChartUiAnimationKind.Out) offsetProgress = easedProgress;
+            rectTransform.anchoredPosition = basePosition + animationDirection * (SlideDistance * offsetProgress);
+        }
+    }
+}

--- a/engines/unity/Assets/Scripts/Game/Elements/GameUiEventController.cs
+++ b/engines/unity/Assets/Scripts/Game/Elements/GameUiEventController.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using UnityEngine;
 
@@ -9,15 +10,17 @@ public sealed class GameUiEventController
 {
     private readonly Game game;
     private readonly ChartUiEventTimeline timeline;
+    private readonly Action<string> warningLogger;
     private readonly Dictionary<ChartUiTarget, CanvasTarget> canvasTargets =
         new Dictionary<ChartUiTarget, CanvasTarget>();
 
     private bool active = true;
 
-    public GameUiEventController(Game game)
+    public GameUiEventController(Game game, Action<string> warningLogger = null)
     {
         this.game = game;
-        timeline = new ChartUiEventTimeline(game.Chart.Model, Debug.LogWarning);
+        this.warningLogger = warningLogger ?? Debug.LogWarning;
+        timeline = new ChartUiEventTimeline(game.Chart.Model, this.warningLogger);
         ResolveTargets();
 
         // Establish only the initial state before the overlay enters. Events authored at tick zero
@@ -84,10 +87,9 @@ public sealed class GameUiEventController
     private void ResolveTargets()
     {
         var overlay = game.levelInfoParent != null ? game.levelInfoParent.transform.parent : null;
-        if (overlay == null) return;
 
         AddCanvasTarget(ChartUiTarget.Combo, FindDescendant(overlay, "Combo"), Vector2.zero);
-        AddCanvasTarget(ChartUiTarget.Score, FindDescendant(overlay, "Score"), Vector2.zero);
+        AddCanvasTarget(ChartUiTarget.Score, FindPerformanceTarget(overlay), Vector2.zero);
 
         var left = game.levelInfoParent != null
             ? FindDescendant(game.levelInfoParent.transform, "LevelInfo") ?? game.levelInfoParent.transform
@@ -102,9 +104,21 @@ public sealed class GameUiEventController
         AddCanvasTarget(ChartUiTarget.ProgressBar, FindDescendant(overlay, "ProgressIndicator"), Vector2.zero);
     }
 
+    private static Transform FindPerformanceTarget(Transform overlay)
+    {
+        var score = FindDescendant(overlay, "Score");
+        if (score?.parent != null && FindDescendant(score.parent, "Accuracy") != null)
+            return score.parent;
+        return score;
+    }
+
     private void AddCanvasTarget(ChartUiTarget target, Transform transform, Vector2 animationDirection)
     {
-        if (!(transform is RectTransform rectTransform)) return;
+        if (!(transform is RectTransform rectTransform))
+        {
+            warningLogger?.Invoke($"Could not resolve C2 UI canvas target '{target}'.");
+            return;
+        }
         var canvasGroup = transform.GetComponent<CanvasGroup>();
         if (canvasGroup == null) canvasGroup = transform.gameObject.AddComponent<CanvasGroup>();
         canvasTargets[target] = new CanvasTarget(canvasGroup, rectTransform, animationDirection);

--- a/engines/unity/Assets/Scripts/Game/Elements/GameUiEventController.cs.meta
+++ b/engines/unity/Assets/Scripts/Game/Elements/GameUiEventController.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 87b44a491a094a21b358744bc1f77d99

--- a/engines/unity/Assets/Scripts/Game/Elements/MeshTriangle.cs
+++ b/engines/unity/Assets/Scripts/Game/Elements/MeshTriangle.cs
@@ -9,6 +9,7 @@ public class MeshTriangle : MonoBehaviour
 
     private Mesh mesh;
     private MeshRenderer meshRenderer;
+    private Material material;
     private Scanner scanner;
     private Camera mainCamera;
 
@@ -29,12 +30,20 @@ public class MeshTriangle : MonoBehaviour
         };
         mesh.triangles = new[] {0, 1, 2};
         meshRenderer = gameObject.GetComponent<MeshRenderer>();
+        material = meshRenderer.material;
         scanner = Scanner.Instance;
         mainCamera = Camera.main;
+        if (scanner != null) scanner.RegisterTriangle(this);
+    }
+
+    private void OnDisable()
+    {
+        if (scanner != null) scanner.UnregisterTriangle(this);
     }
 
     public void Reset()
     {
+        if (mesh == null) return;
         mesh.vertices = new[]
         {
             new Vector3(),
@@ -74,6 +83,11 @@ public class MeshTriangle : MonoBehaviour
         };
         mesh.triangles = new[] {0, 1, 2};
         
-        meshRenderer.material.color = Color.white.WithAlpha(0.1f * Mathf.Min(1f, scanner.opacity));
+        ApplyOpacity(scanner.EffectiveOpacity);
+    }
+
+    public void ApplyOpacity(float scannerOpacity)
+    {
+        if (material != null) material.color = Color.white.WithAlpha(0.1f * scannerOpacity);
     }
 }

--- a/engines/unity/Assets/Scripts/Game/Elements/Scanner.cs
+++ b/engines/unity/Assets/Scripts/Game/Elements/Scanner.cs
@@ -202,11 +202,12 @@ public class Scanner : SingletonMonoBehavior<Scanner>
     private void ApplyVisualState()
     {
         var color = colorOverride == Color.clear ? currentColor : colorOverride;
-        color = color.WithAlpha(EffectiveOpacity);
+        var composedOpacity = color.a * EffectiveOpacity;
+        color = color.WithAlpha(composedOpacity);
         lineRenderer.startColor = color;
         lineRenderer.endColor = color;
         foreach (var triangle in triangles)
-            if (triangle != null) triangle.ApplyOpacity(EffectiveOpacity);
+            if (triangle != null) triangle.ApplyOpacity(composedOpacity);
     }
 
     public void RegisterTriangle(MeshTriangle triangle) => triangles.Add(triangle);

--- a/engines/unity/Assets/Scripts/Game/Elements/Scanner.cs
+++ b/engines/unity/Assets/Scripts/Game/Elements/Scanner.cs
@@ -134,17 +134,20 @@ public class Scanner : SingletonMonoBehavior<Scanner>
 
         if (uiEventAnimationKind == ChartUiAnimationKind.In)
         {
+            StopGeometryAnimation();
             hasAppliedUiEventAnimation = true;
             if (uiEventAnimationProgress >= 1) ApplyNormalLineGeometry();
             else ApplyLineGeometry(uiEventAnimationProgress);
         }
         else if (uiEventAnimationKind == ChartUiAnimationKind.Out)
         {
+            StopGeometryAnimation();
             hasAppliedUiEventAnimation = true;
             ApplyLineGeometry(1 - uiEventAnimationProgress);
         }
         else if (hasAppliedUiEventAnimation)
         {
+            StopGeometryAnimation();
             // A backward seek can move before the latest animation snapshot. Restore the stable
             // geometry once, without overriding the normal system enter animation every frame.
             ApplyNormalLineGeometry();

--- a/engines/unity/Assets/Scripts/Game/Elements/Scanner.cs
+++ b/engines/unity/Assets/Scripts/Game/Elements/Scanner.cs
@@ -1,7 +1,6 @@
 ﻿using System.Collections;
-using DG.Tweening;
+using System.Collections.Generic;
 using UnityEngine;
-using Random = UnityEngine.Random;
 
 public class Scanner : SingletonMonoBehavior<Scanner>
 {
@@ -17,9 +16,15 @@ public class Scanner : SingletonMonoBehavior<Scanner>
     public LineRenderer lineRenderer;
     public float animationDuration;
 
-    private Color colorNext = new Color(1, 1, 1);
-    private float colorNextSpeed;
-    private Coroutine animationCoroutine;
+    private Color currentColor = Color.white;
+    private Coroutine geometryAnimationCoroutine;
+
+    private float uiEventOpacity = 1f;
+    private float uiEventAnimationOpacity = 1f;
+    private ChartUiAnimationKind uiEventAnimationKind = ChartUiAnimationKind.None;
+    private float uiEventAnimationProgress = 1f;
+    private bool hasAppliedUiEventAnimation;
+    private readonly HashSet<MeshTriangle> triangles = new HashSet<MeshTriangle>();
 
     private bool exited;
 
@@ -34,8 +39,6 @@ public class Scanner : SingletonMonoBehavior<Scanner>
         game.onGameStarted.AddListener(_ => PlayEnter());
         game.onGameCompleted.AddListener(_ => PlayExit());
         game.onGameUpdate.AddListener(OnGameUpdate);
-        game.onGameSpeedUp.AddListener(_ => PlaySpeedUp());
-        game.onGameSpeedDown.AddListener(_ => PlaySpeedDown());
     }
 
     private void OnEnable()
@@ -45,74 +48,34 @@ public class Scanner : SingletonMonoBehavior<Scanner>
         lineRenderer.SetPosition(1, new Vector3(0, 0, 0));
         gameObject.GetComponent<LineRenderer>().startColor = new Color(1f, 1f, 1f);
         gameObject.GetComponent<LineRenderer>().startColor = new Color(1f, 1f, 1f);
-        colorNext = new Color(1f, 1f, 1f, opacity);
-        colorNextSpeed = 9.0f;
+        currentColor = Color.white;
     }
 
     private IEnumerator ResetLine()
     {
         yield return null;
-        lineRenderer.positionCount = 2;
-        lineRenderer.SetPosition(0,
-            new Vector3(-game.camera.orthographicSize * UnityEngine.Screen.width / UnityEngine.Screen.height * 1000f, 0,
-                0));
-        lineRenderer.SetPosition(1,
-            new Vector3(game.camera.orthographicSize * UnityEngine.Screen.width / UnityEngine.Screen.height * 1000f, 0,
-                0));
-        lineRenderer.useWorldSpace = false;
-        lineRenderer.endWidth = 0.05f;
-        lineRenderer.startWidth = 0.05f;
+        ApplyNormalLineGeometry();
     }
 
-    public void EnsureSingleAnimation()
+    private void StopGeometryAnimation()
     {
-        if (animationCoroutine != null)
+        if (geometryAnimationCoroutine != null)
         {
-            StopCoroutine(animationCoroutine);
-            StartCoroutine(ResetLine());
+            StopCoroutine(geometryAnimationCoroutine);
+            geometryAnimationCoroutine = null;
         }
     }
 
     public void PlayEnter()
     {
-        EnsureSingleAnimation();
-        animationCoroutine = StartCoroutine(PlayEnterAnimation());
+        StopGeometryAnimation();
+        geometryAnimationCoroutine = StartCoroutine(PlayEnterAnimation());
     }
 
     public void PlayExit()
     {
-        EnsureSingleAnimation();
-        animationCoroutine = StartCoroutine(PlayExitAnimation());
-    }
-
-    public void PlaySpeedUp()
-    {
-        EnsureSingleAnimation();
-        animationCoroutine = StartCoroutine(PlaySpeedUpAnimation());
-    }
-
-    public void PlaySpeedDown()
-    {
-        EnsureSingleAnimation();
-        animationCoroutine = StartCoroutine(PlaySpeedDownAnimation());
-    }
-
-    IEnumerator PlaySpeedUpAnimation()
-    {
-        colorNext = SpeedUpColor;
-        colorNextSpeed = 6.0f;
-        yield return new WaitForSeconds(3.5f);
-        colorNext = new Color(1f, 1f, 1f);
-        colorNextSpeed = 24.0f;
-    }
-
-    IEnumerator PlaySpeedDownAnimation()
-    {
-        colorNext = SpeedDownColor;
-        colorNextSpeed = 6.0f;
-        yield return new WaitForSeconds(3.5f);
-        colorNext = new Color(1f, 1f, 1f);
-        colorNextSpeed = 24.0f;
+        StopGeometryAnimation();
+        geometryAnimationCoroutine = StartCoroutine(PlayExitAnimation());
     }
 
     IEnumerator PlayExitAnimation()
@@ -122,18 +85,7 @@ public class Scanner : SingletonMonoBehavior<Scanner>
         lineRenderer.positionCount = 100;
         while (timing < animationDuration)
         {
-            var progress = timing / animationDuration;
-            var randomRange = 0; // progress / 10;
-            for (var i = 0; i < 100; i++)
-            {
-                var orthographicSize = game.camera.orthographicSize;
-                lineRenderer.SetPosition(i,
-                    new Vector3(
-                        (-orthographicSize * UnityEngine.Screen.width / UnityEngine.Screen.height + 2f *
-                         orthographicSize * UnityEngine.Screen.width / UnityEngine.Screen.height * (i / 100f)) *
-                        (1 - progress),
-                        Random.Range(-randomRange, randomRange)));
-            }
+            ApplyLineGeometry(1 - timing / animationDuration);
 
             yield return null;
             // Continue here next frame
@@ -142,6 +94,7 @@ public class Scanner : SingletonMonoBehavior<Scanner>
 
         lineRenderer.positionCount = 0;
         exited = true;
+        geometryAnimationCoroutine = null;
     }
 
     IEnumerator PlayEnterAnimation()
@@ -151,18 +104,7 @@ public class Scanner : SingletonMonoBehavior<Scanner>
         lineRenderer.positionCount = 100;
         while (timing < animationDuration)
         {
-            var progress = timing / animationDuration;
-            var randomRange = 0; // (1 - progress) / 10;
-            for (var i = 0; i < 100; i++)
-            {
-                var orthographicSize = game.camera.orthographicSize;
-                lineRenderer.SetPosition(i,
-                    new Vector3(
-                        (-orthographicSize * UnityEngine.Screen.width / UnityEngine.Screen.height + 2f *
-                         orthographicSize * UnityEngine.Screen.width / UnityEngine.Screen.height * (i / 100f)) *
-                        progress,
-                        Random.Range(-randomRange, randomRange)));
-            }
+            ApplyLineGeometry(timing / animationDuration);
 
             yield return null;
             //Continue here next frame
@@ -170,40 +112,120 @@ public class Scanner : SingletonMonoBehavior<Scanner>
         }
 
         StartCoroutine(ResetLine());
+        exited = false;
+        geometryAnimationCoroutine = null;
     }
+
+    public float EffectiveOpacity => exited
+        ? 0
+        : Mathf.Clamp01(opacity * uiEventOpacity * uiEventAnimationOpacity);
+
+    public void SetUiEventState(
+        float targetOpacity,
+        float animationOpacity,
+        ChartUiAnimationKind animationKind,
+        float animationProgress,
+        bool applyPosition = true)
+    {
+        uiEventOpacity = Mathf.Clamp01(targetOpacity);
+        uiEventAnimationOpacity = Mathf.Clamp01(animationOpacity);
+        uiEventAnimationKind = animationKind;
+        uiEventAnimationProgress = Mathf.Clamp01(animationProgress);
+
+        if (uiEventAnimationKind == ChartUiAnimationKind.In)
+        {
+            hasAppliedUiEventAnimation = true;
+            if (uiEventAnimationProgress >= 1) ApplyNormalLineGeometry();
+            else ApplyLineGeometry(uiEventAnimationProgress);
+        }
+        else if (uiEventAnimationKind == ChartUiAnimationKind.Out)
+        {
+            hasAppliedUiEventAnimation = true;
+            ApplyLineGeometry(1 - uiEventAnimationProgress);
+        }
+        else if (hasAppliedUiEventAnimation)
+        {
+            // A backward seek can move before the latest animation snapshot. Restore the stable
+            // geometry once, without overriding the normal system enter animation every frame.
+            ApplyNormalLineGeometry();
+            hasAppliedUiEventAnimation = false;
+        }
+
+        // Storyboard position is updated during onGameLateUpdate. Reapply it here so position,
+        // color and opacity all compose in the same rendered frame.
+        if (applyPosition) ApplyPosition();
+        ApplyVisualState();
+    }
+
+    public void SetUiEventOpacity(float targetOpacity, float animationOpacity)
+    {
+        uiEventOpacity = Mathf.Clamp01(targetOpacity);
+        uiEventAnimationOpacity = Mathf.Clamp01(animationOpacity);
+    }
+
+    public void SetChartEventColor(Color color)
+    {
+        currentColor = color;
+        ApplyVisualState();
+    }
+
+    private void ApplyLineGeometry(float visibleWidth)
+    {
+        visibleWidth = Mathf.Clamp01(visibleWidth);
+        lineRenderer.positionCount = 100;
+        var orthographicSize = game.camera.orthographicSize;
+        var halfWidth = orthographicSize * UnityEngine.Screen.width / UnityEngine.Screen.height;
+        for (var i = 0; i < 100; i++)
+        {
+            var x = (-halfWidth + 2f * halfWidth * (i / 100f)) * visibleWidth;
+            lineRenderer.SetPosition(i, new Vector3(x, 0));
+        }
+        lineRenderer.useWorldSpace = false;
+        lineRenderer.endWidth = 0.05f;
+        lineRenderer.startWidth = 0.05f;
+    }
+
+    private void ApplyNormalLineGeometry()
+    {
+        var halfWidth = game.camera.orthographicSize * UnityEngine.Screen.width / UnityEngine.Screen.height;
+        lineRenderer.positionCount = 2;
+        lineRenderer.SetPosition(0, new Vector3(-halfWidth * 1000f, 0, 0));
+        lineRenderer.SetPosition(1, new Vector3(halfWidth * 1000f, 0, 0));
+        lineRenderer.useWorldSpace = false;
+        lineRenderer.endWidth = 0.05f;
+        lineRenderer.startWidth = 0.05f;
+    }
+
+    private void ApplyVisualState()
+    {
+        var color = colorOverride == Color.clear ? currentColor : colorOverride;
+        color = color.WithAlpha(EffectiveOpacity);
+        lineRenderer.startColor = color;
+        lineRenderer.endColor = color;
+        foreach (var triangle in triangles)
+            if (triangle != null) triangle.ApplyOpacity(EffectiveOpacity);
+    }
+
+    public void RegisterTriangle(MeshTriangle triangle) => triangles.Add(triangle);
+
+    public void UnregisterTriangle(MeshTriangle triangle) => triangles.Remove(triangle);
 
     public void OnGameUpdate(Game game)
     {
-        var chart = game.Chart;
-        
-        // Color
-        Color color;
-        if (colorOverride == Color.clear)
-        {
-            color = gameObject.GetComponent<LineRenderer>().startColor;
-            color = new Color((color.r * colorNextSpeed + colorNext.r) / (1 + colorNextSpeed),
-                (color.g * colorNextSpeed + colorNext.g) / (1 + colorNextSpeed),
-                (color.b * colorNextSpeed + colorNext.b) / (1 + colorNextSpeed));
-        }
-        else
-        {
-            color = colorOverride;
-        }
+        ApplyPosition();
 
-        color = color.WithAlpha(exited ? 0 : opacity);
-        gameObject.GetComponent<LineRenderer>().startColor = color;
-        gameObject.GetComponent<LineRenderer>().endColor = color;
+        // Direction
+    }
 
-        // Position
+    private void ApplyPosition()
+    {
         if (positionOverride != float.MinValue)
         {
             transform.SetY(positionOverride);
         }
         else
         {
-            transform.SetY(chart.GetScannerPositionY(game.Time, game.Config.UseScannerSmoothing));
+            transform.SetY(game.Chart.GetScannerPositionY(game.Time, game.Config.UseScannerSmoothing));
         }
-        
-        // Direction
     }
 }

--- a/engines/unity/Assets/Scripts/Game/Game.cs
+++ b/engines/unity/Assets/Scripts/Game/Game.cs
@@ -27,6 +27,8 @@ public class Game : MonoBehaviour
     public GameState State { get; protected set; }
     public TierPlaySession TierPlaySession { get; private set; }
     public GameRenderer Renderer { get; protected set; }
+    public GameUiEventController UiEventController { get; protected set; }
+    public GameEventPresentationController EventPresentationController { get; protected set; }
 
     public Level Level { get; protected set; }
 
@@ -295,6 +297,8 @@ public class Game : MonoBehaviour
         Context.GameState = State;
 
         Config = new GameConfig(this);
+        UiEventController = new GameUiEventController(this);
+        EventPresentationController = new GameEventPresentationController(this);
 
         // Touch handlers
         if (mode != GameMode.GlobalCalibration && !State.Mods.Contains(Mod.Auto))
@@ -429,15 +433,19 @@ public class Game : MonoBehaviour
             {
                 // Process chart elements
                 while (Chart.CurrentEventId < Chart.Model.event_order_list.Count &&
-                       Chart.Model.event_order_list[Chart.CurrentEventId].time < Time)
+                       Chart.Model.event_order_list[Chart.CurrentEventId].time <= Time)
                 {
-                    if (Chart.Model.event_order_list[Chart.CurrentEventId].event_list[0].type == 0)
+                    var eventList = Chart.Model.event_order_list[Chart.CurrentEventId].event_list;
+                    if (eventList != null)
                     {
-                        onGameSpeedUp.Invoke(this);
-                    }
-                    else
-                    {
-                        onGameSpeedDown.Invoke(this);
+                        foreach (var chartEvent in eventList)
+                        {
+                            if (chartEvent == null) continue;
+                            if (chartEvent.type == (int) ChartEventType.SpeedUp)
+                                onGameSpeedUp.Invoke(this);
+                            else if (chartEvent.type == (int) ChartEventType.SpeedDown)
+                                onGameSpeedDown.Invoke(this);
+                        }
                     }
 
                     Chart.CurrentEventId++;
@@ -482,8 +490,11 @@ public class Game : MonoBehaviour
             }
         }
 
+        UiEventController?.ApplyBeforeGameUpdate(Time);
         onGameUpdate.Invoke(this);
         onGameLateUpdate.Invoke(this);
+        UiEventController?.Apply(Time);
+        EventPresentationController?.Apply(Time);
     }
 
     protected virtual void OnApplicationPause(bool willPause)

--- a/engines/unity/Assets/Scripts/Game/Notes/GameRenderer.cs
+++ b/engines/unity/Assets/Scripts/Game/Notes/GameRenderer.cs
@@ -9,6 +9,9 @@ public class GameRenderer
 
     public float OpacityMultiplier { get; set; } = 1f;
 
+    private float uiEventOpacity = 1f;
+    private float uiEventAnimationOpacity = 1f;
+
     private Image cover;
     private GameObject boundaryTop;
     private GameObject boundaryBottom;
@@ -43,7 +46,7 @@ public class GameRenderer
                 .ForEach(it =>
                 {
                     it.color = it.color.WithAlpha(0);
-                    it.DOFade(BoundaryOpacity, 0.4f);
+                    it.DOFade(BoundaryOpacity * uiEventOpacity * uiEventAnimationOpacity, 0.4f);
                 });
             Game.onTopBoundaryBounded.AddListener(_ => boundaryTopAnimator.Play("BoundaryBound"));
             Game.onBottomBoundaryBounded.AddListener(_ => boundaryBottomAnimator.Play("BoundaryBound"));
@@ -91,6 +94,28 @@ public class GameRenderer
         cover.DOFade(0, 0.8f);
     }
 
+    public void SetUiEventOpacity(float opacity, float animationOpacity)
+    {
+        uiEventOpacity = Mathf.Clamp01(opacity);
+        uiEventAnimationOpacity = Mathf.Clamp01(animationOpacity);
+        ApplyBoundaryOpacity();
+    }
+
+    public void ApplyBoundaryOpacity()
+    {
+        if (boundaryTopSpriteRenderer == null || boundaryBottomSpriteRenderer == null) return;
+        if (!Game.State.IsStarted || Game.State.IsCompleted || Game.State.IsFailed) return;
+        var alpha = ComposeBoundaryOpacity(OpacityMultiplier, uiEventOpacity, uiEventAnimationOpacity);
+        boundaryTopSpriteRenderer.color = boundaryTopSpriteRenderer.color.WithAlpha(alpha);
+        boundaryBottomSpriteRenderer.color = boundaryBottomSpriteRenderer.color.WithAlpha(alpha);
+    }
+
+    public static float ComposeBoundaryOpacity(
+        float storyboardOpacity,
+        float eventOpacity,
+        float animationOpacity) =>
+        BoundaryOpacity * storyboardOpacity * eventOpacity * animationOpacity;
+
     public void OnUpdate()
     {
         if (!Game.IsLoaded) return;
@@ -118,11 +143,7 @@ public class GameRenderer
         }
         if (Game.State.IsStarted && Game.State.IsPlaying && !Game.State.IsCompleted)
         {
-            // Update opacity
-            boundaryTopSpriteRenderer.color =
-                boundaryTopSpriteRenderer.color.WithAlpha(BoundaryOpacity * OpacityMultiplier);
-            boundaryBottomSpriteRenderer.color =
-                boundaryBottomSpriteRenderer.color.WithAlpha(BoundaryOpacity * OpacityMultiplier);
+            ApplyBoundaryOpacity();
         }
     }
     

--- a/engines/unity/Assets/Scripts/Utils/TmpRichTextSanitizer.cs
+++ b/engines/unity/Assets/Scripts/Utils/TmpRichTextSanitizer.cs
@@ -1,0 +1,357 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+
+/// <summary>
+/// Sanitizes untrusted TextMesh Pro rich text while preserving a small formatting whitelist.
+/// Unsupported and malformed tags are removed while their surrounding text is preserved.
+/// </summary>
+public static class TmpRichTextSanitizer
+{
+    public const float DefaultBaseFontSize = 28f;
+    public const float MinFontSize = 8f;
+    public const float MaxFontSize = 72f;
+    public const float MinPercentage = 50f;
+    public const float MaxPercentage = 250f;
+    public const float MinEm = 0.5f;
+    public const float MaxEm = 2.5f;
+    public const int MaxNestingDepth = 8;
+    public const int MaxInputLength = 4096;
+    public const int MaxTextLength = 512;
+
+    private static readonly HashSet<string> SimpleTags = new HashSet<string>(
+        StringComparer.OrdinalIgnoreCase)
+    {
+        "b", "i", "u", "s"
+    };
+
+    private static readonly HashSet<string> NamedColors = new HashSet<string>(
+        StringComparer.OrdinalIgnoreCase)
+    {
+        "red", "green", "blue", "yellow", "orange",
+        "black", "white", "purple", "grey", "lightblue"
+    };
+
+    public static string Sanitize(string input, float baseFontSize = DefaultBaseFontSize)
+    {
+        if (string.IsNullOrEmpty(input)) return string.Empty;
+        if (!IsFinitePositive(baseFontSize)) baseFontSize = DefaultBaseFontSize;
+
+        var inputLength = Math.Min(input.Length, MaxInputLength);
+        if (inputLength > 0 && inputLength < input.Length &&
+            char.IsHighSurrogate(input[inputLength - 1]))
+            inputLength--;
+
+        var output = new StringBuilder(Math.Min(inputLength, MaxTextLength));
+        var openTags = new List<OpenTag>();
+        var emittedDepth = 0;
+        var textLength = 0;
+
+        for (var index = 0; index < inputLength && textLength < MaxTextLength;)
+        {
+            if (input[index] != '<')
+            {
+                AppendTextCharacter(input, ref index, inputLength, output, ref textLength);
+                continue;
+            }
+
+            var endIndex = FindTagEnd(input, index + 1, inputLength);
+            if (endIndex < 0)
+            {
+                index++;
+                continue;
+            }
+
+            var token = input.Substring(index, endIndex - index + 1);
+            index = endIndex + 1;
+            if (!TryReadTag(token, out var isClosing, out var name, out var remainder) ||
+                !IsSupportedTag(name))
+                continue;
+
+            if (isClosing)
+            {
+                if (!string.IsNullOrWhiteSpace(remainder) || openTags.Count == 0 ||
+                    !string.Equals(openTags[openTags.Count - 1].Name, name,
+                        StringComparison.OrdinalIgnoreCase))
+                    continue;
+
+                var openTag = openTags[openTags.Count - 1];
+                openTags.RemoveAt(openTags.Count - 1);
+                if (!openTag.Emitted) continue;
+
+                output.Append("</").Append(openTag.Name).Append('>');
+                emittedDepth--;
+                continue;
+            }
+
+            if (!TryNormalizeOpeningTag(name, remainder, baseFontSize, out var normalizedTag))
+            {
+                // Recognized tag with an invalid value: remove the wrapper while preserving text.
+                openTags.Add(new OpenTag(name, false));
+                continue;
+            }
+
+            if (emittedDepth >= MaxNestingDepth)
+            {
+                openTags.Add(new OpenTag(name, false));
+                continue;
+            }
+
+            output.Append(normalizedTag);
+            openTags.Add(new OpenTag(name, true));
+            emittedDepth++;
+        }
+
+        for (var index = openTags.Count - 1; index >= 0; index--)
+        {
+            if (!openTags[index].Emitted) continue;
+            output.Append("</").Append(openTags[index].Name).Append('>');
+        }
+
+        return output.ToString();
+    }
+
+    private static bool IsSupportedTag(string name) =>
+        SimpleTags.Contains(name) ||
+        string.Equals(name, "size", StringComparison.OrdinalIgnoreCase) ||
+        string.Equals(name, "color", StringComparison.OrdinalIgnoreCase);
+
+    private static bool TryNormalizeOpeningTag(
+        string name,
+        string remainder,
+        float baseFontSize,
+        out string normalizedTag)
+    {
+        var normalizedName = name.ToLowerInvariant();
+        if (SimpleTags.Contains(normalizedName))
+        {
+            normalizedTag = $"<{normalizedName}>";
+            return string.IsNullOrWhiteSpace(remainder);
+        }
+
+        if (!TryReadValue(remainder, out var value))
+        {
+            normalizedTag = string.Empty;
+            return false;
+        }
+
+        if (normalizedName == "color")
+        {
+            if (!IsColor(value))
+            {
+                normalizedTag = string.Empty;
+                return false;
+            }
+
+            normalizedTag = $"<color={value}>";
+            return true;
+        }
+
+        if (!TryResolveFontSize(value, baseFontSize, out var fontSize))
+        {
+            normalizedTag = string.Empty;
+            return false;
+        }
+
+        normalizedTag = $"<size={fontSize.ToString("0.###", CultureInfo.InvariantCulture)}>";
+        return true;
+    }
+
+    private static bool TryResolveFontSize(string value, float baseFontSize, out float fontSize)
+    {
+        var unit = SizeUnit.Pixels;
+        var numberText = value;
+        if (value.EndsWith("%", StringComparison.Ordinal))
+        {
+            unit = SizeUnit.Percentage;
+            numberText = value.Substring(0, value.Length - 1);
+        }
+        else if (value.EndsWith("em", StringComparison.OrdinalIgnoreCase))
+        {
+            unit = SizeUnit.Em;
+            numberText = value.Substring(0, value.Length - 2);
+        }
+
+        if (!float.TryParse(numberText, NumberStyles.Float, CultureInfo.InvariantCulture,
+                out var number) || !IsFinitePositive(Math.Abs(number)))
+        {
+            fontSize = 0;
+            return false;
+        }
+
+        switch (unit)
+        {
+            case SizeUnit.Percentage:
+                if (number <= 0)
+                {
+                    fontSize = 0;
+                    return false;
+                }
+                number = Clamp(number, MinPercentage, MaxPercentage);
+                fontSize = baseFontSize * number / 100f;
+                break;
+            case SizeUnit.Em:
+                if (number <= 0)
+                {
+                    fontSize = 0;
+                    return false;
+                }
+                number = Clamp(number, MinEm, MaxEm);
+                fontSize = baseFontSize * number;
+                break;
+            default:
+                fontSize = numberText.StartsWith("+", StringComparison.Ordinal) ||
+                           numberText.StartsWith("-", StringComparison.Ordinal)
+                    ? baseFontSize + number
+                    : number;
+                if (fontSize <= 0) return false;
+                break;
+        }
+
+        fontSize = Clamp(fontSize, MinFontSize, MaxFontSize);
+        return true;
+    }
+
+    private static bool TryReadValue(string remainder, out string value)
+    {
+        remainder = remainder.Trim();
+        if (remainder.Length < 2 || remainder[0] != '=')
+        {
+            value = string.Empty;
+            return false;
+        }
+
+        remainder = remainder.Substring(1).Trim();
+        if (remainder.Length == 0)
+        {
+            value = string.Empty;
+            return false;
+        }
+
+        if (remainder[0] == '"' || remainder[0] == '\'')
+        {
+            var quote = remainder[0];
+            if (remainder.Length < 3 || remainder[remainder.Length - 1] != quote)
+            {
+                value = string.Empty;
+                return false;
+            }
+            value = remainder.Substring(1, remainder.Length - 2);
+        }
+        else
+        {
+            value = remainder;
+        }
+
+        return value.Length > 0 && value.IndexOfAny(new[] {' ', '\t', '\r', '\n'}) < 0;
+    }
+
+    private static bool IsColor(string value)
+    {
+        if (NamedColors.Contains(value)) return true;
+        if (value.Length != 4 && value.Length != 5 && value.Length != 7 && value.Length != 9)
+            return false;
+        if (value[0] != '#') return false;
+        for (var index = 1; index < value.Length; index++)
+        {
+            var c = value[index];
+            if (!((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f') ||
+                  (c >= 'A' && c <= 'F'))) return false;
+        }
+        return true;
+    }
+
+    private static bool TryReadTag(
+        string token,
+        out bool isClosing,
+        out string name,
+        out string remainder)
+    {
+        var content = token.Substring(1, token.Length - 2).Trim();
+        isClosing = content.StartsWith("/", StringComparison.Ordinal);
+        if (isClosing) content = content.Substring(1).TrimStart();
+
+        var nameLength = 0;
+        while (nameLength < content.Length &&
+               (char.IsLetter(content[nameLength]) || content[nameLength] == '-'))
+            nameLength++;
+
+        if (nameLength == 0)
+        {
+            name = string.Empty;
+            remainder = string.Empty;
+            return false;
+        }
+
+        name = content.Substring(0, nameLength).ToLowerInvariant();
+        remainder = content.Substring(nameLength);
+        return true;
+    }
+
+    private static int FindTagEnd(string input, int startIndex, int inputLength)
+    {
+        var quote = '\0';
+        for (var index = startIndex; index < inputLength; index++)
+        {
+            var c = input[index];
+            if (quote != '\0')
+            {
+                if (c == quote) quote = '\0';
+                continue;
+            }
+            if (c == '"' || c == '\'') quote = c;
+            else if (c == '>') return index;
+        }
+        return -1;
+    }
+
+    private static void AppendTextCharacter(
+        string input,
+        ref int index,
+        int inputLength,
+        StringBuilder output,
+        ref int textLength)
+    {
+        if (char.IsHighSurrogate(input[index]) && index + 1 < inputLength &&
+            char.IsLowSurrogate(input[index + 1]))
+        {
+            if (textLength + 2 > MaxTextLength)
+            {
+                textLength = MaxTextLength;
+                return;
+            }
+            output.Append(input[index++]).Append(input[index++]);
+            textLength += 2;
+            return;
+        }
+
+        output.Append(input[index++]);
+        textLength++;
+    }
+
+    private static bool IsFinitePositive(float value) =>
+        value > 0 && !float.IsNaN(value) && !float.IsInfinity(value);
+
+    private static float Clamp(float value, float min, float max) =>
+        Math.Max(min, Math.Min(max, value));
+
+    private readonly struct OpenTag
+    {
+        public string Name { get; }
+        public bool Emitted { get; }
+
+        public OpenTag(string name, bool emitted)
+        {
+            Name = name;
+            Emitted = emitted;
+        }
+    }
+
+    private enum SizeUnit
+    {
+        Pixels,
+        Percentage,
+        Em
+    }
+}

--- a/engines/unity/Assets/Scripts/Utils/TmpRichTextSanitizer.cs.meta
+++ b/engines/unity/Assets/Scripts/Utils/TmpRichTextSanitizer.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 72655bf044064fca8bfa5e2e1410e078
+guid: 2e365d196a9b4695991be975af6637e9
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2


### PR DESCRIPTION
## Summary

Port of Cytoid-private#43 (`codex/ui-events`).

- Add C2 UI event support for show, hide, fade, and target-specific enter/exit animations
- Map song title and difficulty together to Cytoid's left UI while keeping right UI independent
- Add seek-safe type 0/1/8 presentation tracks for localized speed messages, custom text, and scanline colors
- Preserve storyboard composition and silently ignore the unsupported spectrum target

## Behavior

Custom message events parse `content,#RRGGBB`, use the event color for text and scanline presentation, and fall back to white with a warning for invalid colors. Speed colors remain Cytoid's existing colors. Text keeps Cytoid's fade timing; speed-up expands with OutCirc, speed-down contracts with OutCirc, and custom text uses an independent EaseInQuint spacing curve. Scanline color transitions are deterministic across interruptions, seeks, `StartAt`, and playback loops.

## Adaptations for this fork

| File | Reason | Handling |
|---|---|---|
| `GameTooltipText.cs` | CRLF/LF line-ending mismatch vs upstream | Full rewrite preserving LF; identical logic |
| `Game.cs` | Fork has an extra `TierPlaySession` property between `State` and `Renderer` | Three targeted edits; `TierPlaySession` preserved |
| `PlayerGame.cs` | File absent in fork (Player/seek features removed); no callers among new code | Skipped |

## Validation

Unity 6000.0.75f1 EditMode batchmode (`-runTests -testPlatform EditMode`):

```
exit-code: 0
test-run result=Passed total=25 passed=25 failed=0 skipped=0 inconclusive=0 duration=0.294s
```

New suites all green: `ChartEventPresentationTimelineTests`, `ChartUiEventTimelineTests`, `UiEventRuntimeTests`. No compile errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added chart-authored UI events for visibility, fades, slides, animations, scanner opacity, and boundary effects.
  * Added timed chart messages, speed changes, colors, fades, and letter-spacing animations.
  * Added support for charts starting without UI elements.
  * Added safe formatting for supported tooltip rich text.

* **Bug Fixes**
  * Improved seeking, event ordering, interrupted animations, and opacity/color composition.
  * Ensured scanner geometry, tooltip state, and active messages clear correctly during transitions and game exit.

* **Tests**
  * Added comprehensive coverage for timelines, UI animations, seeking, scanner behavior, opacity, colors, tooltips, and rich text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->