### PR TITLE
fix(gameplay): scope clear FX/SFX budget to drag stacks only

### DIFF
--- a/engines/unity/Assets/Scripts/Game/EffectController.cs
+++ b/engines/unity/Assets/Scripts/Game/EffectController.cs
@@ -22,19 +22,26 @@ public class EffectController : MonoBehaviour
     const float ClearRingStartDiameter = 1f;
 
     /// <summary>
-    /// Max clear FX (ripple + particles) spawned in one frame from any settle path:
-    /// stacked-drag input batch, deferred armed Clear, Auto, or mass Miss.
+    /// Max clear FX (ripple + particles) for one co-located drag-stack settle
+    /// (input batch or deferred armed co-clear). Does not cap Click/Flick/Hold/Auto.
     /// </summary>
-    public const int MaxClearFxPerFrame = 3;
+    public const int MaxClearFxPerDragBatch = 3;
 
     /// <summary>
-    /// Max hit sounds (and gated haptics) spawned in one frame from any settle path.
+    /// Max hit sounds (and gated haptics) for one co-located drag-stack settle.
     /// </summary>
-    public const int MaxHitSoundsPerFrame = 1;
+    public const int MaxHitSoundsPerDragBatch = 1;
 
-    private int budgetFrame = -1;
-    private int frameFxUsed;
-    private int frameSoundUsed;
+    /// <summary>
+    /// Active only while a drag-stack budget is open (<see cref="BeginClearBatch"/> or
+    /// <see cref="EnsureDragStackBudget"/>). Cap &lt; 0 means uncapped.
+    /// </summary>
+    private int batchDepth;
+    private int softBudgetFrame = -1;
+    private int batchFxCap = -1;
+    private int batchFxUsed;
+    private int batchSoundCap = -1;
+    private int batchSoundUsed;
 
     private void Awake()
     {
@@ -47,51 +54,79 @@ public class EffectController : MonoBehaviour
         clearEffectSizeMultiplier = Context.Player.Settings.ClearEffectsSize;
     }
 
-    private void ResetBudgetIfNewFrame()
+    private void ExpireSoftBudgetIfStale()
     {
-        var frame = Time.frameCount;
-        if (budgetFrame == frame) return;
-        budgetFrame = frame;
-        frameFxUsed = 0;
-        frameSoundUsed = 0;
+        if (softBudgetFrame < 0 || batchDepth > 0) return;
+        if (softBudgetFrame == Time.frameCount) return;
+        softBudgetFrame = -1;
+        batchFxCap = -1;
+        batchSoundCap = -1;
     }
 
     /// <summary>
-    /// Marks a multi-clear settle group. Budget is always per-frame
-    /// (<see cref="MaxClearFxPerFrame"/> / <see cref="MaxHitSoundsPerFrame"/>);
-    /// this exists so stacked-drag input can share the same counters without resetting them.
+    /// Caps clear FX / hit sounds for one stacked-drag settle batch only.
     /// Nested calls are not supported; always pair with <see cref="EndClearBatch"/>.
     /// </summary>
     public void BeginClearBatch(int maxFx, int maxSounds)
     {
-        // maxFx / maxSounds kept for call-site clarity; frame caps are the source of truth.
-        ResetBudgetIfNewFrame();
+        batchDepth++;
+        if (batchDepth > 1) return;
+        softBudgetFrame = -1;
+        batchFxCap = maxFx;
+        batchFxUsed = 0;
+        batchSoundCap = maxSounds;
+        batchSoundUsed = 0;
     }
 
     public void EndClearBatch()
     {
-        // Per-frame budget persists until the next frame; nothing to clear.
+        if (batchDepth <= 0) return;
+        batchDepth--;
+        if (batchDepth > 0) return;
+        batchFxCap = -1;
+        batchSoundCap = -1;
+    }
+
+    /// <summary>
+    /// Opens the same drag-stack caps for the rest of this frame when deferred armed
+    /// stack notes co-clear outside <see cref="BeginClearBatch"/>. No-op if a hard
+    /// batch is already active or the soft budget was already opened this frame.
+    /// </summary>
+    public void EnsureDragStackBudget(int maxFx, int maxSounds)
+    {
+        ExpireSoftBudgetIfStale();
+        if (batchDepth > 0) return;
+        if (softBudgetFrame == Time.frameCount) return;
+        softBudgetFrame = Time.frameCount;
+        batchFxCap = maxFx;
+        batchFxUsed = 0;
+        batchSoundCap = maxSounds;
+        batchSoundUsed = 0;
     }
 
     /// <returns>
-    /// False when this frame has already used its clear-FX budget.
+    /// False only when a drag-stack budget is active and its FX quota is exhausted.
+    /// Outside a drag-stack budget, always true.
     /// </returns>
     public bool TryConsumeClearFx()
     {
-        ResetBudgetIfNewFrame();
-        if (frameFxUsed >= MaxClearFxPerFrame) return false;
-        frameFxUsed++;
+        ExpireSoftBudgetIfStale();
+        if (batchFxCap < 0) return true;
+        if (batchFxUsed >= batchFxCap) return false;
+        batchFxUsed++;
         return true;
     }
 
     /// <returns>
-    /// False when this frame has already used its hit-sound budget.
+    /// False only when a drag-stack budget is active and its hit-sound quota is exhausted.
+    /// Outside a drag-stack budget, always true.
     /// </returns>
     public bool TryConsumeHitSound()
     {
-        ResetBudgetIfNewFrame();
-        if (frameSoundUsed >= MaxHitSoundsPerFrame) return false;
-        frameSoundUsed++;
+        ExpireSoftBudgetIfStale();
+        if (batchSoundCap < 0) return true;
+        if (batchSoundUsed >= batchSoundCap) return false;
+        batchSoundUsed++;
         return true;
     }
 

--- a/engines/unity/Assets/Scripts/Game/EffectController.cs
+++ b/engines/unity/Assets/Scripts/Game/EffectController.cs
@@ -34,10 +34,15 @@ public class EffectController : MonoBehaviour
 
     /// <summary>
     /// Active only while a drag-stack budget is open (<see cref="BeginClearBatch"/> or
-    /// <see cref="EnsureDragStackBudget"/>). Cap &lt; 0 means uncapped.
+    /// <see cref="EnterDragStackClear"/>). Cap &lt; 0 means uncapped.
+    /// Soft budgets apply only to clears inside <see cref="EnterDragStackClear"/>;
+    /// hard batches apply to every clear under <see cref="BeginClearBatch"/>.
     /// </summary>
     private int batchDepth;
     private int softBudgetFrame = -1;
+    private int softBudgetStackId = -1;
+    private int nextDragStackBudgetId;
+    private bool stackBudgetParticipant;
     private int batchFxCap = -1;
     private int batchFxUsed;
     private int batchSoundCap = -1;
@@ -59,9 +64,16 @@ public class EffectController : MonoBehaviour
         if (softBudgetFrame < 0 || batchDepth > 0) return;
         if (softBudgetFrame == Time.frameCount) return;
         softBudgetFrame = -1;
+        softBudgetStackId = -1;
         batchFxCap = -1;
         batchSoundCap = -1;
     }
+
+    /// <summary>
+    /// Allocates an id shared by one co-located deferred drag-stack settle so sibling
+    /// armed notes reuse one soft FX/SFX quota while a different stack gets a fresh one.
+    /// </summary>
+    public int AllocateDragStackBudgetId() => ++nextDragStackBudgetId;
 
     /// <summary>
     /// Caps clear FX / hit sounds for one stacked-drag settle batch only.
@@ -72,6 +84,7 @@ public class EffectController : MonoBehaviour
         batchDepth++;
         if (batchDepth > 1) return;
         softBudgetFrame = -1;
+        softBudgetStackId = -1;
         batchFxCap = maxFx;
         batchFxUsed = 0;
         batchSoundCap = maxSounds;
@@ -88,29 +101,55 @@ public class EffectController : MonoBehaviour
     }
 
     /// <summary>
-    /// Opens the same drag-stack caps for the rest of this frame when deferred armed
-    /// stack notes co-clear outside <see cref="BeginClearBatch"/>. No-op if a hard
-    /// batch is already active or the soft budget was already opened this frame.
+    /// Opens (or shares) soft drag-stack caps for deferred armed co-clears outside
+    /// <see cref="BeginClearBatch"/>. Same <paramref name="stackId"/> reuses the quota;
+    /// a different id resets it. No-op while a hard batch is active.
     /// </summary>
-    public void EnsureDragStackBudget(int maxFx, int maxSounds)
+    public void EnsureDragStackBudget(int maxFx, int maxSounds, int stackId)
     {
         ExpireSoftBudgetIfStale();
         if (batchDepth > 0) return;
-        if (softBudgetFrame == Time.frameCount) return;
+        if (softBudgetFrame == Time.frameCount && softBudgetStackId == stackId) return;
         softBudgetFrame = Time.frameCount;
+        softBudgetStackId = stackId;
         batchFxCap = maxFx;
         batchFxUsed = 0;
         batchSoundCap = maxSounds;
         batchSoundUsed = 0;
     }
 
+    /// <summary>
+    /// Marks the current <see cref="Note.Clear"/> as a soft-budget participant and opens
+    /// or shares that stack's caps. Pair with <see cref="ExitDragStackClear"/>.
+    /// </summary>
+    public void EnterDragStackClear(int maxFx, int maxSounds, int stackId)
+    {
+        EnsureDragStackBudget(maxFx, maxSounds, stackId);
+        stackBudgetParticipant = true;
+    }
+
+    public void ExitDragStackClear()
+    {
+        stackBudgetParticipant = false;
+    }
+
+    private bool ShouldApplyClearBudget()
+    {
+        if (batchFxCap < 0 && batchSoundCap < 0) return false;
+        // Hard batch: every clear in the settle pass shares the caps.
+        if (batchDepth > 0) return true;
+        // Soft budget: only the marked stack clear currently inside Enter/Exit.
+        return stackBudgetParticipant;
+    }
+
     /// <returns>
-    /// False only when a drag-stack budget is active and its FX quota is exhausted.
-    /// Outside a drag-stack budget, always true.
+    /// False only when a drag-stack budget applies to this clear and its FX quota is exhausted.
+    /// Uncapped clears (including non-stack clears while a soft budget is open) return true.
     /// </returns>
     public bool TryConsumeClearFx()
     {
         ExpireSoftBudgetIfStale();
+        if (!ShouldApplyClearBudget()) return true;
         if (batchFxCap < 0) return true;
         if (batchFxUsed >= batchFxCap) return false;
         batchFxUsed++;
@@ -118,12 +157,13 @@ public class EffectController : MonoBehaviour
     }
 
     /// <returns>
-    /// False only when a drag-stack budget is active and its hit-sound quota is exhausted.
-    /// Outside a drag-stack budget, always true.
+    /// False only when a drag-stack budget applies to this clear and its hit-sound quota
+    /// is exhausted. Uncapped clears return true.
     /// </returns>
     public bool TryConsumeHitSound()
     {
         ExpireSoftBudgetIfStale();
+        if (!ShouldApplyClearBudget()) return true;
         if (batchSoundCap < 0) return true;
         if (batchSoundUsed >= batchSoundCap) return false;
         batchSoundUsed++;

--- a/engines/unity/Assets/Scripts/Game/EffectController.cs
+++ b/engines/unity/Assets/Scripts/Game/EffectController.cs
@@ -77,7 +77,8 @@ public class EffectController : MonoBehaviour
 
     /// <summary>
     /// Caps clear FX / hit sounds for one stacked-drag settle batch only.
-    /// Nested calls are not supported; always pair with <see cref="EndClearBatch"/>.
+    /// Nesting is depth-counted: inner <see cref="BeginClearBatch"/> calls share the
+    /// outermost caps; pair each begin with <see cref="EndClearBatch"/>.
     /// </summary>
     public void BeginClearBatch(int maxFx, int maxSounds)
     {

--- a/engines/unity/Assets/Scripts/Game/InputController.cs
+++ b/engines/unity/Assets/Scripts/Game/InputController.cs
@@ -221,15 +221,18 @@ public class InputController : MonoBehaviour
     /// legacy FingerUpdate path so early contacts still arm to perfect time.
     /// When <paramref name="deferred"/> is true (Select claimed the Down), every
     /// note in the batch is deferred. Multi-note stacks that arm mark
-    /// <see cref="Note.MarkDragStackBudget"/> so later co-clears share the same caps
-    /// via <see cref="EffectController.EnsureDragStackBudget"/> without affecting
-    /// Click/Flick/Hold/Auto feedback.
+    /// <see cref="Note.MarkDragStackBudget"/> with one shared stack id so later
+    /// co-clears share caps via <see cref="EffectController.EnterDragStackClear"/>
+    /// without affecting Click/Flick/Hold/Auto feedback.
     /// </summary>
     private void SettleDragBatch(Vector2 screenPos, bool deferred)
     {
         if (dragBatchScratch.Count == 0) return;
 
         var budgetStack = dragBatchScratch.Count > 1;
+        var stackBudgetId = budgetStack
+            ? game.effectController.AllocateDragStackBudgetId()
+            : 0;
         for (var i = 0; i < dragBatchScratch.Count; i++)
         {
             var note = dragBatchScratch[i];
@@ -237,7 +240,7 @@ public class InputController : MonoBehaviour
             if (deferred || i > 0)
             {
                 note.OnTouchDeferred(screenPos);
-                if (budgetStack && note.IsArmed) note.MarkDragStackBudget();
+                if (budgetStack && note.IsArmed) note.MarkDragStackBudget(stackBudgetId);
             }
             else note.OnTouch(screenPos);
         }
@@ -483,9 +486,9 @@ public class InputController : MonoBehaviour
 
     /// <summary>
     /// Order Click / CDrag-head / Hold candidates for one FingerDown.
-    /// Sort by <c>effectiveNoteTime</c>, then split into clusters with span ?
+    /// Sort by <c>effectiveNoteTime</c>, then split into clusters with span &lt;=
     /// <see cref="NoteClusterGapSeconds"/> (earlier clusters first; soft fallthrough).
-    /// Within a cluster: |?x| ? note time ? type (Click/CDrag head before Hold) ? id.
+    /// Within a cluster: |dx| -&gt; note time -&gt; type (Click/CDrag head before Hold) -&gt; id.
     /// Flick is never passed here (list-order bind on the scan path).
     /// Not re-entrant: mutates <see cref="hitCandidates"/> / <c>clusterScratch</c> while yielding.
     /// </summary>
@@ -536,7 +539,7 @@ public class InputController : MonoBehaviour
     }
 
     /// <summary>
-    /// In-cluster type rank after |?x| and note time. Lower = preferred.
+    /// In-cluster type rank after |dx| and note time. Lower = preferred.
     /// Click / CDrag head beat Hold on same-time / same-position ties so chart id
     /// alone does not decide who consumes FingerDown.
     /// </summary>

--- a/engines/unity/Assets/Scripts/Game/InputController.cs
+++ b/engines/unity/Assets/Scripts/Game/InputController.cs
@@ -7,7 +7,7 @@ public class InputController : MonoBehaviour
     /// <summary>
     /// Max note-to-note span (seconds) for one FingerDown hit cluster
     /// (true or pseudo simultaneous press). Applies to Click / CDrag head / unheld Hold.
-    /// Candidates are re-clustered each Down by <c>effectiveNoteTime</c> span ≤ this gap
+    /// Candidates are re-clustered each Down by <c>effectiveNoteTime</c> span <= this gap
     /// (no adjacent-gap chain expansion). Soft fallthrough across clusters remains.
     /// In-cluster rank: see <see cref="OrderHitCandidatesByNoteTimeClusters"/>.
     /// Flick stays list-order bind; Drag settles all colliding eligible notes per input.
@@ -25,19 +25,19 @@ public class InputController : MonoBehaviour
     public const float DragCoHitWindowSeconds = 0.030f;
 
     /// <summary>
-    /// Clear FX budget for stacked-drag settle; aliases
-    /// <see cref="EffectController.MaxClearFxPerFrame"/> (also covers armed/Auto Clear).
+    /// Clear FX budget for one co-located drag-stack settle; aliases
+    /// <see cref="EffectController.MaxClearFxPerDragBatch"/>.
     /// </summary>
-    public const int DragBatchMaxClearFx = EffectController.MaxClearFxPerFrame;
+    public const int DragBatchMaxClearFx = EffectController.MaxClearFxPerDragBatch;
 
     /// <summary>
-    /// Hit-sound budget for stacked-drag settle; aliases
-    /// <see cref="EffectController.MaxHitSoundsPerFrame"/>.
+    /// Hit-sound budget for one co-located drag-stack settle; aliases
+    /// <see cref="EffectController.MaxHitSoundsPerDragBatch"/>.
     /// </summary>
-    public const int DragBatchMaxHitSounds = EffectController.MaxHitSoundsPerFrame;
+    public const int DragBatchMaxHitSounds = EffectController.MaxHitSoundsPerDragBatch;
 
     /// <summary>
-    /// Max |ΔeffectiveNoteTime| from the DragCoHit representative (first colliding
+    /// Max |delta effectiveNoteTime| from the DragCoHit representative (first colliding
     /// non-Miss in list order) for other colliding Drags settled in the same batch.
     /// Keeps same-tick stacks co-clearing without changing which Drag gates Select.
     /// </summary>
@@ -138,16 +138,28 @@ public class InputController : MonoBehaviour
             ? game.camera.ScreenToWorldPoint(finger.ScreenPosition)
             : game.camera.ScreenToWorldPoint(new Vector3(finger.ScreenPosition.x, finger.ScreenPosition.y, 10));
 
-        // Collect all colliding eligible Drags without settling yet: Immediate vs Armed
-        // depends on whether a higher-priority Select candidate claims this fresh Down.
-        // Misses still settle immediately and do not arm DragCoHit.
-        var acceptedDrag = CollectCollidingDragBatch(pressedPosition);
+        // Collect + settle under one drag-stack FX/SFX budget so Miss clears during
+        // collection share the same caps as the co-located non-Miss batch.
+        var effects = game.effectController;
+        effects.BeginClearBatch(DragBatchMaxClearFx, DragBatchMaxHitSounds);
+        Note acceptedSelect;
+        try
+        {
+            // Collect all colliding eligible Drags without settling yet: Immediate vs Armed
+            // depends on whether a higher-priority Select candidate claims this fresh Down.
+            // Misses still settle immediately and do not arm DragCoHit.
+            var acceptedDrag = CollectCollidingDragBatch(pressedPosition);
 
-        // Select is still gated by the accepted Drag before either candidate settles,
-        // preserving DragCoHit and cross-page suppression without changing event order.
-        var acceptedSelect = FindAcceptedSelect(finger, pressedPosition, acceptedDrag);
+            // Select is still gated by the accepted Drag before either candidate settles,
+            // preserving DragCoHit and cross-page suppression without changing event order.
+            acceptedSelect = FindAcceptedSelect(finger, pressedPosition, acceptedDrag);
 
-        SettleDragBatch(finger.ScreenPosition, deferred: acceptedSelect != null);
+            SettleDragBatch(finger.ScreenPosition, deferred: acceptedSelect != null);
+        }
+        finally
+        {
+            effects.EndClearBatch();
+        }
 
         AcceptSelect(acceptedSelect, finger, pressedPosition);
     }
@@ -155,7 +167,7 @@ public class InputController : MonoBehaviour
     /// <summary>
     /// Collects a Drag settle batch and returns the DragCoHit representative.
     /// Representative is the first colliding non-Miss in <see cref="TouchableDragNotes"/>
-    /// list order — same as legacy <c>FindAcceptedDrag</c>, so Select gating is unchanged.
+    /// list order -- same as legacy <c>FindAcceptedDrag</c>, so Select gating is unchanged.
     /// Additional colliding non-Miss notes within
     /// <see cref="DragStackBatchGapSeconds"/> of that note are added to
     /// <see cref="dragBatchScratch"/> for co-clear. Misses before the representative
@@ -200,37 +212,37 @@ public class InputController : MonoBehaviour
     }
 
     /// <summary>
-    /// Settles <see cref="dragBatchScratch"/> under the shared per-frame clear-FX /
-    /// hit-sound budget (<see cref="EffectController.MaxClearFxPerFrame"/>).
+    /// Settles <see cref="dragBatchScratch"/>. Caller must hold
+    /// <see cref="EffectController.BeginClearBatch"/> so immediate Clears (including
+    /// Misses collected earlier) share one co-located drag-stack FX/SFX budget.
     /// When <paramref name="deferred"/> is false, only the DragCoHit representative
     /// (index 0) uses immediate <see cref="Note.OnTouch"/> -- same as legacy Down.
     /// The rest of the stack uses <see cref="Note.OnTouchDeferred"/>, matching the
     /// legacy FingerUpdate path so early contacts still arm to perfect time.
     /// When <paramref name="deferred"/> is true (Select claimed the Down), every
-    /// note in the batch is deferred. Armed notes that later Clear in
-    /// <see cref="Note"/> still share the same per-frame FX/SFX budget.
+    /// note in the batch is deferred. Multi-note stacks that arm mark
+    /// <see cref="Note.MarkDragStackBudget"/> so later co-clears share the same caps
+    /// via <see cref="EffectController.EnsureDragStackBudget"/> without affecting
+    /// Click/Flick/Hold/Auto feedback.
     /// </summary>
     private void SettleDragBatch(Vector2 screenPos, bool deferred)
     {
         if (dragBatchScratch.Count == 0) return;
 
-        var effects = game.effectController;
-        effects.BeginClearBatch(DragBatchMaxClearFx, DragBatchMaxHitSounds);
-        try
+        var budgetStack = dragBatchScratch.Count > 1;
+        for (var i = 0; i < dragBatchScratch.Count; i++)
         {
-            for (var i = 0; i < dragBatchScratch.Count; i++)
+            var note = dragBatchScratch[i];
+            if (!IsTouchableNote(note)) continue;
+            if (deferred || i > 0)
             {
-                var note = dragBatchScratch[i];
-                if (!IsTouchableNote(note)) continue;
-                if (deferred || i > 0) note.OnTouchDeferred(screenPos);
-                else note.OnTouch(screenPos);
+                note.OnTouchDeferred(screenPos);
+                if (budgetStack && note.IsArmed) note.MarkDragStackBudget();
             }
+            else note.OnTouch(screenPos);
         }
-        finally
-        {
-            effects.EndClearBatch();
-            dragBatchScratch.Clear();
-        }
+
+        dragBatchScratch.Clear();
     }
 
     /// <summary>
@@ -381,9 +393,18 @@ public class InputController : MonoBehaviour
             if (cleared) FlickingNotes.Remove(finger.Index);
         }
 
-        // Drag: continuous contact — clear/arm colliding stack batch in one pass
-        CollectCollidingDragBatch(pos);
-        SettleDragBatch(finger.ScreenPosition, deferred: true);
+        // Drag: continuous contact -- clear/arm colliding stack batch in one pass
+        var effects = game.effectController;
+        effects.BeginClearBatch(DragBatchMaxClearFx, DragBatchMaxHitSounds);
+        try
+        {
+            CollectCollidingDragBatch(pos);
+            SettleDragBatch(finger.ScreenPosition, deferred: true);
+        }
+        finally
+        {
+            effects.EndClearBatch();
+        }
 
         // If this is a new finger (Down did not already bind a Hold)
         if (!HoldingNotes.ContainsKey(finger.Index))
@@ -462,9 +483,9 @@ public class InputController : MonoBehaviour
 
     /// <summary>
     /// Order Click / CDrag-head / Hold candidates for one FingerDown.
-    /// Sort by <c>effectiveNoteTime</c>, then split into clusters with span ≤
+    /// Sort by <c>effectiveNoteTime</c>, then split into clusters with span ?
     /// <see cref="NoteClusterGapSeconds"/> (earlier clusters first; soft fallthrough).
-    /// Within a cluster: |Δx| → note time → type (Click/CDrag head before Hold) → id.
+    /// Within a cluster: |?x| ? note time ? type (Click/CDrag head before Hold) ? id.
     /// Flick is never passed here (list-order bind on the scan path).
     /// Not re-entrant: mutates <see cref="hitCandidates"/> / <c>clusterScratch</c> while yielding.
     /// </summary>
@@ -515,7 +536,7 @@ public class InputController : MonoBehaviour
     }
 
     /// <summary>
-    /// In-cluster type rank after |Δx| and note time. Lower = preferred.
+    /// In-cluster type rank after |?x| and note time. Lower = preferred.
     /// Click / CDrag head beat Hold on same-time / same-position ties so chart id
     /// alone does not decide who consumes FingerDown.
     /// </summary>

--- a/engines/unity/Assets/Scripts/Game/Notes/Note.cs
+++ b/engines/unity/Assets/Scripts/Game/Notes/Note.cs
@@ -28,10 +28,11 @@ public abstract class Note : MonoBehaviour
     public bool IsArmed { get; private set; }
     private NoteGrade armedGrade = NoteGrade.None;
     /// <summary>
-    /// When set, the next <see cref="Clear"/> opens a drag-stack FX/SFX budget for
-    /// co-located deferred settles only (see <see cref="MarkDragStackBudget"/>).
+    /// When set, the next <see cref="Clear"/> joins a deferred drag-stack soft budget
+    /// (see <see cref="MarkDragStackBudget"/>).
     /// </summary>
     private bool dragStackBudgetPending;
+    private int dragStackBudgetId;
 
     // For ranked mode: weighted difference between the current timing and the perfect timing
     public float GreatGradeWeight { get; protected set; }
@@ -57,6 +58,7 @@ public abstract class Note : MonoBehaviour
         IsArmed = false;
         armedGrade = NoteGrade.None;
         dragStackBudgetPending = false;
+        dragStackBudgetId = 0;
     
         Chart = Game.Chart.Model;
         Model = Game.Chart.Model.note_map[noteId];
@@ -102,6 +104,7 @@ public abstract class Note : MonoBehaviour
         IsArmed = default;
         armedGrade = NoteGrade.None;
         dragStackBudgetPending = false;
+        dragStackBudgetId = 0;
         GreatGradeWeight = default;
         JudgmentOffset = default;
     }
@@ -114,26 +117,39 @@ public abstract class Note : MonoBehaviour
         armedGrade = NoteGrade.None;
         IsCleared = true;
 
-        // Deferred multi-note drag stacks open a same-frame budget before FX/SFX.
-        // Ordinary Click/Flick/Hold/Auto clears remain uncapped.
+        // Deferred multi-note drag stacks join a per-stack soft budget for this Clear only.
+        // Ordinary Click/Flick/Hold/Auto clears remain uncapped even in the same frame.
+        var effects = Game.effectController;
+        var joinedDragStackBudget = false;
         if (dragStackBudgetPending)
         {
             dragStackBudgetPending = false;
-            Game.effectController.EnsureDragStackBudget(
+            var stackId = dragStackBudgetId;
+            dragStackBudgetId = 0;
+            effects.EnterDragStackClear(
                 EffectController.MaxClearFxPerDragBatch,
-                EffectController.MaxHitSoundsPerDragBatch);
+                EffectController.MaxHitSoundsPerDragBatch,
+                stackId);
+            joinedDragStackBudget = true;
         }
 
-        Renderer.OnClear(grade);
-        Game.State.Judge(this, grade, -TimeUntilEnd, GreatGradeWeight);
-        Game.onNoteJudged.Invoke(Game, this, new JudgeData(grade, -TimeUntilEnd, GreatGradeWeight));
-
-        // Hit sound (drag-stack budget via EffectController when active)
-        if (grade != NoteGrade.Miss &&
-            (!(this is HoldNote) || Context.Player.Settings.HoldHitSoundTiming.Let(it => it == HoldHitSoundTiming.End || it == HoldHitSoundTiming.Both)) &&
-            Game.effectController.TryConsumeHitSound())
+        try
         {
-            PlayHitSound();
+            Renderer.OnClear(grade);
+            Game.State.Judge(this, grade, -TimeUntilEnd, GreatGradeWeight);
+            Game.onNoteJudged.Invoke(Game, this, new JudgeData(grade, -TimeUntilEnd, GreatGradeWeight));
+
+            // Hit sound (drag-stack budget via EffectController when this clear participates)
+            if (grade != NoteGrade.Miss &&
+                (!(this is HoldNote) || Context.Player.Settings.HoldHitSoundTiming.Let(it => it == HoldHitSoundTiming.End || it == HoldHitSoundTiming.Both)) &&
+                effects.TryConsumeHitSound())
+            {
+                PlayHitSound();
+            }
+        }
+        finally
+        {
+            if (joinedDragStackBudget) effects.ExitDragStackClear();
         }
 
         Game.onNoteClear.Invoke(Game, this);
@@ -142,11 +158,13 @@ public abstract class Note : MonoBehaviour
 
     /// <summary>
     /// Marks this note so its later armed <see cref="Clear"/> shares the co-located
-    /// drag-stack FX/SFX budget with sibling stack notes clearing in the same frame.
+    /// drag-stack FX/SFX budget with siblings that received the same
+    /// <paramref name="stackId"/>.
     /// </summary>
-    public void MarkDragStackBudget()
+    public void MarkDragStackBudget(int stackId)
     {
         dragStackBudgetPending = true;
+        dragStackBudgetId = stackId;
     }
 
     public virtual void PlayHitSound()

--- a/engines/unity/Assets/Scripts/Game/Notes/Note.cs
+++ b/engines/unity/Assets/Scripts/Game/Notes/Note.cs
@@ -27,6 +27,11 @@ public abstract class Note : MonoBehaviour
     public bool IsCleared { get; private set; }
     public bool IsArmed { get; private set; }
     private NoteGrade armedGrade = NoteGrade.None;
+    /// <summary>
+    /// When set, the next <see cref="Clear"/> opens a drag-stack FX/SFX budget for
+    /// co-located deferred settles only (see <see cref="MarkDragStackBudget"/>).
+    /// </summary>
+    private bool dragStackBudgetPending;
 
     // For ranked mode: weighted difference between the current timing and the perfect timing
     public float GreatGradeWeight { get; protected set; }
@@ -51,6 +56,7 @@ public abstract class Note : MonoBehaviour
         IsCollected = false;
         IsArmed = false;
         armedGrade = NoteGrade.None;
+        dragStackBudgetPending = false;
     
         Chart = Game.Chart.Model;
         Model = Game.Chart.Model.note_map[noteId];
@@ -95,6 +101,7 @@ public abstract class Note : MonoBehaviour
         IsCleared = default;
         IsArmed = default;
         armedGrade = NoteGrade.None;
+        dragStackBudgetPending = false;
         GreatGradeWeight = default;
         JudgmentOffset = default;
     }
@@ -106,11 +113,22 @@ public abstract class Note : MonoBehaviour
         IsArmed = false;
         armedGrade = NoteGrade.None;
         IsCleared = true;
+
+        // Deferred multi-note drag stacks open a same-frame budget before FX/SFX.
+        // Ordinary Click/Flick/Hold/Auto clears remain uncapped.
+        if (dragStackBudgetPending)
+        {
+            dragStackBudgetPending = false;
+            Game.effectController.EnsureDragStackBudget(
+                EffectController.MaxClearFxPerDragBatch,
+                EffectController.MaxHitSoundsPerDragBatch);
+        }
+
         Renderer.OnClear(grade);
         Game.State.Judge(this, grade, -TimeUntilEnd, GreatGradeWeight);
         Game.onNoteJudged.Invoke(Game, this, new JudgeData(grade, -TimeUntilEnd, GreatGradeWeight));
 
-        // Hit sound (frame / batch budget via EffectController)
+        // Hit sound (drag-stack budget via EffectController when active)
         if (grade != NoteGrade.Miss &&
             (!(this is HoldNote) || Context.Player.Settings.HoldHitSoundTiming.Let(it => it == HoldHitSoundTiming.End || it == HoldHitSoundTiming.Both)) &&
             Game.effectController.TryConsumeHitSound())
@@ -120,6 +138,15 @@ public abstract class Note : MonoBehaviour
 
         Game.onNoteClear.Invoke(Game, this);
         AwaitAndCollect();
+    }
+
+    /// <summary>
+    /// Marks this note so its later armed <see cref="Clear"/> shares the co-located
+    /// drag-stack FX/SFX budget with sibling stack notes clearing in the same frame.
+    /// </summary>
+    public void MarkDragStackBudget()
+    {
+        dragStackBudgetPending = true;
     }
 
     public virtual void PlayHitSound()


### PR DESCRIPTION
## Summary
- Follow-up to #199: the clear FX / hit-sound caps no longer apply as a global per-frame budget that mutes Click / Flick / Hold / Auto.
- Budget is active only for co-located drag-stack settles (`BeginClearBatch` / `EndClearBatch`), including Miss clears collected in the same pass.
- Deferred armed multi-note stacks share caps via `MarkDragStackBudget(stackId)` + `EnterDragStackClear` / `ExitDragStackClear`. Soft consumption applies **only while that Clear is a stack participant**, so same-frame Auto / Miss / Hold / Click remain uncapped.
- Distinct deferred stacks get distinct `stackId`s and therefore fresh soft quotas in the same frame.

Addresses Teages's blocking review on #199 about global budget scope and the no-op batch API.

## Test plan
- [ ] Dense same-position drag stack: still batch-clears; at most 3 clear FX / 1 hit sound for that stack settle
- [ ] Chord of Click / Flick / Hold in one frame (no drag stack): full FX and hit sounds (not capped by drag budget)
- [ ] Drag + Click same Down (DragCoHit): Select still gets feedback when it clears outside the drag batch
- [ ] Passive early contact on a multi-note stack: arms, then co-clears at perfect time with stack budget only
- [ ] Deferred stack co-clear same frame as Auto / Miss / Hold-end: non-stack notes keep full FX/SFX
- [ ] Two deferred multi-note stacks co-clearing same frame: each gets its own 3 FX / 1 hit-sound quota
- [ ] Normal spaced drag chain: no skipping; single notes remain uncapped
- [ ] Autoplay / mass Miss of non-drag notes: not limited by drag-stack budget

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved visual-effect and hit-sound limits across complete drag actions, including missed notes and deferred clears.
  * Prevented unintended per-frame throttling for effects outside active drag batches.
  * Improved consistency when handling grouped note interactions and shared visual and audio effects.
  * Ensured nested and deferred drag clears share limits reliably across the full interaction.

* **Refactor**
  * Updated drag-batch terminology and effect-limit configuration to reflect the new behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->