### PR TITLE
fix(chart): prefer C2 message color suffix over escaped comma

### DIFF
--- a/engines/unity/Assets/Editor/Tests/ChartEventPresentationTimelineTests.cs
+++ b/engines/unity/Assets/Editor/Tests/ChartEventPresentationTimelineTests.cs
@@ -64,6 +64,32 @@ public class ChartEventPresentationTimelineTests
     }
 
     [Test]
+    public void BackslashOnlyMessageKeepsClassicC2ColorSuffix()
+    {
+        // Community charts encode spinner "\" as "\,#FFFFFF" (JSON "\\,#FFFFFF").
+        // That must remain content "\" + white, not leaked text ",#FFFFFF".
+        var state = Timeline(Order(
+            0,
+            Event(ChartEventType.Message, "\\,#FFFFFF"))).Evaluate(1);
+
+        Assert.That(state.Content, Is.EqualTo("\\"));
+        Assert.That(state.IsTextVisible, Is.True);
+        AssertColor(state.TextColor, Color.white);
+        AssertColor(state.ScanlineColor, Color.white);
+    }
+
+    [Test]
+    public void EscapedCommaBeforeColorStillAllowsLiteralCommaContent()
+    {
+        var state = Timeline(Order(
+            0,
+            Event(ChartEventType.Message, "Hello\\,,#00FF00"))).Evaluate(1);
+
+        Assert.That(state.Content, Is.EqualTo("Hello,"));
+        AssertColor(state.TextColor, Color.green);
+    }
+
+    [Test]
     public void MissingColorSilentlyFallsBackToWhite()
     {
         var warnings = new List<string>();

--- a/engines/unity/Assets/Scripts/Game/Chart/ChartEventPresentationTimeline.cs
+++ b/engines/unity/Assets/Scripts/Game/Chart/ChartEventPresentationTimeline.cs
@@ -302,6 +302,16 @@ public sealed class ChartEventPresentationTimeline
 
     private static int FindMessageSeparator(string value)
     {
+        // Classic C2 is "content,#RRGGBB". Community charts write spinner frames like
+        // "\,#FFFFFF" meaning content "\" + white. Prefer a comma whose suffix is a valid
+        // color so "\," is not treated as an escaped comma that swallows the color.
+        for (var i = value.Length - 1; i >= 0; i--)
+        {
+            if (value[i] != ',') continue;
+            if (IsRgbHexColor(value.Substring(i + 1).Trim())) return i;
+        }
+
+        // Fallback for invalid color suffixes / mid-text commas: first unescaped comma.
         for (var i = 0; i < value.Length; i++)
         {
             if (value[i] == '\\' && i + 1 < value.Length &&


### PR DESCRIPTION
## Summary
- Prefer a comma whose suffix is a valid `#RRGGBB` / `#RRGGBBAA` when parsing C2 type-8 message args, matching classic `content,#FFFFFF`.
- Fixes community spinner frames like `"\\,#FFFFFF"` (content `\`) that previously leaked `,#FFFFFF` on screen because `\,` was treated as an escaped comma.
- Keeps Lab escape support (`\,`, `\\`) for content; adds regression tests.

## Test plan
- [x] Unit: `BackslashOnlyMessageKeepsClassicC2ColorSuffix`, `EscapedCommaBeforeColorStillAllowsLiteralCommaContent`, existing escape/RGBA tests
- [x] Play a chart with spinner frames `-- / | \` using `"\\,#FFFFFF"` — color code no longer leaks as text
- [x] Spot-check normal messages like `Loading,#FFFFFF` and empty `,#FFFFFF` (scanline color only)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chart event message parsing when messages contain escaped commas and RGB/RGBA color suffixes.
  * Preserved literal comma content while correctly applying text and scanline colors.
  * Maintained compatibility with existing color-formatted messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->