### PR TITLE
fix(gameplay): initialize long hold scale on immediate trigger

### DIFF
--- a/engines/unity/Assets/Scripts/Game/Notes/Classic/ClassicHoldNoteRenderer.cs
+++ b/engines/unity/Assets/Scripts/Game/Notes/Classic/ClassicHoldNoteRenderer.cs
@@ -12,6 +12,7 @@ public class ClassicHoldNoteRenderer : ClassicNoteRenderer
     public ParticleSystem HoldFx;
     protected SpriteMask SpriteMask;
     protected Vector3 InitialProgressRingScale;
+    private bool hasReachedFullScale;
 
     public ClassicHoldNoteRenderer(HoldNote holdNote) : base(holdNote)
     {
@@ -48,6 +49,7 @@ public class ClassicHoldNoteRenderer : ClassicNoteRenderer
     public override void OnNoteLoaded()
     {
         base.OnNoteLoaded();
+        hasReachedFullScale = false;
         Triangle.gameObject.SetActive(true);
         Triangle.Note = Note;
         ProgressRing.spriteRenderer.enabled = true;
@@ -62,6 +64,7 @@ public class ClassicHoldNoteRenderer : ClassicNoteRenderer
     public override void OnCollect()
     {
         base.OnCollect();
+        hasReachedFullScale = false;
         ProgressRing.Reset();
         Triangle.Reset();
         Triangle.gameObject.SetActive(false);
@@ -201,7 +204,10 @@ public class ClassicHoldNoteRenderer : ClassicNoteRenderer
 
     protected override void UpdateTransformScale()
     {
-        if (Game.Time > Note.Model.start_time) return; // Already scaled to maximum TODO: size_multiplier no longer works?
+        // A note can be spawned and held after its start time in the same frame. In
+        // that case it has never passed through the intro animation, so apply the
+        // final scale once before leaving the transform to the holding animation.
+        if (hasReachedFullScale) return;
 
         var scale = BaseTransformScale * Note.Model.Override.SizeMultiplier;
         var newProgressRingScale = InitialProgressRingScale * scale;
@@ -209,6 +215,7 @@ public class ClassicHoldNoteRenderer : ClassicNoteRenderer
         
         // Scale the entire transform
         var timeScale = Mathf.Clamp((Game.Time - Note.Model.intro_time) / (Note.Model.start_time - Note.Model.intro_time), 0f, 1f);
+        hasReachedFullScale = timeScale >= 1f;
 
         var size = BaseTransformSize * Note.Model.Override.SizeMultiplier;
         var minPercentageSize = Note.Model.initial_scale;

--- a/engines/unity/Assets/Scripts/Game/Notes/Classic/ClassicHoldNoteRenderer.cs
+++ b/engines/unity/Assets/Scripts/Game/Notes/Classic/ClassicHoldNoteRenderer.cs
@@ -3,6 +3,8 @@ using UnityEngine;
 
 public class ClassicHoldNoteRenderer : ClassicNoteRenderer
 {
+    private const float ExperimentalHoldingScale = 0.85f;
+
     public HoldNote HoldNote => (HoldNote) Note; 
 
     public SpriteRenderer Line;
@@ -12,6 +14,7 @@ public class ClassicHoldNoteRenderer : ClassicNoteRenderer
     public ParticleSystem HoldFx;
     protected SpriteMask SpriteMask;
     protected Vector3 InitialProgressRingScale;
+    private bool hasAppliedTransformScale;
     private bool hasReachedFullScale;
 
     public ClassicHoldNoteRenderer(HoldNote holdNote) : base(holdNote)
@@ -49,6 +52,7 @@ public class ClassicHoldNoteRenderer : ClassicNoteRenderer
     public override void OnNoteLoaded()
     {
         base.OnNoteLoaded();
+        hasAppliedTransformScale = false;
         hasReachedFullScale = false;
         Triangle.gameObject.SetActive(true);
         Triangle.Note = Note;
@@ -64,6 +68,7 @@ public class ClassicHoldNoteRenderer : ClassicNoteRenderer
     public override void OnCollect()
     {
         base.OnCollect();
+        hasAppliedTransformScale = false;
         hasReachedFullScale = false;
         ProgressRing.Reset();
         Triangle.Reset();
@@ -73,6 +78,14 @@ public class ClassicHoldNoteRenderer : ClassicNoteRenderer
 
     protected override void UpdateComponentStates()
     {
+        if (!hasAppliedTransformScale && UseExperimentalAnimations && HoldNote.IsHolding &&
+            Note.Game.Time >= Note.Model.start_time &&
+            Note.Game.Time > Note.Model.start_time + Note.JudgmentOffset)
+        {
+            ApplyTransformScale(1f, ExperimentalHoldingScale);
+            hasReachedFullScale = true;
+        }
+
         base.UpdateComponentStates();
         if (!Note.IsCleared && Game.Time >= Note.Model.intro_time + Note.JudgmentOffset && Game.Time <= Note.Model.end_time + Note.MissThreshold + Note.JudgmentOffset)
         {
@@ -124,9 +137,9 @@ public class ClassicHoldNoteRenderer : ClassicNoteRenderer
                         if (UseExperimentalAnimations)
                         {
                             var size = BaseTransformSize * Note.Model.Override.SizeMultiplier;
-                            Ring.transform.DOScale(size * 0.85f, 0.2f);
-                            Fill.transform.DOScale(size * 0.85f, 0.2f);
-                            SpriteMask.transform.DOScale(size * 0.85f, 0.2f);
+                            Ring.transform.DOScale(size * ExperimentalHoldingScale, 0.2f);
+                            Fill.transform.DOScale(size * ExperimentalHoldingScale, 0.2f);
+                            SpriteMask.transform.DOScale(size * ExperimentalHoldingScale, 0.2f);
                         }
                         
                         if (Game.State.IsPlaying && !HoldFx.isPlaying)
@@ -209,17 +222,20 @@ public class ClassicHoldNoteRenderer : ClassicNoteRenderer
         // final scale once before leaving the transform to the holding animation.
         if (hasReachedFullScale) return;
 
+        var timeScale = Mathf.Clamp((Game.Time - Note.Model.intro_time) / (Note.Model.start_time - Note.Model.intro_time), 0f, 1f);
+        ApplyTransformScale(timeScale);
+        hasReachedFullScale = timeScale >= 1f;
+    }
+
+    private void ApplyTransformScale(float timeScale, float holdingScale = 1f)
+    {
         var scale = BaseTransformScale * Note.Model.Override.SizeMultiplier;
         var newProgressRingScale = InitialProgressRingScale * scale;
         ProgressRing.transform.SetLocalScaleXY(newProgressRingScale.x, newProgressRingScale.y);
-        
-        // Scale the entire transform
-        var timeScale = Mathf.Clamp((Game.Time - Note.Model.intro_time) / (Note.Model.start_time - Note.Model.intro_time), 0f, 1f);
-        hasReachedFullScale = timeScale >= 1f;
 
         var size = BaseTransformSize * Note.Model.Override.SizeMultiplier;
         var minPercentageSize = Note.Model.initial_scale;
-        var timeScaledSize = size * minPercentageSize + size * (1 - minPercentageSize) * timeScale;
+        var timeScaledSize = (size * minPercentageSize + size * (1 - minPercentageSize) * timeScale) * holdingScale;
         const float minPercentageLineSize = 0.0f;
         
         Ring.transform.SetLocalScaleXY(timeScaledSize, timeScaledSize);
@@ -236,6 +252,7 @@ public class ClassicHoldNoteRenderer : ClassicNoteRenderer
             fxScale *= (float) Note.Model.size;
         }
         HoldFx.transform.SetLocalScale(5 * (1 + Context.Player.Settings.ClearEffectsSize) * fxScale);
+        hasAppliedTransformScale = true;
     }
 
     protected override void UpdateFillScale()


### PR DESCRIPTION
## What changed

- Track whether hold-note visuals have actually reached their full scale.
- When a hold is first rendered at or after its start time, apply the final scale once before handing control to the holding animation.
- Reset the scale-initialized state when pooled notes are loaded or collected.
- Extract `ApplyTransformScale(timeScale, holdingScale)` and call it from `UpdateComponentStates` so experimental-animations holds that spawn late also get the correct base scale before the `DOScale` tween runs.
- Replace the `0.85f` literal with a named `ExperimentalHoldingScale` const.

## Why

A long hold could appear and be triggered in the same frame. The renderer previously returned immediately once game time had passed the note start time, assuming the intro animation had already initialized every visual. In this timing edge case, the note body and progress ring remained at their prefab/intermediate scale, making the note look too small and the hold progress ring effectively invisible. The same class of bug also affected the experimental-animations tween, which animated from the wrong base size when the hold spawned late.

## Impact

Immediately triggered long holds now initialize the note body, mask, line width, effects, and progress ring at the correct size while preserving the existing holding animation — both with and without experimental animations.

## Validation

- Unity 6000.0.75f1 batchmode compile check on `engines/unity/` after each commit — exit 0, no `error CS` and no warnings on the touched file.
- Diff matches upstream Cytoid-private PR #45 byte-for-byte modulo the `engines/unity/` path prefix. Commit 1 `+9 / −2`, commit 2 `+25 / −8` (combined `+33 / −9`).

## Origin

Ported from Cytoid-private PR [#45](https://github.com/Cytoid/Cytoid-private/pull/45) (`codex/fix-long-hold-initial-scale`):
- commit 1 `88b0fde` → `5d8eae4` "initialize long hold scale on immediate trigger"
- commit 2 `9a2b47e` → `a2b2ef6` "apply scale on late-spawn hold tween"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved hold-note scaling during gameplay for smoother, more consistent visuals.
  * Hold notes now reach and maintain their intended final size correctly.
  * Corrected scaling for notes that appear after their scheduled start time.
  * Prevented unnecessary repeated scaling updates during note interactions.
  * Scaling state now resets correctly when notes are loaded or collected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->