### PR TITLE
fix(gameplay): defer passive drag judgments

### DIFF
--- a/engines/unity/Assets/Scripts/Game/InputController.cs
+++ b/engines/unity/Assets/Scripts/Game/InputController.cs
@@ -15,7 +15,7 @@ public class InputController : MonoBehaviour
     public const float NoteClusterGapSeconds = 0.015f;
 
     /// <summary>
-    /// After a non-Miss Drag clears on the same FingerDown, block Click / CDrag head /
+    /// After a non-Miss Drag is accepted on the same FingerDown, block Click / CDrag head /
     /// Hold / Flick whose <c>effectiveNoteTime</c> is more than this many seconds later.
     /// Earlier or within-window selects stay eligible.
     /// Wider than <see cref="NoteClusterGapSeconds"/> (30ms vs 15ms) so short Drag+tap
@@ -91,7 +91,7 @@ public class InputController : MonoBehaviour
         foreach (var id in game.SpawnedNotes.Keys)
         {
             var note = game.SpawnedNotes[id];
-            if (!note.HasEmerged || note.IsCleared || note.IsCollected) continue;
+            if (!note.HasEmerged || note.IsCleared || note.IsArmed || note.IsCollected) continue;
 
             if (note.Type == NoteType.DragHead || note.Type == NoteType.DragChild || note.Type == NoteType.CDragChild || note.Type == NoteType.DropDrag)
             {
@@ -118,26 +118,61 @@ public class InputController : MonoBehaviour
             ? game.camera.ScreenToWorldPoint(finger.ScreenPosition)
             : game.camera.ScreenToWorldPoint(new Vector3(finger.ScreenPosition.x, finger.ScreenPosition.y, 10));
 
-        // Drag clears first (settlement order) but does not consume the Down for select.
-        // Arm DragCoHit only on a real hit grade — TryClear also returns true on Miss.
-        Note acceptedDrag = null;
+        // Pick a Drag without settling it yet: whether it clears immediately or arms
+        // depends on whether a higher-priority Select candidate claims this fresh Down.
+        var acceptedDrag = FindAcceptedDrag(pressedPosition);
+
+        // Select is still gated by the accepted Drag before either candidate settles,
+        // preserving DragCoHit and cross-page suppression without changing event order.
+        var acceptedSelect = FindAcceptedSelect(finger, pressedPosition, acceptedDrag);
+
+        if (acceptedDrag != null)
+        {
+            if (acceptedSelect != null)
+            {
+                acceptedDrag.OnTouchDeferred(finger.ScreenPosition);
+            }
+            else
+            {
+                acceptedDrag.OnTouch(finger.ScreenPosition);
+            }
+        }
+
+        AcceptSelect(acceptedSelect, finger, pressedPosition);
+    }
+
+    /// <summary>
+    /// Returns the first valid non-Miss Drag in list order. Expired Drag notes retain
+    /// their legacy immediate Miss settlement and do not arm DragCoHit.
+    /// </summary>
+    private Note FindAcceptedDrag(Vector2 pressedPosition)
+    {
         foreach (var note in TouchableDragNotes)
         {
             if (!IsTouchableNote(note)) continue;
             if (!note.DoesCollide(pressedPosition)) continue;
+            if (!note.CanHandleTouch(pressedPosition)) continue;
 
-            // Snapshot before OnTouch: ShouldMiss/CalculateGrade Miss both Clear(Miss) via TryClear.
-            var preTouchGrade = note.ShouldMiss() ? NoteGrade.Miss : note.CalculateGrade();
-            if (!note.OnTouch(finger.ScreenPosition)) continue;
-            if (preTouchGrade == NoteGrade.Miss)
+            var grade = note.GetTouchGrade();
+            if (grade == NoteGrade.None) continue;
+            if (grade == NoteGrade.Miss)
             {
-                // Miss on this Down must not arm DragCoHit (would block later select).
+                note.Clear(NoteGrade.Miss);
                 continue;
             }
 
-            acceptedDrag = note;
-            break;
+            return note;
         }
+        return null;
+    }
+
+    /// <summary>
+    /// Chooses, but does not settle, the Select note that would consume this Down.
+    /// This lets Drag decide Immediate versus Armed while keeping Drag settlement first.
+    /// </summary>
+    private Note FindAcceptedSelect(GameFinger finger, Vector2 pressedPosition, Note acceptedDrag)
+    {
+        if (!game.IsLoaded || !game.State.IsPlaying) return null;
 
         // Select in SpawnedNotes id order (TouchableSelectNotes).
         // Flick: list-order bind; flush earlier Click/Hold cluster first (even if Flick is
@@ -151,14 +186,13 @@ public class InputController : MonoBehaviour
 
             if (note is FlickNote flickNote)
             {
-                if (TryAcceptSelectClickCluster(finger, pressedPosition.x)) return;
+                var clusterCandidate = FindSelectClickCluster(pressedPosition.x, pressedPosition);
+                if (clusterCandidate != null) return clusterCandidate;
 
                 if (FlickingNotes.ContainsKey(finger.Index) || FlickingNotes.ContainsValue(flickNote))
                     continue;
                 if (!IsEligibleSelectAfterDrag(flickNote, acceptedDrag)) continue;
-                FlickingNotes.Add(finger.Index, flickNote);
-                flickNote.StartFlicking(pressedPosition);
-                return;
+                return flickNote;
             }
 
             if (note is HoldNote holdNote)
@@ -174,7 +208,7 @@ public class InputController : MonoBehaviour
             hitCandidates.Add(note);
         }
 
-        TryAcceptSelectClickCluster(finger, pressedPosition.x);
+        return FindSelectClickCluster(pressedPosition.x, pressedPosition);
     }
 
     /// <summary>
@@ -182,7 +216,7 @@ public class InputController : MonoBehaviour
     /// Gate before touching Model or colliders.
     /// </summary>
     private static bool IsTouchableNote(Note note) =>
-        note != null && !note.IsCollected && !note.IsCleared;
+        note != null && !note.IsCollected && !note.IsCleared && !note.IsArmed;
 
     /// <summary>
     /// Same-Down select gate after an optional accepted Drag.
@@ -208,39 +242,62 @@ public class InputController : MonoBehaviour
     }
 
     /// <summary>
-    /// Accept one Click / CDrag-head / Hold from <see cref="hitCandidates"/> using
-    /// <see cref="OrderHitCandidatesByNoteTimeClusters"/>. Hold binds and consumes Down.
+    /// Finds one Click / CDrag-head / Hold from <see cref="hitCandidates"/> using
+    /// <see cref="OrderHitCandidatesByNoteTimeClusters"/> without settling it.
     /// </summary>
-    private bool TryAcceptSelectClickCluster(GameFinger finger, float touchWorldX)
+    private Note FindSelectClickCluster(float touchWorldX, Vector2 pressedPosition)
     {
-        if (hitCandidates.Count == 0) return false;
+        if (hitCandidates.Count == 0) return null;
         if (!game.IsLoaded || !game.State.IsPlaying)
         {
             hitCandidates.Clear();
-            return false;
+            return null;
         }
 
+        Note accepted = null;
         foreach (var note in OrderHitCandidatesByNoteTimeClusters(touchWorldX))
         {
             if (!IsTouchableNote(note)) continue;
 
             if (note is HoldNote holdNote)
             {
-                // Reject holds already bound this frame (stale snapshot).
-                if (holdNote.IsHolding || HoldingNotes.ContainsKey(finger.Index)) continue;
-                HoldingNotes.Add(finger.Index, holdNote);
-                holdNote.UpdateFinger(finger.Index, true);
-                hitCandidates.Clear();
-                return true;
+                if (holdNote.IsHolding) continue;
+                accepted = holdNote;
+                break;
             }
 
-            if (!note.OnTouch(finger.ScreenPosition)) continue;
-            hitCandidates.Clear();
-            return true;
+            if (!note.CanHandleTouch(pressedPosition)) continue;
+            if (note.GetTouchGrade() == NoteGrade.None) continue;
+            accepted = note;
+            break;
         }
 
         hitCandidates.Clear();
-        return false;
+        return accepted;
+    }
+
+    /// <summary>Settles the previously selected candidate.</summary>
+    private bool AcceptSelect(Note note, GameFinger finger, Vector2 pressedPosition)
+    {
+        if (!IsTouchableNote(note) || !game.IsLoaded || !game.State.IsPlaying) return false;
+
+        if (note is FlickNote flickNote)
+        {
+            if (FlickingNotes.ContainsKey(finger.Index) || FlickingNotes.ContainsValue(flickNote)) return false;
+            FlickingNotes.Add(finger.Index, flickNote);
+            flickNote.StartFlicking(pressedPosition);
+            return true;
+        }
+
+        if (note is HoldNote holdNote)
+        {
+            if (holdNote.IsHolding || HoldingNotes.ContainsKey(finger.Index)) return false;
+            HoldingNotes.Add(finger.Index, holdNote);
+            holdNote.UpdateFinger(finger.Index, true);
+            return true;
+        }
+
+        return note.OnTouch(finger.ScreenPosition);
     }
 
     protected virtual void OnFingerUpdate(GameFinger finger)
@@ -262,7 +319,7 @@ public class InputController : MonoBehaviour
         {
             if (!IsTouchableNote(note)) continue;
             if (!note.DoesCollide(pos)) continue;
-            if (!note.OnTouch(finger.ScreenPosition)) continue;
+            if (!note.OnTouchDeferred(finger.ScreenPosition)) continue;
             break;
         }
 

--- a/engines/unity/Assets/Scripts/Game/InputController.cs
+++ b/engines/unity/Assets/Scripts/Game/InputController.cs
@@ -151,7 +151,7 @@ public class InputController : MonoBehaviour
         {
             if (!IsTouchableNote(note)) continue;
             if (!note.DoesCollide(pressedPosition)) continue;
-            if (!note.CanHandleTouch(pressedPosition)) continue;
+            if (!note.CanHandleTouch()) continue;
 
             var grade = note.GetTouchGrade();
             if (grade == NoteGrade.None) continue;
@@ -266,7 +266,7 @@ public class InputController : MonoBehaviour
                 break;
             }
 
-            if (!note.CanHandleTouch(pressedPosition)) continue;
+            if (!note.CanHandleTouch()) continue;
             if (note.GetTouchGrade() == NoteGrade.None) continue;
             accepted = note;
             break;

--- a/engines/unity/Assets/Scripts/Game/Notes/DragChildNote.cs
+++ b/engines/unity/Assets/Scripts/Game/Notes/DragChildNote.cs
@@ -12,13 +12,14 @@ public class DragChildNote : Note
             : throw new NotSupportedException();
     }
 
-    public override bool OnTouch(Vector2 screenPos)
+    public override bool CanHandleTouch(Vector2 screenPos)
     {
+        if (!base.CanHandleTouch(screenPos)) return false;
         // Do not handle touch event if touched too ahead of scanner
         if (Model.start_time - Game.Time > 0.31f) return false;
         // Do not handle touch event if in a later page, unless the timing is close (half a screen)
         if (Model.page_index > Game.Chart.CurrentPageId && Model.start_time - Game.Time > Page.Duration / 2f) return false;
-        return base.OnTouch(screenPos);
+        return true;
     }
 
     public override NoteGrade CalculateGrade()

--- a/engines/unity/Assets/Scripts/Game/Notes/DragChildNote.cs
+++ b/engines/unity/Assets/Scripts/Game/Notes/DragChildNote.cs
@@ -12,9 +12,9 @@ public class DragChildNote : Note
             : throw new NotSupportedException();
     }
 
-    public override bool CanHandleTouch(Vector2 screenPos)
+    public override bool CanHandleTouch()
     {
-        if (!base.CanHandleTouch(screenPos)) return false;
+        if (!base.CanHandleTouch()) return false;
         // Do not handle touch event if touched too ahead of scanner
         if (Model.start_time - Game.Time > 0.31f) return false;
         // Do not handle touch event if in a later page, unless the timing is close (half a screen)

--- a/engines/unity/Assets/Scripts/Game/Notes/DragHeadNote.cs
+++ b/engines/unity/Assets/Scripts/Game/Notes/DragHeadNote.cs
@@ -162,15 +162,16 @@ public class DragHeadNote : Note
         }
     }
 
-    // SYNC-WARNING: DropDrag judgment is a verbatim copy of DragHeadNote's OnTouch, CalculateGrade,
+    // SYNC-WARNING: DropDrag judgment is a verbatim copy of DragHeadNote's CanHandleTouch, CalculateGrade,
     // IsAutoEnabled, and PlayHitSound (DragHeadNote.cs:165-252). If you change judgment in either
     // file, update the other. DragHead chain logic (OnGameLateUpdate, Collect, FromNoteModel/ToNoteModel)
     // is INTENTIONALLY NOT inherited — DropDrag is standalone per design decision.
     // NOTE: DragHead's cross-page check is redundant for drop notes (5×pageDuration >> Page.Duration/2
     // always, so the 0.31s check dominates) — safe to copy verbatim, do not remove.
     // Mirror: Assets/Scripts/Game/Notes/Drop/DropDragNote.cs
-    public override bool OnTouch(Vector2 screenPos)
+    public override bool CanHandleTouch(Vector2 screenPos)
     {
+        if (!base.CanHandleTouch(screenPos)) return false;
         if (!IsCDrag)
         {
             // Do not handle touch event if touched too ahead of scanner
@@ -179,7 +180,7 @@ public class DragHeadNote : Note
             if (Model.page_index > Game.Chart.CurrentPageId &&
                 Model.start_time - Game.Time > Page.Duration / 2f) return false;
         }
-        return base.OnTouch(screenPos);
+        return true;
     }
 
     public override async void Collect()

--- a/engines/unity/Assets/Scripts/Game/Notes/DragHeadNote.cs
+++ b/engines/unity/Assets/Scripts/Game/Notes/DragHeadNote.cs
@@ -169,9 +169,9 @@ public class DragHeadNote : Note
     // NOTE: DragHead's cross-page check is redundant for drop notes (5×pageDuration >> Page.Duration/2
     // always, so the 0.31s check dominates) — safe to copy verbatim, do not remove.
     // Mirror: Assets/Scripts/Game/Notes/Drop/DropDragNote.cs
-    public override bool CanHandleTouch(Vector2 screenPos)
+    public override bool CanHandleTouch()
     {
-        if (!base.CanHandleTouch(screenPos)) return false;
+        if (!base.CanHandleTouch()) return false;
         if (!IsCDrag)
         {
             // Do not handle touch event if touched too ahead of scanner

--- a/engines/unity/Assets/Scripts/Game/Notes/Drop/DropDragNote.cs
+++ b/engines/unity/Assets/Scripts/Game/Notes/Drop/DropDragNote.cs
@@ -1,6 +1,6 @@
 using UnityEngine;
 
-// SYNC-WARNING: DropDrag judgment is a verbatim copy of DragHeadNote's OnTouch, CalculateGrade,
+// SYNC-WARNING: DropDrag judgment is a verbatim copy of DragHeadNote's CanHandleTouch, CalculateGrade,
 // IsAutoEnabled, and PlayHitSound (DragHeadNote.cs:165-252). If you change judgment in either
 // file, update the other. DragHead chain logic (OnGameLateUpdate, Collect, FromNoteModel/ToNoteModel)
 // is INTENTIONALLY NOT inherited — DropDrag is standalone per design decision.
@@ -13,14 +13,15 @@ public class DropDragNote : Note
         return new DropDragNoteRenderer(this);
     }
 
-    public override bool OnTouch(Vector2 screenPos)
+    public override bool CanHandleTouch(Vector2 screenPos)
     {
+        if (!base.CanHandleTouch(screenPos)) return false;
         // Do not handle touch event if touched too ahead of scanner
         if (Model.start_time - Game.Time > 0.31f) return false;
         // Do not handle touch event if in a later page, unless the timing is close (half a screen) TODO: Fix inaccurate algorithm
         if (Model.page_index > Game.Chart.CurrentPageId &&
             Model.start_time - Game.Time > Page.Duration / 2f) return false;
-        return base.OnTouch(screenPos);
+        return true;
     }
 
     public override NoteGrade CalculateGrade()

--- a/engines/unity/Assets/Scripts/Game/Notes/Drop/DropDragNote.cs
+++ b/engines/unity/Assets/Scripts/Game/Notes/Drop/DropDragNote.cs
@@ -13,9 +13,9 @@ public class DropDragNote : Note
         return new DropDragNoteRenderer(this);
     }
 
-    public override bool CanHandleTouch(Vector2 screenPos)
+    public override bool CanHandleTouch()
     {
-        if (!base.CanHandleTouch(screenPos)) return false;
+        if (!base.CanHandleTouch()) return false;
         // Do not handle touch event if touched too ahead of scanner
         if (Model.start_time - Game.Time > 0.31f) return false;
         // Do not handle touch event if in a later page, unless the timing is close (half a screen) TODO: Fix inaccurate algorithm

--- a/engines/unity/Assets/Scripts/Game/Notes/Note.cs
+++ b/engines/unity/Assets/Scripts/Game/Notes/Note.cs
@@ -26,6 +26,7 @@ public abstract class Note : MonoBehaviour
 
     public bool IsCleared { get; private set; }
     public bool IsArmed { get; private set; }
+    private NoteGrade armedGrade = NoteGrade.None;
 
     // For ranked mode: weighted difference between the current timing and the perfect timing
     public float GreatGradeWeight { get; protected set; }
@@ -49,6 +50,7 @@ public abstract class Note : MonoBehaviour
     {
         IsCollected = false;
         IsArmed = false;
+        armedGrade = NoteGrade.None;
     
         Chart = Game.Chart.Model;
         Model = Game.Chart.Model.note_map[noteId];
@@ -92,6 +94,7 @@ public abstract class Note : MonoBehaviour
         MissThreshold = default;
         IsCleared = default;
         IsArmed = default;
+        armedGrade = NoteGrade.None;
         GreatGradeWeight = default;
         JudgmentOffset = default;
     }
@@ -101,6 +104,7 @@ public abstract class Note : MonoBehaviour
         if (IsCleared) return;
 
         IsArmed = false;
+        armedGrade = NoteGrade.None;
         IsCleared = true;
         Renderer.OnClear(grade);
         Game.State.Judge(this, grade, -TimeUntilEnd, GreatGradeWeight);
@@ -136,7 +140,7 @@ public abstract class Note : MonoBehaviour
             {
                 if (Game.Time >= Model.start_time + JudgmentOffset)
                 {
-                    Clear(NoteGrade.Perfect);
+                    Clear(armedGrade);
                 }
             }
             else
@@ -232,7 +236,7 @@ public abstract class Note : MonoBehaviour
     /// <returns>True if this note took the touch (cleared or otherwise handled).</returns>
     public virtual bool OnTouch(Vector2 screenPos)
     {
-        if (!CanHandleTouch(screenPos)) return false;
+        if (!CanHandleTouch()) return false;
         return TryClear();
     }
 
@@ -243,7 +247,7 @@ public abstract class Note : MonoBehaviour
     /// </summary>
     public virtual bool OnTouchDeferred(Vector2 screenPos)
     {
-        if (!CanHandleTouch(screenPos) || IsArmed) return false;
+        if (!CanHandleTouch() || IsArmed) return false;
 
         var grade = GetTouchGrade();
         if (grade == NoteGrade.None) return false;
@@ -254,6 +258,7 @@ public abstract class Note : MonoBehaviour
         else
         {
             IsArmed = true;
+            armedGrade = grade;
         }
         return true;
     }
@@ -262,7 +267,7 @@ public abstract class Note : MonoBehaviour
     /// Returns whether this note may consider a touch at the current chart time.
     /// Drag variants extend this with their early and cross-page admission gates.
     /// </summary>
-    public virtual bool CanHandleTouch(Vector2 screenPos)
+    public virtual bool CanHandleTouch()
     {
         return Game.IsLoaded && Game.State.IsPlaying && !IsCollected && !IsCleared && !IsArmed;
     }

--- a/engines/unity/Assets/Scripts/Game/Notes/Note.cs
+++ b/engines/unity/Assets/Scripts/Game/Notes/Note.cs
@@ -25,6 +25,7 @@ public abstract class Note : MonoBehaviour
     public float MissThreshold { get; set; }
 
     public bool IsCleared { get; private set; }
+    public bool IsArmed { get; private set; }
 
     // For ranked mode: weighted difference between the current timing and the perfect timing
     public float GreatGradeWeight { get; protected set; }
@@ -47,7 +48,8 @@ public abstract class Note : MonoBehaviour
     public virtual void SetData(int noteId)
     {
         IsCollected = false;
-
+        IsArmed = false;
+    
         Chart = Game.Chart.Model;
         Model = Game.Chart.Model.note_map[noteId];
         if (Model.next_id > 0 && Chart.note_map.ContainsKey(Model.next_id))
@@ -89,6 +91,7 @@ public abstract class Note : MonoBehaviour
         Page = default;
         MissThreshold = default;
         IsCleared = default;
+        IsArmed = default;
         GreatGradeWeight = default;
         JudgmentOffset = default;
     }
@@ -97,6 +100,7 @@ public abstract class Note : MonoBehaviour
     {
         if (IsCleared) return;
 
+        IsArmed = false;
         IsCleared = true;
         Renderer.OnClear(grade);
         Game.State.Judge(this, grade, -TimeUntilEnd, GreatGradeWeight);
@@ -128,26 +132,36 @@ public abstract class Note : MonoBehaviour
             // Update position
             gameObject.transform.localPosition = Model.CalculatePosition(Game.Chart);
 
-            // Autoplay
-            if (IsAutoEnabled())
+            if (IsArmed)
             {
-                if (TimeUntilStart < 0)
+                if (Game.Time >= Model.start_time + JudgmentOffset)
                 {
-                    if (this is HoldNote)
-                    {
-                        ((HoldNote) this).UpdateFinger(0, true);
-                    }
-                    else
-                    {
-                        Clear(NoteGrade.Perfect);
-                    }
+                    Clear(NoteGrade.Perfect);
                 }
             }
-
-            // Check removable
-            if (ShouldMiss())
+            else
             {
-                Clear(NoteGrade.Miss);
+                // Autoplay
+                if (IsAutoEnabled())
+                {
+                    if (TimeUntilStart < 0)
+                    {
+                        if (this is HoldNote)
+                        {
+                            ((HoldNote) this).UpdateFinger(0, true);
+                        }
+                        else
+                        {
+                            Clear(NoteGrade.Perfect);
+                        }
+                    }
+                }
+
+                // Check removable
+                if (ShouldMiss())
+                {
+                    Clear(NoteGrade.Miss);
+                }
             }
         }
 
@@ -218,8 +232,50 @@ public abstract class Note : MonoBehaviour
     /// <returns>True if this note took the touch (cleared or otherwise handled).</returns>
     public virtual bool OnTouch(Vector2 screenPos)
     {
-        if (!Game.IsLoaded || !Game.State.IsPlaying) return false;
+        if (!CanHandleTouch(screenPos)) return false;
         return TryClear();
+    }
+
+    /// <summary>
+    /// Handles passive contact from an already-down finger. A valid early hit is armed
+    /// and resolves at the effective perfect time; a hit at or after that time resolves
+    /// immediately. Misses retain the existing immediate settlement behavior.
+    /// </summary>
+    public virtual bool OnTouchDeferred(Vector2 screenPos)
+    {
+        if (!CanHandleTouch(screenPos) || IsArmed) return false;
+
+        var grade = GetTouchGrade();
+        if (grade == NoteGrade.None) return false;
+        if (grade == NoteGrade.Miss || Game.Time >= Model.start_time + JudgmentOffset)
+        {
+            Clear(grade);
+        }
+        else
+        {
+            IsArmed = true;
+        }
+        return true;
+    }
+
+    /// <summary>
+    /// Returns whether this note may consider a touch at the current chart time.
+    /// Drag variants extend this with their early and cross-page admission gates.
+    /// </summary>
+    public virtual bool CanHandleTouch(Vector2 screenPos)
+    {
+        return Game.IsLoaded && Game.State.IsPlaying && !IsCollected && !IsCleared && !IsArmed;
+    }
+
+    /// <summary>
+    /// Side-effect-free preview of the grade that an immediate touch would settle with,
+    /// apart from CalculateGrade's existing GreatGradeWeight calculation.
+    /// </summary>
+    public NoteGrade GetTouchGrade()
+    {
+        if (IsAutoEnabled()) return NoteGrade.Perfect;
+        if (ShouldMiss()) return NoteGrade.Miss;
+        return CalculateGrade();
     }
 
     /// <returns>
@@ -228,10 +284,8 @@ public abstract class Note : MonoBehaviour
     /// </returns>
     public virtual bool TryClear()
     {
-        if (IsCleared) return false;
-        if (IsAutoEnabled()) Clear(NoteGrade.Perfect);
-        if (ShouldMiss()) Clear(NoteGrade.Miss);
-        var grade = CalculateGrade();
+        if (IsCleared || IsArmed) return false;
+        var grade = GetTouchGrade();
         if (grade != NoteGrade.None) Clear(grade);
         return IsCleared;
     }


### PR DESCRIPTION
## Summary

- add an armed state for Drag notes contacted passively before their effective perfect time
- arbitrate Drag and Select candidates before settlement so a higher-priority Select can claim a fresh FingerDown
- preserve immediate Drag feedback when no Select claims the Down
- preserve DragCoHit, cross-page suppression, and one-valid-Drag-per-input scanning
- keep Drag admission windows shared between immediate and deferred touch paths

## Root cause

Drag notes previously cleared as soon as an existing pointer entered their hitbox. Clear immediately submitted judgment, combo, effects, hit sound, and haptics, so passive early contacts could put gameplay feedback noticeably ahead of the music.

## Behavior

A fresh FingerDown still resolves Drag immediately when no higher-priority Select candidate consumes it. Passive FingerUpdate contact, or a Drag sharing a Down claimed by Select, arms the Drag and resolves it at `start_time + JudgmentOffset`.

No state is stored on the finger; the fresh-Down claim remains event-local.

## Notes

Replicates [Cytoid-private #48](https://github.com/Cytoid/Cytoid-private/pull/48). This repo has renamed `LeanFinger` to `GameFinger`; the patch is otherwise semantically identical (same 176+/62- diffstat).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved touch and drag recognition for more reliable note interactions.
  * Refined handling of overlapping Drag and Select actions.
  * Improved timing for early, late, and simultaneous note inputs.
  * Prevented stale or already-resolved notes from responding to touch.
  * Unified handling for Flick, Hold, and standard notes.
* **Improvements**
  * Enhanced clustered note selection for Click, CDrag, and Hold interactions.
  * Deferred valid inputs when needed to ensure accurate final judgments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->