### PR TITLE
fix(gameplay): batch-clear stacked drag notes on one contact

### DIFF
--- a/engines/unity/Assets/Scripts/Game/EffectController.cs
+++ b/engines/unity/Assets/Scripts/Game/EffectController.cs
@@ -22,13 +22,19 @@ public class EffectController : MonoBehaviour
     const float ClearRingStartDiameter = 1f;
 
     /// <summary>
-    /// Active only between <see cref="BeginClearBatch"/> and <see cref="EndClearBatch"/>
-    /// (stacked drag settle). Outside a batch, FX / hit sounds are uncapped.
+    /// Max clear FX (ripple + particles) spawned in one frame from any settle path:
+    /// stacked-drag input batch, deferred armed Clear, Auto, or mass Miss.
     /// </summary>
-    private int batchFxCap = -1;
-    private int batchFxUsed;
-    private int batchSoundCap = -1;
-    private int batchSoundUsed;
+    public const int MaxClearFxPerFrame = 3;
+
+    /// <summary>
+    /// Max hit sounds (and gated haptics) spawned in one frame from any settle path.
+    /// </summary>
+    public const int MaxHitSoundsPerFrame = 1;
+
+    private int budgetFrame = -1;
+    private int frameFxUsed;
+    private int frameSoundUsed;
 
     private void Awake()
     {
@@ -41,45 +47,51 @@ public class EffectController : MonoBehaviour
         clearEffectSizeMultiplier = Context.Player.Settings.ClearEffectsSize;
     }
 
+    private void ResetBudgetIfNewFrame()
+    {
+        var frame = Time.frameCount;
+        if (budgetFrame == frame) return;
+        budgetFrame = frame;
+        frameFxUsed = 0;
+        frameSoundUsed = 0;
+    }
+
     /// <summary>
-    /// Caps clear FX / hit sounds for one stacked-drag settle batch only.
+    /// Marks a multi-clear settle group. Budget is always per-frame
+    /// (<see cref="MaxClearFxPerFrame"/> / <see cref="MaxHitSoundsPerFrame"/>);
+    /// this exists so stacked-drag input can share the same counters without resetting them.
     /// Nested calls are not supported; always pair with <see cref="EndClearBatch"/>.
     /// </summary>
     public void BeginClearBatch(int maxFx, int maxSounds)
     {
-        batchFxCap = maxFx;
-        batchFxUsed = 0;
-        batchSoundCap = maxSounds;
-        batchSoundUsed = 0;
+        // maxFx / maxSounds kept for call-site clarity; frame caps are the source of truth.
+        ResetBudgetIfNewFrame();
     }
 
     public void EndClearBatch()
     {
-        batchFxCap = -1;
-        batchSoundCap = -1;
+        // Per-frame budget persists until the next frame; nothing to clear.
     }
 
     /// <returns>
-    /// False only when inside a clear batch that has already used its FX budget.
-    /// Outside a batch, always true.
+    /// False when this frame has already used its clear-FX budget.
     /// </returns>
     public bool TryConsumeClearFx()
     {
-        if (batchFxCap < 0) return true;
-        if (batchFxUsed >= batchFxCap) return false;
-        batchFxUsed++;
+        ResetBudgetIfNewFrame();
+        if (frameFxUsed >= MaxClearFxPerFrame) return false;
+        frameFxUsed++;
         return true;
     }
 
     /// <returns>
-    /// False only when inside a clear batch that has already used its hit-sound budget.
-    /// Outside a batch, always true.
+    /// False when this frame has already used its hit-sound budget.
     /// </returns>
     public bool TryConsumeHitSound()
     {
-        if (batchSoundCap < 0) return true;
-        if (batchSoundUsed >= batchSoundCap) return false;
-        batchSoundUsed++;
+        ResetBudgetIfNewFrame();
+        if (frameSoundUsed >= MaxHitSoundsPerFrame) return false;
+        frameSoundUsed++;
         return true;
     }
 

--- a/engines/unity/Assets/Scripts/Game/EffectController.cs
+++ b/engines/unity/Assets/Scripts/Game/EffectController.cs
@@ -21,6 +21,15 @@ public class EffectController : MonoBehaviour
     /// <summary>Outer diameter at ring spawn; matches legacy FlatFX ripple preset.</summary>
     const float ClearRingStartDiameter = 1f;
 
+    /// <summary>
+    /// Active only between <see cref="BeginClearBatch"/> and <see cref="EndClearBatch"/>
+    /// (stacked drag settle). Outside a batch, FX / hit sounds are uncapped.
+    /// </summary>
+    private int batchFxCap = -1;
+    private int batchFxUsed;
+    private int batchSoundCap = -1;
+    private int batchSoundUsed;
+
     private void Awake()
     {
         EffectParentTransform = effectParent.transform;
@@ -30,6 +39,48 @@ public class EffectController : MonoBehaviour
     public void OnGameLoaded()
     {
         clearEffectSizeMultiplier = Context.Player.Settings.ClearEffectsSize;
+    }
+
+    /// <summary>
+    /// Caps clear FX / hit sounds for one stacked-drag settle batch only.
+    /// Nested calls are not supported; always pair with <see cref="EndClearBatch"/>.
+    /// </summary>
+    public void BeginClearBatch(int maxFx, int maxSounds)
+    {
+        batchFxCap = maxFx;
+        batchFxUsed = 0;
+        batchSoundCap = maxSounds;
+        batchSoundUsed = 0;
+    }
+
+    public void EndClearBatch()
+    {
+        batchFxCap = -1;
+        batchSoundCap = -1;
+    }
+
+    /// <returns>
+    /// False only when inside a clear batch that has already used its FX budget.
+    /// Outside a batch, always true.
+    /// </returns>
+    public bool TryConsumeClearFx()
+    {
+        if (batchFxCap < 0) return true;
+        if (batchFxUsed >= batchFxCap) return false;
+        batchFxUsed++;
+        return true;
+    }
+
+    /// <returns>
+    /// False only when inside a clear batch that has already used its hit-sound budget.
+    /// Outside a batch, always true.
+    /// </returns>
+    public bool TryConsumeHitSound()
+    {
+        if (batchSoundCap < 0) return true;
+        if (batchSoundUsed >= batchSoundCap) return false;
+        batchSoundUsed++;
+        return true;
     }
 
     public void PlayRippleEffect(Vector3 position)
@@ -57,6 +108,8 @@ public class EffectController : MonoBehaviour
         {
             return;
         }
+
+        if (!TryConsumeClearFx()) return;
         
         var color = game.Config.NoteGradeEffectColors[grade];
         var at = noteRenderer.Note.transform.position;

--- a/engines/unity/Assets/Scripts/Game/InputController.cs
+++ b/engines/unity/Assets/Scripts/Game/InputController.cs
@@ -10,7 +10,7 @@ public class InputController : MonoBehaviour
     /// Candidates are re-clustered each Down by <c>effectiveNoteTime</c> span ≤ this gap
     /// (no adjacent-gap chain expansion). Soft fallthrough across clusters remains.
     /// In-cluster rank: see <see cref="OrderHitCandidatesByNoteTimeClusters"/>.
-    /// Flick stays list-order bind; Drag stays list-order scan.
+    /// Flick stays list-order bind; Drag settles all colliding eligible notes per input.
     /// </summary>
     public const float NoteClusterGapSeconds = 0.015f;
 
@@ -23,6 +23,24 @@ public class InputController : MonoBehaviour
     /// Replaces legacy collidedDrag + Page.Duration/8.
     /// </summary>
     public const float DragCoHitWindowSeconds = 0.030f;
+
+    /// <summary>
+    /// Max clear FX (ripple + particles) spawned from one drag input batch
+    /// (FingerDown settle or FingerUpdate multi-clear).
+    /// </summary>
+    public const int DragBatchMaxClearFx = 3;
+
+    /// <summary>
+    /// Max hit sounds (and gated haptics) from one drag input batch.
+    /// </summary>
+    public const int DragBatchMaxHitSounds = 1;
+
+    /// <summary>
+    /// Max |ΔeffectiveNoteTime| from the DragCoHit representative (first colliding
+    /// non-Miss in list order) for other colliding Drags settled in the same batch.
+    /// Keeps same-tick stacks co-clearing without changing which Drag gates Select.
+    /// </summary>
+    public const float DragStackBatchGapSeconds = 0.015f;
 
     public Game game;
 
@@ -39,6 +57,7 @@ public class InputController : MonoBehaviour
 
     private readonly List<Note> hitCandidates = new List<Note>();
     private readonly List<Note> clusterScratch = new List<Note>();
+    private readonly List<Note> dragBatchScratch = new List<Note>();
 
     private void Awake()
     {
@@ -118,52 +137,97 @@ public class InputController : MonoBehaviour
             ? game.camera.ScreenToWorldPoint(finger.ScreenPosition)
             : game.camera.ScreenToWorldPoint(new Vector3(finger.ScreenPosition.x, finger.ScreenPosition.y, 10));
 
-        // Pick a Drag without settling it yet: whether it clears immediately or arms
+        // Collect all colliding eligible Drags without settling yet: Immediate vs Armed
         // depends on whether a higher-priority Select candidate claims this fresh Down.
-        var acceptedDrag = FindAcceptedDrag(pressedPosition);
+        // Misses still settle immediately and do not arm DragCoHit.
+        var acceptedDrag = CollectCollidingDragBatch(pressedPosition);
 
         // Select is still gated by the accepted Drag before either candidate settles,
         // preserving DragCoHit and cross-page suppression without changing event order.
         var acceptedSelect = FindAcceptedSelect(finger, pressedPosition, acceptedDrag);
 
-        if (acceptedDrag != null)
-        {
-            if (acceptedSelect != null)
-            {
-                acceptedDrag.OnTouchDeferred(finger.ScreenPosition);
-            }
-            else
-            {
-                acceptedDrag.OnTouch(finger.ScreenPosition);
-            }
-        }
+        SettleDragBatch(finger.ScreenPosition, deferred: acceptedSelect != null);
 
         AcceptSelect(acceptedSelect, finger, pressedPosition);
     }
 
     /// <summary>
-    /// Returns the first valid non-Miss Drag in list order. Expired Drag notes retain
-    /// their legacy immediate Miss settlement and do not arm DragCoHit.
+    /// Collects a Drag settle batch and returns the DragCoHit representative.
+    /// Representative is the first colliding non-Miss in <see cref="TouchableDragNotes"/>
+    /// list order — same as legacy <c>FindAcceptedDrag</c>, so Select gating is unchanged.
+    /// Additional colliding non-Miss notes within
+    /// <see cref="DragStackBatchGapSeconds"/> of that note are added to
+    /// <see cref="dragBatchScratch"/> for co-clear. Misses before the representative
+    /// still clear immediately; scanning after the representative does not Miss-clear
+    /// (legacy returned on first hit).
     /// </summary>
-    private Note FindAcceptedDrag(Vector2 pressedPosition)
+    private Note CollectCollidingDragBatch(Vector2 worldPos)
     {
+        dragBatchScratch.Clear();
+        Note accepted = null;
+        var acceptedTime = 0f;
         foreach (var note in TouchableDragNotes)
         {
             if (!IsTouchableNote(note)) continue;
-            if (!note.DoesCollide(pressedPosition)) continue;
+            if (!note.DoesCollide(worldPos)) continue;
             if (!note.CanHandleTouch()) continue;
 
             var grade = note.GetTouchGrade();
             if (grade == NoteGrade.None) continue;
             if (grade == NoteGrade.Miss)
             {
-                note.Clear(NoteGrade.Miss);
+                // Legacy FindAcceptedDrag cleared Misses only until the first valid hit.
+                if (accepted == null) note.Clear(NoteGrade.Miss);
                 continue;
             }
 
-            return note;
+            if (accepted == null)
+            {
+                accepted = note;
+                acceptedTime = EffectiveNoteTime(note);
+                dragBatchScratch.Add(note);
+                continue;
+            }
+
+            if (Math.Abs(EffectiveNoteTime(note) - acceptedTime) > DragStackBatchGapSeconds)
+                continue;
+
+            dragBatchScratch.Add(note);
         }
-        return null;
+
+        return accepted;
+    }
+
+    /// <summary>
+    /// Settles <see cref="dragBatchScratch"/> under a shared clear-FX / hit-sound budget.
+    /// When <paramref name="deferred"/> is false, only the DragCoHit representative
+    /// (index 0) uses immediate <see cref="Note.OnTouch"/> — same as legacy Down.
+    /// The rest of the stack uses <see cref="Note.OnTouchDeferred"/>, matching the
+    /// legacy FingerUpdate path so early contacts still arm to perfect time.
+    /// When <paramref name="deferred"/> is true (Select claimed the Down), every
+    /// note in the batch is deferred.
+    /// </summary>
+    private void SettleDragBatch(Vector2 screenPos, bool deferred)
+    {
+        if (dragBatchScratch.Count == 0) return;
+
+        var effects = game.effectController;
+        effects.BeginClearBatch(DragBatchMaxClearFx, DragBatchMaxHitSounds);
+        try
+        {
+            for (var i = 0; i < dragBatchScratch.Count; i++)
+            {
+                var note = dragBatchScratch[i];
+                if (!IsTouchableNote(note)) continue;
+                if (deferred || i > 0) note.OnTouchDeferred(screenPos);
+                else note.OnTouch(screenPos);
+            }
+        }
+        finally
+        {
+            effects.EndClearBatch();
+            dragBatchScratch.Clear();
+        }
     }
 
     /// <summary>
@@ -314,14 +378,9 @@ public class InputController : MonoBehaviour
             if (cleared) FlickingNotes.Remove(finger.Index);
         }
 
-        // Drag: continuous contact — list-order scan
-        foreach (var note in TouchableDragNotes)
-        {
-            if (!IsTouchableNote(note)) continue;
-            if (!note.DoesCollide(pos)) continue;
-            if (!note.OnTouchDeferred(finger.ScreenPosition)) continue;
-            break;
-        }
+        // Drag: continuous contact — clear/arm colliding stack batch in one pass
+        CollectCollidingDragBatch(pos);
+        SettleDragBatch(finger.ScreenPosition, deferred: true);
 
         // If this is a new finger (Down did not already bind a Hold)
         if (!HoldingNotes.ContainsKey(finger.Index))

--- a/engines/unity/Assets/Scripts/Game/InputController.cs
+++ b/engines/unity/Assets/Scripts/Game/InputController.cs
@@ -7,7 +7,7 @@ public class InputController : MonoBehaviour
     /// <summary>
     /// Max note-to-note span (seconds) for one FingerDown hit cluster
     /// (true or pseudo simultaneous press). Applies to Click / CDrag head / unheld Hold.
-    /// Candidates are re-clustered each Down by <c>effectiveNoteTime</c> span â‰?this gap
+    /// Candidates are re-clustered each Down by <c>effectiveNoteTime</c> span â‰¤ this gap
     /// (no adjacent-gap chain expansion). Soft fallthrough across clusters remains.
     /// In-cluster rank: see <see cref="OrderHitCandidatesByNoteTimeClusters"/>.
     /// Flick stays list-order bind; Drag settles all colliding eligible notes per input.
@@ -155,7 +155,7 @@ public class InputController : MonoBehaviour
     /// <summary>
     /// Collects a Drag settle batch and returns the DragCoHit representative.
     /// Representative is the first colliding non-Miss in <see cref="TouchableDragNotes"/>
-    /// list order â€?same as legacy <c>FindAcceptedDrag</c>, so Select gating is unchanged.
+    /// list order â€” same as legacy <c>FindAcceptedDrag</c>, so Select gating is unchanged.
     /// Additional colliding non-Miss notes within
     /// <see cref="DragStackBatchGapSeconds"/> of that note are added to
     /// <see cref="dragBatchScratch"/> for co-clear. Misses before the representative
@@ -381,7 +381,7 @@ public class InputController : MonoBehaviour
             if (cleared) FlickingNotes.Remove(finger.Index);
         }
 
-        // Drag: continuous contact â€?clear/arm colliding stack batch in one pass
+        // Drag: continuous contact â€” clear/arm colliding stack batch in one pass
         CollectCollidingDragBatch(pos);
         SettleDragBatch(finger.ScreenPosition, deferred: true);
 
@@ -462,8 +462,9 @@ public class InputController : MonoBehaviour
 
     /// <summary>
     /// Order Click / CDrag-head / Hold candidates for one FingerDown.
-    /// Sort by <c>effectiveNoteTime</c>, then split into clusters with span â‰?    /// <see cref="NoteClusterGapSeconds"/> (earlier clusters first; soft fallthrough).
-    /// Within a cluster: |Î”x| â†?note time â†?type (Click/CDrag head before Hold) â†?id.
+    /// Sort by <c>effectiveNoteTime</c>, then split into clusters with span â‰¤
+    /// <see cref="NoteClusterGapSeconds"/> (earlier clusters first; soft fallthrough).
+    /// Within a cluster: |Î”x| â†’ note time â†’ type (Click/CDrag head before Hold) â†’ id.
     /// Flick is never passed here (list-order bind on the scan path).
     /// Not re-entrant: mutates <see cref="hitCandidates"/> / <c>clusterScratch</c> while yielding.
     /// </summary>

--- a/engines/unity/Assets/Scripts/Game/InputController.cs
+++ b/engines/unity/Assets/Scripts/Game/InputController.cs
@@ -7,7 +7,7 @@ public class InputController : MonoBehaviour
     /// <summary>
     /// Max note-to-note span (seconds) for one FingerDown hit cluster
     /// (true or pseudo simultaneous press). Applies to Click / CDrag head / unheld Hold.
-    /// Candidates are re-clustered each Down by <c>effectiveNoteTime</c> span â‰¤ this gap
+    /// Candidates are re-clustered each Down by <c>effectiveNoteTime</c> span â‰?this gap
     /// (no adjacent-gap chain expansion). Soft fallthrough across clusters remains.
     /// In-cluster rank: see <see cref="OrderHitCandidatesByNoteTimeClusters"/>.
     /// Flick stays list-order bind; Drag settles all colliding eligible notes per input.
@@ -25,15 +25,16 @@ public class InputController : MonoBehaviour
     public const float DragCoHitWindowSeconds = 0.030f;
 
     /// <summary>
-    /// Max clear FX (ripple + particles) spawned from one drag input batch
-    /// (FingerDown settle or FingerUpdate multi-clear).
+    /// Clear FX budget for stacked-drag settle; aliases
+    /// <see cref="EffectController.MaxClearFxPerFrame"/> (also covers armed/Auto Clear).
     /// </summary>
-    public const int DragBatchMaxClearFx = 3;
+    public const int DragBatchMaxClearFx = EffectController.MaxClearFxPerFrame;
 
     /// <summary>
-    /// Max hit sounds (and gated haptics) from one drag input batch.
+    /// Hit-sound budget for stacked-drag settle; aliases
+    /// <see cref="EffectController.MaxHitSoundsPerFrame"/>.
     /// </summary>
-    public const int DragBatchMaxHitSounds = 1;
+    public const int DragBatchMaxHitSounds = EffectController.MaxHitSoundsPerFrame;
 
     /// <summary>
     /// Max |Î”effectiveNoteTime| from the DragCoHit representative (first colliding
@@ -154,7 +155,7 @@ public class InputController : MonoBehaviour
     /// <summary>
     /// Collects a Drag settle batch and returns the DragCoHit representative.
     /// Representative is the first colliding non-Miss in <see cref="TouchableDragNotes"/>
-    /// list order â€” same as legacy <c>FindAcceptedDrag</c>, so Select gating is unchanged.
+    /// list order â€?same as legacy <c>FindAcceptedDrag</c>, so Select gating is unchanged.
     /// Additional colliding non-Miss notes within
     /// <see cref="DragStackBatchGapSeconds"/> of that note are added to
     /// <see cref="dragBatchScratch"/> for co-clear. Misses before the representative
@@ -199,13 +200,15 @@ public class InputController : MonoBehaviour
     }
 
     /// <summary>
-    /// Settles <see cref="dragBatchScratch"/> under a shared clear-FX / hit-sound budget.
+    /// Settles <see cref="dragBatchScratch"/> under the shared per-frame clear-FX /
+    /// hit-sound budget (<see cref="EffectController.MaxClearFxPerFrame"/>).
     /// When <paramref name="deferred"/> is false, only the DragCoHit representative
-    /// (index 0) uses immediate <see cref="Note.OnTouch"/> â€” same as legacy Down.
+    /// (index 0) uses immediate <see cref="Note.OnTouch"/> -- same as legacy Down.
     /// The rest of the stack uses <see cref="Note.OnTouchDeferred"/>, matching the
     /// legacy FingerUpdate path so early contacts still arm to perfect time.
     /// When <paramref name="deferred"/> is true (Select claimed the Down), every
-    /// note in the batch is deferred.
+    /// note in the batch is deferred. Armed notes that later Clear in
+    /// <see cref="Note"/> still share the same per-frame FX/SFX budget.
     /// </summary>
     private void SettleDragBatch(Vector2 screenPos, bool deferred)
     {
@@ -378,7 +381,7 @@ public class InputController : MonoBehaviour
             if (cleared) FlickingNotes.Remove(finger.Index);
         }
 
-        // Drag: continuous contact â€” clear/arm colliding stack batch in one pass
+        // Drag: continuous contact â€?clear/arm colliding stack batch in one pass
         CollectCollidingDragBatch(pos);
         SettleDragBatch(finger.ScreenPosition, deferred: true);
 
@@ -459,9 +462,8 @@ public class InputController : MonoBehaviour
 
     /// <summary>
     /// Order Click / CDrag-head / Hold candidates for one FingerDown.
-    /// Sort by <c>effectiveNoteTime</c>, then split into clusters with span â‰¤
-    /// <see cref="NoteClusterGapSeconds"/> (earlier clusters first; soft fallthrough).
-    /// Within a cluster: |Î”x| â†’ note time â†’ type (Click/CDrag head before Hold) â†’ id.
+    /// Sort by <c>effectiveNoteTime</c>, then split into clusters with span â‰?    /// <see cref="NoteClusterGapSeconds"/> (earlier clusters first; soft fallthrough).
+    /// Within a cluster: |Î”x| â†?note time â†?type (Click/CDrag head before Hold) â†?id.
     /// Flick is never passed here (list-order bind on the scan path).
     /// Not re-entrant: mutates <see cref="hitCandidates"/> / <c>clusterScratch</c> while yielding.
     /// </summary>

--- a/engines/unity/Assets/Scripts/Game/Notes/Note.cs
+++ b/engines/unity/Assets/Scripts/Game/Notes/Note.cs
@@ -110,8 +110,10 @@ public abstract class Note : MonoBehaviour
         Game.State.Judge(this, grade, -TimeUntilEnd, GreatGradeWeight);
         Game.onNoteJudged.Invoke(Game, this, new JudgeData(grade, -TimeUntilEnd, GreatGradeWeight));
 
-        // Hit sound
-        if (grade != NoteGrade.Miss && (!(this is HoldNote) || Context.Player.Settings.HoldHitSoundTiming.Let(it => it == HoldHitSoundTiming.End || it == HoldHitSoundTiming.Both)))
+        // Hit sound (frame / batch budget via EffectController)
+        if (grade != NoteGrade.Miss &&
+            (!(this is HoldNote) || Context.Player.Settings.HoldHitSoundTiming.Let(it => it == HoldHitSoundTiming.End || it == HoldHitSoundTiming.Both)) &&
+            Game.effectController.TryConsumeHitSound())
         {
             PlayHitSound();
         }


### PR DESCRIPTION
## Summary
- Settle colliding stacked drag-bucket notes in one FingerDown/Update pass (representative = first list-order non-Miss for DragCoHit; others within 15ms co-settle with legacy Immediate/Deferred rules).
- Preserve Select one-per-Down, DragCoHit 30ms, and deferred arming for passive contact.
- Cap clear FX / hit sounds with a **per-frame** budget so stacked-drag batches and deferred armed/Auto Clears share the same limits (`MaxClearFxPerFrame = 3`, `MaxHitSoundsPerFrame = 1`).

## Feedback budget
| Constant | Value | Role |
|----------|-------|------|
| `EffectController.MaxClearFxPerFrame` | **3** | Max ripple+particle clear FX per frame from any settle path |
| `EffectController.MaxHitSoundsPerFrame` | **1** | Max hit sound (+gated haptic) per frame from any settle path |

`InputController.DragBatchMaxClearFx` / `DragBatchMaxHitSounds` alias the EffectController constants. Judgment / combo / `onNoteClear` still run per note.

Out of scope: drag-stack visual host / shared child object mounting.

## Test plan
- [ ] Dense same-position drag stack: one finger settles the in-window stack without one-per-frame drip
- [ ] Normal spaced drag chain: no skipping ahead via overlapping hitboxes outside the 15ms batch gap
- [ ] Drag + Click/Flick within/outside 30ms DragCoHit: Select gating unchanged vs main
- [ ] Passive early drag contact still arms and resolves at perfect time (deferred)
- [ ] Deferred armed stack settle: at most 1 hit sound and 3 clear FX in that frame
- [ ] A simultaneous Click still has full feedback when it clears outside the exhausted budget frame (next frame)
- [ ] AutoDrag / mass Miss: per-frame FX/SFX budget applies (no hitch from unbounded FX)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved drag interactions by grouping nearby notes into a single batch.
  * Supports smoother continuous-drag play across multiple notes.
  * Added automatic per-frame limits for clear effects and hit sounds.

* **Bug Fixes**
  * Prevents excessive visual effects and hit sounds when clearing multiple notes.
  * Ensures missed and selected notes are settled consistently during drag input.
  * Applies sound limits consistently to note hits and hold-note effects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
