### PR TITLE
fix(storyboard): harden trigger destroy, shared resources, and RT cleanup

### DIFF
--- a/engines/unity/Assets/Editor/Tests/StoryboardLifecycleGuardTests.cs
+++ b/engines/unity/Assets/Editor/Tests/StoryboardLifecycleGuardTests.cs
@@ -74,7 +74,7 @@ public class StoryboardLifecycleGuardTests
         Assert.That(spawn, Does.Contain("catch"));
         Assert.That(init, Does.Contain("await renderer.Initialize()"));
         Assert.That(init, Does.Contain("RollbackSpawnedRenderer(renderer)"));
-        Assert.That(rollback, Does.Contain("DestroyObject(id, renderer)"));
+        Assert.That(rollback, Does.Contain("DestroyObjectsById(id)"));
 
         var publish = spawn.IndexOf("ComponentRenderers[transformedObj.Id] = renderer");
         var parentCheck = spawn.IndexOf("transformedObj.ParentId != null");
@@ -84,6 +84,35 @@ public class StoryboardLifecycleGuardTests
         Assert.That(publish, Is.GreaterThanOrEqualTo(0), "ComponentRenderers publish missing");
         Assert.That(publish, Is.GreaterThan(parentCheck));
         Assert.That(publish, Is.GreaterThan(targetCheck));
+    }
+
+    [Test]
+    public void StoryboardRenderer_Initialize_DisposesOnFailure()
+    {
+        var body = MethodBody(
+            Path.Combine(Application.dataPath, "Scripts/Storyboard/StoryboardRenderer.cs"),
+            "public async UniTask Initialize()",
+            null);
+        Assert.That(body, Does.Contain("catch"));
+        Assert.That(body, Does.Contain("Dispose()"));
+        Assert.That(body, Does.Contain("throw"));
+        // Listeners must register only after successful spawn batches.
+        var catchIdx = body.IndexOf("catch");
+        var disposeListenerIdx = body.IndexOf("Game.onGameDisposed.AddListener");
+        Assert.That(catchIdx, Is.GreaterThanOrEqualTo(0));
+        Assert.That(disposeListenerIdx, Is.GreaterThan(catchIdx));
+    }
+
+    [Test]
+    public void Storyboard_Initialize_DisposesOnFailure()
+    {
+        var body = MethodBody(
+            Path.Combine(Application.dataPath, "Scripts/Storyboard/Storyboard.cs"),
+            "public async UniTask Initialize()",
+            null);
+        Assert.That(body, Does.Contain("catch"));
+        Assert.That(body, Does.Contain("Dispose()"));
+        Assert.That(body, Does.Contain("throw"));
     }
 
     [Test]

--- a/engines/unity/Assets/Editor/Tests/StoryboardLifecycleGuardTests.cs
+++ b/engines/unity/Assets/Editor/Tests/StoryboardLifecycleGuardTests.cs
@@ -44,14 +44,59 @@ public class StoryboardLifecycleGuardTests
     }
 
     [Test]
+    public void StoryboardRenderer_OnGameUpdate_DestroysFlattenForward()
+    {
+        // Brace-scoped to OnGameUpdate only (not the rest of the type).
+        var body = MethodBody(
+            Path.Combine(Application.dataPath, "Scripts/Storyboard/StoryboardRenderer.cs"),
+            "public void OnGameUpdate(Game _)",
+            null);
+        Assert.That(body, Does.Contain(".Flatten(it => it.Children)"));
+        Assert.That(body, Does.Contain("EnqueueDestroy(it.Component.Id)"));
+        Assert.That(body, Does.Contain("for (var i = 0; i < renderersToDestroy.Count; i++)"));
+        Assert.That(body, Does.Contain("DestroyObject(id, renderer)"));
+        Assert.That(body, Does.Not.Contain("Count - 1"));
+        Assert.That(body, Does.Not.Contain("i >= 0; i--"));
+        Assert.That(body, Does.Not.Contain("EnqueueDestroy(renderer.Parent.Component.Id)"));
+    }
+
+    [Test]
+    public void StoryboardRenderer_SpawnObjects_RollsBackOnFailure()
+    {
+        var path = Path.Combine(Application.dataPath, "Scripts/Storyboard/StoryboardRenderer.cs");
+        // Brace-scope each method so helper definitions cannot satisfy SpawnObjects assertions.
+        var spawn = MethodBody(path, "private async UniTask<List<TR>> SpawnObjects", null);
+        var init = MethodBody(path, "private async UniTask InitializeSpawnedRenderer", null);
+        var rollback = MethodBody(path, "private void RollbackSpawnedRenderer", null);
+
+        Assert.That(spawn, Does.Contain("tasks.Add(InitializeSpawnedRenderer(renderer))"));
+        Assert.That(spawn, Does.Contain("RollbackSpawnedRenderer(renderer)"));
+        Assert.That(spawn, Does.Contain("catch"));
+        Assert.That(init, Does.Contain("await renderer.Initialize()"));
+        Assert.That(init, Does.Contain("RollbackSpawnedRenderer(renderer)"));
+        Assert.That(rollback, Does.Contain("DestroyObject(id, renderer)"));
+
+        var publish = spawn.IndexOf("ComponentRenderers[transformedObj.Id] = renderer");
+        var parentCheck = spawn.IndexOf("transformedObj.ParentId != null");
+        var targetCheck = spawn.IndexOf("transformedObj.TargetId != null");
+        Assert.That(parentCheck, Is.GreaterThanOrEqualTo(0), "parent_id check missing");
+        Assert.That(targetCheck, Is.GreaterThanOrEqualTo(0), "target_id check missing");
+        Assert.That(publish, Is.GreaterThanOrEqualTo(0), "ComponentRenderers publish missing");
+        Assert.That(publish, Is.GreaterThan(parentCheck));
+        Assert.That(publish, Is.GreaterThan(targetCheck));
+    }
+
+    [Test]
     public void StoryboardRenderer_DestroyObject_UsesObjectType()
     {
         var body = MethodBody(
             Path.Combine(Application.dataPath, "Scripts/Storyboard/StoryboardRenderer.cs"),
             "public void DestroyObject(string id, StoryboardComponentRenderer renderer)",
-            "private static void DetachFromParent");
+            null);
         Assert.That(body, Does.Contain("renderer.ObjectType"));
         Assert.That(body, Does.Not.Contain("GetType()"));
+        Assert.That(body, Does.Contain("finally"));
+        Assert.That(body, Does.Contain("ReferenceEquals(current, renderer)"));
     }
 
     [Test]

--- a/engines/unity/Assets/Editor/Tests/StoryboardLifecycleGuardTests.cs
+++ b/engines/unity/Assets/Editor/Tests/StoryboardLifecycleGuardTests.cs
@@ -3,64 +3,124 @@ using System.IO;
 using NUnit.Framework;
 using UnityEngine;
 
-// Source-level guards for storyboard lifecycle fixes (trigger remove, destroy typing, RT release).
+// Temporary source-level guards for storyboard lifecycle fixes.
+// Prefer behavioral tests when EditMode can host Storyboard/AssetMemory fixtures.
 public class StoryboardLifecycleGuardTests
 {
     [Test]
-    public void Storyboard_OnNoteClear_DoesNotForeachRemoveTriggers()
+    public void Storyboard_OnNoteClear_FiresInOrderThenRemovesSafely()
     {
-        var source = File.ReadAllText(Path.Combine(Application.dataPath, "Scripts/Storyboard/Storyboard.cs"));
-        var methodStart = source.IndexOf("public void OnNoteClear(Game game, Note note)");
-        Assert.That(methodStart, Is.GreaterThanOrEqualTo(0));
-        var methodEnd = source.IndexOf("public bool OnTrigger(Trigger trigger)", methodStart);
-        Assert.That(methodEnd, Is.GreaterThan(methodStart));
-        var body = source.Substring(methodStart, methodEnd - methodStart);
+        var body = MethodBody(
+            Path.Combine(Application.dataPath, "Scripts/Storyboard/Storyboard.cs"),
+            "public void OnNoteClear(Game game, Note note)",
+            "public bool OnTrigger(Trigger trigger)");
         Assert.That(body, Does.Not.Contain("foreach (var trigger in Triggers)"));
-        Assert.That(body, Does.Contain("for (var i = Triggers.Count - 1; i >= 0; i--)"));
+        Assert.That(body, Does.Contain("for (var i = 0; i < Triggers.Count; i++)"));
         Assert.That(body, Does.Contain("Triggers.RemoveAt(i)"));
+        Assert.That(body, Does.Contain("removals"));
     }
 
     [Test]
     public void Storyboard_OnTrigger_ReturnsShouldRemoveInsteadOfMutatingList()
     {
-        var source = File.ReadAllText(Path.Combine(Application.dataPath, "Scripts/Storyboard/Storyboard.cs"));
-        var methodStart = source.IndexOf("public bool OnTrigger(Trigger trigger)");
-        Assert.That(methodStart, Is.GreaterThanOrEqualTo(0));
-        var methodEnd = source.IndexOf("public JObject Compile()", methodStart);
-        Assert.That(methodEnd, Is.GreaterThan(methodStart));
-        var body = source.Substring(methodStart, methodEnd - methodStart);
+        var body = MethodBody(
+            Path.Combine(Application.dataPath, "Scripts/Storyboard/Storyboard.cs"),
+            "public bool OnTrigger(Trigger trigger)",
+            "public JObject Compile()");
         Assert.That(body, Does.Not.Contain("Triggers.Remove"));
         Assert.That(body, Does.Contain("return trigger.CurrentUses == trigger.Uses"));
     }
 
     [Test]
-    public void TextureScaler_ReleasesTemporaryRenderTexture()
+    public void TextureScaler_ReleaseTemporary_RestoresActiveAndDestroysRt()
     {
-        var source = File.ReadAllText(Path.Combine(Application.dataPath, "Scripts/Utils/TextureScaler.cs"));
-        Assert.That(source, Does.Contain("ReleaseTemporary"));
-        Assert.That(source, Does.Contain("temporary.Release()"));
-        Assert.That(source, Does.Contain("Object.Destroy(temporary)"));
-        Assert.That(source, Does.Contain("RenderTexture.active = previous"));
+        var body = MethodBody(
+            Path.Combine(Application.dataPath, "Scripts/Utils/TextureScaler.cs"),
+            "static void ReleaseTemporary(RenderTexture temporary, RenderTexture previous)",
+            null);
+        Assert.That(body, Does.Contain("RenderTexture.active = previous"));
+        Assert.That(body, Does.Contain("temporary.Release()"));
+        Assert.That(body, Does.Contain("Object.Destroy(temporary)"));
     }
 
     [Test]
-    public void StoryboardRenderer_DestroyUsesObjectTypeNotGetType()
+    public void StoryboardRenderer_DestroyObject_UsesObjectType()
     {
-        var source = File.ReadAllText(Path.Combine(Application.dataPath, "Scripts/Storyboard/StoryboardRenderer.cs"));
-        Assert.That(source, Does.Contain("renderer.ObjectType"));
-        Assert.That(source, Does.Not.Contain("TypedComponentRenderers[it.GetType()]"));
-        Assert.That(source, Does.Contain("public void DestroyObject(string id, StoryboardComponentRenderer renderer)"));
+        var body = MethodBody(
+            Path.Combine(Application.dataPath, "Scripts/Storyboard/StoryboardRenderer.cs"),
+            "public void DestroyObject(string id, StoryboardComponentRenderer renderer)",
+            "private static void DetachFromParent");
+        Assert.That(body, Does.Contain("renderer.ObjectType"));
+        Assert.That(body, Does.Not.Contain("GetType()"));
     }
 
     [Test]
-    public void StoryboardRenderers_GuardSharedResourceOwnership()
+    public void SpriteRenderer_StaleLoad_UsesCapturedPathAndRenderer()
     {
-        Assert.That(File.ReadAllText(Path.Combine(Application.dataPath, "Scripts/Storyboard/Videos/VideoRenderer.cs")),
-            Does.Contain("ownsResources"));
-        Assert.That(File.ReadAllText(Path.Combine(Application.dataPath, "Scripts/Storyboard/Sprites/SpriteRenderer.cs")),
-            Does.Contain("IsInitializeStale"));
-        Assert.That(File.ReadAllText(Path.Combine(Application.dataPath, "Scripts/Storyboard/Sprites/SpriteRenderer.cs")),
-            Does.Contain("ReleaseUnusedLoadedAsset"));
+        var body = MethodBody(
+            Path.Combine(Application.dataPath, "Scripts/Storyboard/Sprites/SpriteRenderer.cs"),
+            "public override async UniTask Initialize()",
+            "public override void Clear()");
+        Assert.That(body, Does.Contain("var loadPath ="));
+        Assert.That(body, Does.Contain("var mainRenderer = MainRenderer"));
+        Assert.That(body, Does.Contain("ReleaseUnusedLoadedAsset(loadPath, mainRenderer)"));
+        Assert.That(body, Does.Contain("IsInitializeStale"));
+    }
+
+    [Test]
+    public void VideoRenderer_OwnsResourcesGate()
+    {
+        var body = MethodBody(
+            Path.Combine(Application.dataPath, "Scripts/Storyboard/Videos/VideoRenderer.cs"),
+            "public override void Dispose()",
+            "private void UnsubscribePrepareCompleted");
+        Assert.That(body, Does.Contain("if (ownsResources)"));
+        Assert.That(body, Does.Contain("base.Dispose()"));
+    }
+
+    [Test]
+    public void AssetMemory_WaiterRetriesWhenLeaderDroppedCache()
+    {
+        var body = MethodBody(
+            Path.Combine(Application.dataPath, "Scripts/Utils/AssetMemory.cs"),
+            "public async UniTask<T> LoadAsset<T>(",
+            "public bool DisposeAsset(string path, AssetTag tag)");
+        Assert.That(body, Does.Contain("return await LoadAsset<T>(path, tag, cancellationToken)"));
+        Assert.That(body, Does.Not.Contain("Concurrent asset load failed"));
+    }
+
+    static string MethodBody(string path, string startMarker, string endMarker)
+    {
+        var source = File.ReadAllText(path);
+        var methodStart = source.IndexOf(startMarker);
+        Assert.That(methodStart, Is.GreaterThanOrEqualTo(0), $"Missing start marker: {startMarker}");
+        int methodEnd;
+        if (endMarker == null)
+        {
+            methodEnd = source.IndexOf('{', methodStart);
+            Assert.That(methodEnd, Is.GreaterThan(methodStart));
+            var depth = 0;
+            for (var i = methodEnd; i < source.Length; i++)
+            {
+                if (source[i] == '{') depth++;
+                else if (source[i] == '}')
+                {
+                    depth--;
+                    if (depth == 0)
+                    {
+                        methodEnd = i + 1;
+                        break;
+                    }
+                }
+            }
+        }
+        else
+        {
+            methodEnd = source.IndexOf(endMarker, methodStart);
+            Assert.That(methodEnd, Is.GreaterThan(methodStart), $"Missing end marker: {endMarker}");
+        }
+
+        return source.Substring(methodStart, methodEnd - methodStart);
     }
 }
 #endif

--- a/engines/unity/Assets/Editor/Tests/StoryboardLifecycleGuardTests.cs
+++ b/engines/unity/Assets/Editor/Tests/StoryboardLifecycleGuardTests.cs
@@ -1,0 +1,66 @@
+#if UNITY_INCLUDE_TESTS
+using System.IO;
+using NUnit.Framework;
+using UnityEngine;
+
+// Source-level guards for storyboard lifecycle fixes (trigger remove, destroy typing, RT release).
+public class StoryboardLifecycleGuardTests
+{
+    [Test]
+    public void Storyboard_OnNoteClear_DoesNotForeachRemoveTriggers()
+    {
+        var source = File.ReadAllText(Path.Combine(Application.dataPath, "Scripts/Storyboard/Storyboard.cs"));
+        var methodStart = source.IndexOf("public void OnNoteClear(Game game, Note note)");
+        Assert.That(methodStart, Is.GreaterThanOrEqualTo(0));
+        var methodEnd = source.IndexOf("public bool OnTrigger(Trigger trigger)", methodStart);
+        Assert.That(methodEnd, Is.GreaterThan(methodStart));
+        var body = source.Substring(methodStart, methodEnd - methodStart);
+        Assert.That(body, Does.Not.Contain("foreach (var trigger in Triggers)"));
+        Assert.That(body, Does.Contain("for (var i = Triggers.Count - 1; i >= 0; i--)"));
+        Assert.That(body, Does.Contain("Triggers.RemoveAt(i)"));
+    }
+
+    [Test]
+    public void Storyboard_OnTrigger_ReturnsShouldRemoveInsteadOfMutatingList()
+    {
+        var source = File.ReadAllText(Path.Combine(Application.dataPath, "Scripts/Storyboard/Storyboard.cs"));
+        var methodStart = source.IndexOf("public bool OnTrigger(Trigger trigger)");
+        Assert.That(methodStart, Is.GreaterThanOrEqualTo(0));
+        var methodEnd = source.IndexOf("public JObject Compile()", methodStart);
+        Assert.That(methodEnd, Is.GreaterThan(methodStart));
+        var body = source.Substring(methodStart, methodEnd - methodStart);
+        Assert.That(body, Does.Not.Contain("Triggers.Remove"));
+        Assert.That(body, Does.Contain("return trigger.CurrentUses == trigger.Uses"));
+    }
+
+    [Test]
+    public void TextureScaler_ReleasesTemporaryRenderTexture()
+    {
+        var source = File.ReadAllText(Path.Combine(Application.dataPath, "Scripts/Utils/TextureScaler.cs"));
+        Assert.That(source, Does.Contain("ReleaseTemporary"));
+        Assert.That(source, Does.Contain("temporary.Release()"));
+        Assert.That(source, Does.Contain("Object.Destroy(temporary)"));
+        Assert.That(source, Does.Contain("RenderTexture.active = previous"));
+    }
+
+    [Test]
+    public void StoryboardRenderer_DestroyUsesObjectTypeNotGetType()
+    {
+        var source = File.ReadAllText(Path.Combine(Application.dataPath, "Scripts/Storyboard/StoryboardRenderer.cs"));
+        Assert.That(source, Does.Contain("renderer.ObjectType"));
+        Assert.That(source, Does.Not.Contain("TypedComponentRenderers[it.GetType()]"));
+        Assert.That(source, Does.Contain("public void DestroyObject(string id, StoryboardComponentRenderer renderer)"));
+    }
+
+    [Test]
+    public void StoryboardRenderers_GuardSharedResourceOwnership()
+    {
+        Assert.That(File.ReadAllText(Path.Combine(Application.dataPath, "Scripts/Storyboard/Videos/VideoRenderer.cs")),
+            Does.Contain("ownsResources"));
+        Assert.That(File.ReadAllText(Path.Combine(Application.dataPath, "Scripts/Storyboard/Sprites/SpriteRenderer.cs")),
+            Does.Contain("IsInitializeStale"));
+        Assert.That(File.ReadAllText(Path.Combine(Application.dataPath, "Scripts/Storyboard/Sprites/SpriteRenderer.cs")),
+            Does.Contain("ReleaseUnusedLoadedAsset"));
+    }
+}
+#endif

--- a/engines/unity/Assets/Editor/Tests/StoryboardLifecycleGuardTests.cs.meta
+++ b/engines/unity/Assets/Editor/Tests/StoryboardLifecycleGuardTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b8d4f02e5c9a43b1af7e2d6c3b9a5f81
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/engines/unity/Assets/Scripts/Game/Game.cs
+++ b/engines/unity/Assets/Scripts/Game/Game.cs
@@ -278,6 +278,10 @@ public class Game : MonoBehaviour
             {
                 Debug.LogError($"[CYTOID-DBG] Game.Initialize: STORYBOARD LOAD FAILED: {e}");
                 Debug.LogError("Could not load storyboard.");
+                // Storyboard.Initialize disposes on failure, but clear the dangling reference so
+                // the rest of the session does not treat a failed load as an active storyboard.
+                Storyboard?.Dispose();
+                Storyboard = null;
             }
         }
         else

--- a/engines/unity/Assets/Scripts/Storyboard/Controllers/ControllerRenderer.cs
+++ b/engines/unity/Assets/Scripts/Storyboard/Controllers/ControllerRenderer.cs
@@ -30,6 +30,8 @@ namespace Cytoid.Storyboard.Controllers
 
         public override void Dispose()
         {
+            if (IsDisposed) return;
+            base.Dispose();
         }
 
     }

--- a/engines/unity/Assets/Scripts/Storyboard/Lines/LineRenderer.cs
+++ b/engines/unity/Assets/Scripts/Storyboard/Lines/LineRenderer.cs
@@ -9,10 +9,12 @@ namespace Cytoid.Storyboard.Sprites
     {
         public UnityEngine.LineRenderer Line { get; private set; }
 
-        public override Transform Transform => Line.transform;
-
+        public override Transform Transform => Line != null ? Line.transform : null;
+        
         public override bool IsOnCanvas => false;
 
+        private bool ownsResources;
+        
         public LineRenderer(StoryboardRenderer mainRenderer, Line component) : base(mainRenderer, component)
         {
         }
@@ -21,13 +23,16 @@ namespace Cytoid.Storyboard.Sprites
 
         public override async UniTask Initialize()
         {
+            BeginInitialize();
             var targetRenderer = GetTargetRenderer<LineRenderer>();
             if (targetRenderer != null)
             {
+                ownsResources = false;
                 Line = targetRenderer.Line;
             }
             else
             {
+                ownsResources = true;
                 var gameObject = new GameObject("Line_" + Component.Id);
                 gameObject.transform.parent = MainRenderer.Game.contentParent.transform;
                 Line = gameObject.AddComponent<UnityEngine.LineRenderer>();
@@ -37,6 +42,7 @@ namespace Cytoid.Storyboard.Sprites
 
         public override void Clear()
         {
+            if (Line == null) return;
             Line.positionCount = 0;
             Line.startColor = Line.endColor = UnityEngine.Color.white.WithAlpha(0);
             Line.startWidth = Line.endWidth = 0.05f;
@@ -45,7 +51,12 @@ namespace Cytoid.Storyboard.Sprites
 
         public override void Dispose()
         {
-            Destroy(Line.gameObject);
+            if (IsDisposed) return;
+            if (ownsResources && Line != null)
+                Destroy(Line.gameObject);
+            Line = null;
+            ownsResources = false;
+            base.Dispose();
         }
 
     }

--- a/engines/unity/Assets/Scripts/Storyboard/Notes/NoteControllerRenderer.cs
+++ b/engines/unity/Assets/Scripts/Storyboard/Notes/NoteControllerRenderer.cs
@@ -45,12 +45,14 @@ namespace Cytoid.Storyboard.Sprites
 
         public override void Dispose()
         {
+            if (IsDisposed) return;
             if (notePlaceholderTransform != null)
             {
                 UnityEngine.Object.Destroy(notePlaceholderTransform.gameObject);
             }
             notePlaceholderTransform = null;
             noteGameObject = null;
+            base.Dispose();
         }
 
         public override void Update(NoteControllerState fromState, NoteControllerState toState)

--- a/engines/unity/Assets/Scripts/Storyboard/Sprites/SpriteRenderer.cs
+++ b/engines/unity/Assets/Scripts/Storyboard/Sprites/SpriteRenderer.cs
@@ -63,25 +63,28 @@ namespace Cytoid.Storyboard.Sprites
                 }
                 Image.gameObject.name = $"Sprite[{spritePath}]";
 
-                LoadPath = MainRenderer.Game.UsesExternalContent
+                var loadPath = MainRenderer.Game.UsesExternalContent
                     ? GameLaunchVfs.ResolveRequiredFileUri(
                         MainRenderer.Game.Level.Path,
                         spritePath,
                         "storyboard.sprite.path")
                     : "file://" + MainRenderer.Game.Level.Path + spritePath;
-                var sprite = await Context.AssetMemory.LoadAsset<UnityEngine.Sprite>(LoadPath, AssetTag.Storyboard);
+                LoadPath = loadPath;
+                // Capture before await: Dispose may null MainRenderer / clear fields mid-load.
+                var mainRenderer = MainRenderer;
+                var sprite = await Context.AssetMemory.LoadAsset<UnityEngine.Sprite>(loadPath, AssetTag.Storyboard);
 
                 if (IsInitializeStale(version) || Image == null)
                 {
-                    ReleaseUnusedLoadedAsset();
+                    ReleaseUnusedLoadedAsset(loadPath, mainRenderer);
                     return;
                 }
 
                 Image.sprite = sprite;
 
-                if (!MainRenderer.SpritePathRefCount.ContainsKey(LoadPath))
-                    MainRenderer.SpritePathRefCount[LoadPath] = 0;
-                MainRenderer.SpritePathRefCount[LoadPath]++;
+                if (!mainRenderer.SpritePathRefCount.ContainsKey(loadPath))
+                    mainRenderer.SpritePathRefCount[loadPath] = 0;
+                mainRenderer.SpritePathRefCount[loadPath]++;
                 holdsAssetRef = true;
             }
         }
@@ -127,13 +130,18 @@ namespace Cytoid.Storyboard.Sprites
             holdsAssetRef = false;
         }
 
-        private void ReleaseUnusedLoadedAsset()
+        private static void ReleaseUnusedLoadedAsset(string loadPath, StoryboardRenderer mainRenderer)
         {
             // Stale completion: LoadAsset already pinned the cache entry, but no business ref was taken.
-            if (LoadPath == null || MainRenderer == null) return;
-            if (MainRenderer.SpritePathRefCount.TryGetValue(LoadPath, out var count) && count > 0)
+            if (string.IsNullOrEmpty(loadPath)) return;
+            if (mainRenderer != null &&
+                mainRenderer.SpritePathRefCount.TryGetValue(loadPath, out var count) &&
+                count > 0)
+            {
                 return;
-            Context.AssetMemory.DisposeAsset(LoadPath, AssetTag.Storyboard);
+            }
+
+            Context.AssetMemory.DisposeAsset(loadPath, AssetTag.Storyboard);
         }
 
     }

--- a/engines/unity/Assets/Scripts/Storyboard/Sprites/SpriteRenderer.cs
+++ b/engines/unity/Assets/Scripts/Storyboard/Sprites/SpriteRenderer.cs
@@ -18,6 +18,9 @@ namespace Cytoid.Storyboard.Sprites
 
         public string LoadPath { get; private set; }
 
+        private bool ownsResources;
+        private bool holdsAssetRef;
+
         public SpriteRenderer(StoryboardRenderer mainRenderer, Sprite component) : base(mainRenderer, component)
         {
         }
@@ -30,9 +33,11 @@ namespace Cytoid.Storyboard.Sprites
 
         public override async UniTask Initialize()
         {
+            var version = BeginInitialize();
             var targetRenderer = GetTargetRenderer<SpriteRenderer>();
             if (targetRenderer != null)
             {
+                ownsResources = false;
                 Image = targetRenderer.Image;
                 RectTransform = targetRenderer.RectTransform;
                 Canvas = targetRenderer.Canvas;
@@ -40,6 +45,7 @@ namespace Cytoid.Storyboard.Sprites
             }
             else
             {
+                ownsResources = true;
                 Image = Instantiate(Provider.SpritePrefab, GetParentTransform());
                 RectTransform = Image.rectTransform;
                 Canvas = Image.GetComponent<Canvas>();
@@ -63,34 +69,71 @@ namespace Cytoid.Storyboard.Sprites
                         spritePath,
                         "storyboard.sprite.path")
                     : "file://" + MainRenderer.Game.Level.Path + spritePath;
-                Image.sprite = await Context.AssetMemory.LoadAsset<UnityEngine.Sprite>(LoadPath, AssetTag.Storyboard);
+                var sprite = await Context.AssetMemory.LoadAsset<UnityEngine.Sprite>(LoadPath, AssetTag.Storyboard);
+
+                if (IsInitializeStale(version) || Image == null)
+                {
+                    ReleaseUnusedLoadedAsset();
+                    return;
+                }
+
+                Image.sprite = sprite;
 
                 if (!MainRenderer.SpritePathRefCount.ContainsKey(LoadPath))
                     MainRenderer.SpritePathRefCount[LoadPath] = 0;
                 MainRenderer.SpritePathRefCount[LoadPath]++;
+                holdsAssetRef = true;
             }
         }
 
         public override void Clear()
         {
-            Image.color = UnityEngine.Color.white;
-            Image.preserveAspect = true;
-            CanvasGroup.alpha = 0;
+            if (Image != null)
+            {
+                Image.color = UnityEngine.Color.white;
+                Image.preserveAspect = true;
+            }
+            if (CanvasGroup != null)
+                CanvasGroup.alpha = 0;
             IsTransformActive = false;
         }
 
         public override void Dispose()
         {
-            if (LoadPath != null && MainRenderer.SpritePathRefCount.ContainsKey(LoadPath))
+            if (IsDisposed) return;
+            ReleaseAssetRef();
+            if (ownsResources && Image != null)
+                Destroy(Image.gameObject);
+            Image = null;
+            RectTransform = null;
+            Canvas = null;
+            CanvasGroup = null;
+            ownsResources = false;
+            base.Dispose();
+        }
+
+        private void ReleaseAssetRef()
+        {
+            if (!holdsAssetRef || LoadPath == null || MainRenderer == null) return;
+            if (MainRenderer.SpritePathRefCount.ContainsKey(LoadPath))
             {
                 MainRenderer.SpritePathRefCount[LoadPath]--;
-                if (MainRenderer.SpritePathRefCount[LoadPath] == 0)
+                if (MainRenderer.SpritePathRefCount[LoadPath] <= 0)
                 {
+                    MainRenderer.SpritePathRefCount.Remove(LoadPath);
                     Context.AssetMemory.DisposeAsset(LoadPath, AssetTag.Storyboard);
                 }
             }
-            Destroy(Image.gameObject);
-            Image = null;
+            holdsAssetRef = false;
+        }
+
+        private void ReleaseUnusedLoadedAsset()
+        {
+            // Stale completion: LoadAsset already pinned the cache entry, but no business ref was taken.
+            if (LoadPath == null || MainRenderer == null) return;
+            if (MainRenderer.SpritePathRefCount.TryGetValue(LoadPath, out var count) && count > 0)
+                return;
+            Context.AssetMemory.DisposeAsset(LoadPath, AssetTag.Storyboard);
         }
 
     }

--- a/engines/unity/Assets/Scripts/Storyboard/Storyboard.cs
+++ b/engines/unity/Assets/Scripts/Storyboard/Storyboard.cs
@@ -149,39 +149,43 @@ namespace Cytoid.Storyboard
 
         public void OnNoteClear(Game game, Note note)
         {
-            foreach (var trigger in Triggers)
+            // Reverse walk so Uses-exhausted / Score one-shot removals never mutate during foreach.
+            for (var i = Triggers.Count - 1; i >= 0; i--)
             {
+                var trigger = Triggers[i];
+                var hit = false;
                 if (trigger.Type == TriggerType.NoteClear && trigger.Notes.Contains(note.Model.id))
                 {
                     trigger.Triggerer = note;
-                    OnTrigger(trigger);
+                    hit = true;
                 }
-
-                if (trigger.Type == TriggerType.Combo && Game.State.Combo == trigger.Combo)
+                else if (trigger.Type == TriggerType.Combo && Game.State.Combo == trigger.Combo)
                 {
                     trigger.Triggerer = note;
-                    OnTrigger(trigger);
+                    hit = true;
                 }
-
-                if (trigger.Type == TriggerType.Score && Game.State.Score >= trigger.Score)
+                else if (trigger.Type == TriggerType.Score && Game.State.Score >= trigger.Score)
                 {
                     trigger.Triggerer = note;
-                    OnTrigger(trigger);
-                    Triggers.Remove(trigger);
+                    hit = true;
                 }
+
+                if (!hit) continue;
+
+                var shouldRemove = OnTrigger(trigger);
+                // Score triggers remain one-shot after fire (legacy behavior).
+                if (shouldRemove || trigger.Type == TriggerType.Score)
+                    Triggers.RemoveAt(i);
             }
         }
 
-        public void OnTrigger(Trigger trigger)
+        /// <returns>True when the trigger should be removed from <see cref="Triggers"/>.</returns>
+        public bool OnTrigger(Trigger trigger)
         {
             Renderer.OnTrigger(trigger);
-            
-            // Destroy trigger if needed
+
             trigger.CurrentUses++;
-            if (trigger.CurrentUses == trigger.Uses)
-            {
-                Triggers.Remove(trigger);
-            }
+            return trigger.CurrentUses == trigger.Uses;
         }
 
         public JObject Compile()

--- a/engines/unity/Assets/Scripts/Storyboard/Storyboard.cs
+++ b/engines/unity/Assets/Scripts/Storyboard/Storyboard.cs
@@ -140,11 +140,21 @@ namespace Cytoid.Storyboard
 
         public async UniTask Initialize()
         {
-            await Renderer.Initialize();
-            // Register note clear listener for triggers
-            Game.onNoteClear.AddListener(OnNoteClear);
-            Game.onGameDisposed.AddListener(_ => Dispose());
-            Game.onGameLateUpdate.AddListener(Renderer.OnGameUpdate);
+            try
+            {
+                await Renderer.Initialize();
+                // Register note clear listener for triggers
+                Game.onNoteClear.AddListener(OnNoteClear);
+                Game.onGameDisposed.AddListener(_ => Dispose());
+                Game.onGameLateUpdate.AddListener(Renderer.OnGameUpdate);
+            }
+            catch
+            {
+                // Game.Initialize catches and continues; dispose partial renderer graph / parsed
+                // maps here so a failed load does not leave Storyboard state for the session.
+                Dispose();
+                throw;
+            }
         }
 
         public void OnNoteClear(Game game, Note note)

--- a/engines/unity/Assets/Scripts/Storyboard/Storyboard.cs
+++ b/engines/unity/Assets/Scripts/Storyboard/Storyboard.cs
@@ -149,8 +149,10 @@ namespace Cytoid.Storyboard
 
         public void OnNoteClear(Game game, Note note)
         {
-            // Reverse walk so Uses-exhausted / Score one-shot removals never mutate during foreach.
-            for (var i = Triggers.Count - 1; i >= 0; i--)
+            // Fire in registration order, then remove by descending index so list mutation is safe
+            // and same-frame multi-trigger side effects keep legacy spawn/update ordering.
+            var removals = new HashSet<Trigger>();
+            for (var i = 0; i < Triggers.Count; i++)
             {
                 var trigger = Triggers[i];
                 var hit = false;
@@ -175,6 +177,12 @@ namespace Cytoid.Storyboard
                 var shouldRemove = OnTrigger(trigger);
                 // Score triggers remain one-shot after fire (legacy behavior).
                 if (shouldRemove || trigger.Type == TriggerType.Score)
+                    removals.Add(trigger);
+            }
+
+            for (var i = Triggers.Count - 1; i >= 0; i--)
+            {
+                if (removals.Contains(Triggers[i]))
                     Triggers.RemoveAt(i);
             }
         }

--- a/engines/unity/Assets/Scripts/Storyboard/StoryboardComponentRenderer.cs
+++ b/engines/unity/Assets/Scripts/Storyboard/StoryboardComponentRenderer.cs
@@ -8,26 +8,44 @@ namespace Cytoid.Storyboard
     public abstract class StoryboardComponentRenderer
     {
         public Object Component { get; protected set; }
-
+        
         public List<StoryboardComponentRenderer> Children = new List<StoryboardComponentRenderer>();
 
         public StoryboardComponentRenderer Parent;
 
+        /// <summary>Storyboard object type key used in <see cref="StoryboardRenderer.TypedComponentRenderers"/>.</summary>
+        public abstract Type ObjectType { get; }
+        
         public abstract Transform Transform { get; }
-
+        
         public abstract Transform CanvasTransform { get; }
-
+        
         public abstract Transform WorldTransform { get; }
 
         public abstract bool IsOnCanvas { get; }
+
+        public bool IsDisposed { get; private set; }
+
+        protected int InitializeVersion { get; private set; }
 
         public abstract UniTask Initialize();
 
         public abstract void Clear();
 
-        public abstract void Dispose();
+        public virtual void Dispose()
+        {
+            if (IsDisposed) return;
+            IsDisposed = true;
+            InitializeVersion++;
+            Children.Clear();
+            Parent = null;
+        }
 
         public abstract void Update(ObjectState fromState, ObjectState toState);
+
+        protected int BeginInitialize() => ++InitializeVersion;
+
+        protected bool IsInitializeStale(int version) => IsDisposed || version != InitializeVersion;
 
         public bool IsTransformActive
         {
@@ -37,23 +55,26 @@ namespace Cytoid.Storyboard
                 if (isTransformActive != value)
                 {
                     isTransformActive = value;
-                    Transform.gameObject.SetActive(value);
+                    if (Transform != null)
+                        Transform.gameObject.SetActive(value);
                 }
             }
         }
 
         private bool isTransformActive;
-
+        
     }
-
+    
     public abstract class StoryboardComponentRenderer<TO, TS> : StoryboardComponentRenderer where TS : ObjectState where TO : Object<TS>
     {
 
         public StoryboardRenderer MainRenderer { get; private set; }
-
+        
         public StoryboardRendererEaser<TS> Easer { get; private set; }
 
         public new TO Component { get; private set; }
+
+        public override Type ObjectType => typeof(TO);
 
         public StoryboardRendererProvider Provider => StoryboardRendererProvider.Instance;
 
@@ -68,6 +89,7 @@ namespace Cytoid.Storyboard
 
         public override void Dispose()
         {
+            if (IsDisposed) return;
             MainRenderer = null;
             Component = null;
             if (equivalentTransform != null)
@@ -75,6 +97,7 @@ namespace Cytoid.Storyboard
                 UnityEngine.Object.Destroy(equivalentTransform);
             }
             equivalentTransform = null;
+            base.Dispose();
         }
 
         public virtual void Update(TS fromState, TS toState)
@@ -89,6 +112,7 @@ namespace Cytoid.Storyboard
 
         public override void Update(ObjectState fromState, ObjectState toState)
         {
+            if (IsDisposed || MainRenderer == null) return;
             Update((TS) fromState, (TS) toState);
             UpdateEquivalentTransform();
         }
@@ -162,7 +186,7 @@ namespace Cytoid.Storyboard
             }
             equivalentTransform.transform.localPosition = Vector3.zero;
             equivalentTransform.transform.localScale = Vector3.one;
-
+            
             UpdateEquivalentTransform();
         }
 
@@ -191,7 +215,7 @@ namespace Cytoid.Storyboard
                     // World -> Canvas
                     var pos = Transform.position;
                     var screenPos = MainRenderer.Camera.WorldToScreenPoint(pos);
-
+                    
                     rectTransform.anchoredPosition = new Vector2(
                         screenPos.x * MainRenderer.Constants.WorldToCanvasXMultiplier,
                         screenPos.y * MainRenderer.Constants.WorldToCanvasYMultiplier
@@ -199,7 +223,7 @@ namespace Cytoid.Storyboard
                 }
             }
         }
-
+        
         protected virtual Transform GetParentTransform()
         {
             if (Component.ParentId != null)
@@ -211,5 +235,5 @@ namespace Cytoid.Storyboard
         }
 
     }
-
+    
 }

--- a/engines/unity/Assets/Scripts/Storyboard/StoryboardRenderer.cs
+++ b/engines/unity/Assets/Scripts/Storyboard/StoryboardRenderer.cs
@@ -148,51 +148,92 @@ namespace Cytoid.Storyboard
             if (predicate == default) predicate = _ => true;
             if (transformer == default) transformer = _ => _;
             var renderers = new List<TR>();
-            var tasks = new List<UniTask>();
-            foreach (var obj in objects)
+            try
             {
-                if (!predicate(obj)) continue;
-                var transformedObj = transformer(obj);
-                
-                var renderer = rendererCreator(transformedObj);
-                if (ComponentRenderers.ContainsKey(transformedObj.Id))
+                // Phase 1: validate parent/target, then publish. Failures here never leave a
+                // half-registered id, and no Initialize is in flight yet.
+                foreach (var obj in objects)
                 {
-                    Debug.LogWarning($"Storyboard: Object {transformedObj.Id} is already spawned");
-                    continue;
-                }
-                ComponentRenderers[transformedObj.Id] = renderer;
-                TypedComponentRenderers[typeof(TO)].Add(renderer);
-                // Debug.Log($"StoryboardRenderer: Spawned {typeof(TO).Name} with ID {obj.Id}");
-                
-                // Resolve parent
-                StoryboardComponentRenderer parent = null;
-                if (transformedObj.ParentId != null)
-                {
-                    if (!ComponentRenderers.ContainsKey(transformedObj.ParentId))
-                    {
-                        throw new InvalidOperationException($"Storyboard: parent_id \"{transformedObj.ParentId}\" does not exist");
-                    }
-                    parent = ComponentRenderers[transformedObj.ParentId];
-                }
-                else if (transformedObj.TargetId != null)
-                {
-                    if (!ComponentRenderers.ContainsKey(transformedObj.TargetId))
-                    {
-                        throw new InvalidOperationException($"Storyboard: target_id \"{transformedObj.TargetId}\" does not exist");
-                    }
-                    parent = ComponentRenderers[transformedObj.TargetId] as TR ?? throw new InvalidOperationException($"Storyboard: target_id \"{transformedObj.TargetId} does not have type {typeof(TR).Name}");
-                }
-                if (parent != null)
-                {
-                    parent.Children.Add(renderer);
-                    renderer.Parent = parent;
-                }
-                
-                tasks.Add(renderer.Initialize());
-            }
+                    if (!predicate(obj)) continue;
+                    var transformedObj = transformer(obj);
 
-            await UniTask.WhenAll(tasks);
-            return renderers;
+                    if (ComponentRenderers.ContainsKey(transformedObj.Id))
+                    {
+                        Debug.LogWarning($"Storyboard: Object {transformedObj.Id} is already spawned");
+                        continue;
+                    }
+
+                    var renderer = rendererCreator(transformedObj);
+
+                    StoryboardComponentRenderer parent = null;
+                    if (transformedObj.ParentId != null)
+                    {
+                        if (!ComponentRenderers.ContainsKey(transformedObj.ParentId))
+                        {
+                            throw new InvalidOperationException($"Storyboard: parent_id \"{transformedObj.ParentId}\" does not exist");
+                        }
+                        parent = ComponentRenderers[transformedObj.ParentId];
+                    }
+                    else if (transformedObj.TargetId != null)
+                    {
+                        if (!ComponentRenderers.ContainsKey(transformedObj.TargetId))
+                        {
+                            throw new InvalidOperationException($"Storyboard: target_id \"{transformedObj.TargetId}\" does not exist");
+                        }
+                        parent = ComponentRenderers[transformedObj.TargetId] as TR ?? throw new InvalidOperationException($"Storyboard: target_id \"{transformedObj.TargetId} does not have type {typeof(TR).Name}");
+                    }
+
+                    ComponentRenderers[transformedObj.Id] = renderer;
+                    TypedComponentRenderers[typeof(TO)].Add(renderer);
+                    if (parent != null)
+                    {
+                        parent.Children.Add(renderer);
+                        renderer.Parent = parent;
+                    }
+
+                    renderers.Add(renderer);
+                }
+
+                // Phase 2: initialize; any failure rolls back every renderer published above.
+                var tasks = new List<UniTask>(renderers.Count);
+                foreach (var renderer in renderers)
+                    tasks.Add(InitializeSpawnedRenderer(renderer));
+
+                await UniTask.WhenAll(tasks);
+                return renderers;
+            }
+            catch
+            {
+                // Drop any renderers published by this call so trigger retries and bulk init
+                // cannot keep a half-initialized id after SpawnObjectByIdLogged swallows the error.
+                foreach (var renderer in renderers)
+                    RollbackSpawnedRenderer(renderer);
+                throw;
+            }
+        }
+
+        private async UniTask InitializeSpawnedRenderer(StoryboardComponentRenderer renderer)
+        {
+            try
+            {
+                await renderer.Initialize();
+            }
+            catch
+            {
+                RollbackSpawnedRenderer(renderer);
+                throw;
+            }
+        }
+
+        private void RollbackSpawnedRenderer(StoryboardComponentRenderer renderer)
+        {
+            if (renderer?.Component?.Id == null) return;
+            var id = renderer.Component.Id;
+            if (!ComponentRenderers.TryGetValue(id, out var current) || current != renderer) return;
+            // Cascade children first: DestroyObject Dispose()-clears Children without
+            // destroying them, and concurrent SpawnObjectById children are not in the
+            // failing SpawnObjects renderers list for the outer catch to roll back.
+            DestroyObjectsById(id);
         }
 
         public void OnGameUpdate(Game _)
@@ -203,8 +244,9 @@ namespace Cytoid.Storyboard
             var updateOrder = new[]
                 {typeof(NoteController), typeof(Text), typeof(Sprite), typeof(Line), typeof(Video), typeof(Controller)};
 
-            // Insertion order is parent/self then descendants; destroy in reverse so
-            // children run first (same invariant as DestroyObjectsById).
+            // Flatten is already post-order (descendants then root). Enqueue in that order and
+            // destroy forward so children/borrowers run before their owner (same invariant as
+            // DestroyObjectsById). Do not reverse Flatten output.
             var renderersToDestroy = new List<string>();
             var renderersToDestroySet = new HashSet<string>();
             void EnqueueDestroy(string id)
@@ -228,7 +270,6 @@ namespace Cytoid.Storyboard
                         // Destroy the target as well
                         if (renderer.Parent != null && renderer.Component.TargetId != null)
                         {
-                            EnqueueDestroy(renderer.Parent.Component.Id);
                             this.ListOf(renderer.Parent).Flatten(it => it.Children).ForEach(it =>
                             {
                                 EnqueueDestroy(it.Component.Id);
@@ -249,7 +290,7 @@ namespace Cytoid.Storyboard
                 }
             }
 
-            for (var i = renderersToDestroy.Count - 1; i >= 0; i--)
+            for (var i = 0; i < renderersToDestroy.Count; i++)
             {
                 var id = renderersToDestroy[i];
                 if (!ComponentRenderers.TryGetValue(id, out var renderer)) continue;
@@ -330,11 +371,23 @@ namespace Cytoid.Storyboard
             if (renderer == null) return;
 
             DetachFromParent(renderer);
-            renderer.Dispose();
+            try
+            {
+                renderer.Dispose();
+            }
+            finally
+            {
+                if (TypedComponentRenderers.TryGetValue(renderer.ObjectType, out var list))
+                    list.Remove(renderer);
 
-            if (TypedComponentRenderers.TryGetValue(renderer.ObjectType, out var list))
-                list.Remove(renderer);
-            ComponentRenderers.Remove(id);
+                // Identity guard: if Dispose re-entered spawn for the same id, do not
+                // remove the replacement instance from ComponentRenderers.
+                if (ComponentRenderers.TryGetValue(id, out var current) &&
+                    ReferenceEquals(current, renderer))
+                {
+                    ComponentRenderers.Remove(id);
+                }
+            }
         }
 
         private static void DetachFromParent(StoryboardComponentRenderer renderer)

--- a/engines/unity/Assets/Scripts/Storyboard/StoryboardRenderer.cs
+++ b/engines/unity/Assets/Scripts/Storyboard/StoryboardRenderer.cs
@@ -203,7 +203,7 @@ namespace Cytoid.Storyboard
             var updateOrder = new[]
                 {typeof(NoteController), typeof(Text), typeof(Sprite), typeof(Line), typeof(Video), typeof(Controller)};
 
-            var renderersToDestroy = new Dictionary<string, Type>();
+            var renderersToDestroy = new HashSet<string>();
 
             foreach (var type in updateOrder)
             {
@@ -220,10 +220,10 @@ namespace Cytoid.Storyboard
                         // Destroy the target as well
                         if (renderer.Parent != null && renderer.Component.TargetId != null)
                         {
-                            renderersToDestroy[renderer.Parent.Component.Id] = type;
+                            renderersToDestroy.Add(renderer.Parent.Component.Id);
                             this.ListOf(renderer.Parent).Flatten(it => it.Children).ForEach(it =>
                             {
-                                renderersToDestroy[it.Component.Id] = type;
+                                renderersToDestroy.Add(it.Component.Id);
                             });
                         }
                         else
@@ -231,7 +231,7 @@ namespace Cytoid.Storyboard
                             renderer.Parent?.Children.Remove(renderer);
                             this.ListOf(renderer).Flatten(it => it.Children).ForEach(it =>
                             {
-                                renderersToDestroy[it.Component.Id] = type;
+                                renderersToDestroy.Add(it.Component.Id);
                             });
                         }
                         continue;
@@ -241,16 +241,11 @@ namespace Cytoid.Storyboard
                 }
             }
 
-            renderersToDestroy.ForEach(it =>
+            foreach (var id in renderersToDestroy)
             {
-                var id = it.Key;
-                var type = it.Value;
-                var renderer = ComponentRenderers[id];
-                
-                renderer.Dispose();
-                ComponentRenderers.Remove(id);
-                TypedComponentRenderers[type].Remove(renderer);
-            });
+                if (!ComponentRenderers.TryGetValue(id, out var renderer)) continue;
+                DestroyObject(id, renderer);
+            }
         }
 
         public void OnTrigger(Trigger trigger)
@@ -260,7 +255,7 @@ namespace Cytoid.Storyboard
             {
                 foreach (var id in trigger.Spawn)
                 {
-                    SpawnObjectById(id);
+                    SpawnObjectById(id).Forget();
                 }
             }
 
@@ -274,7 +269,7 @@ namespace Cytoid.Storyboard
             }
         }
 
-        public async void SpawnObjectById(string id)
+        public async UniTask SpawnObjectById(string id)
         {
             bool Predicate<TO>(TO obj) where TO : Object => obj.Id == id;
             TO Transformer<TO, TS>(TO obj) where TO : Object<TS> where TS : ObjectState
@@ -284,22 +279,46 @@ namespace Cytoid.Storyboard
                 return res;
             }
             if (Storyboard.Texts.ContainsKey(id)) await SpawnObjects<Text, TextState, TextRenderer>(new List<Text> {Storyboard.Texts[id]}, text => new TextRenderer(this, text), Predicate, Transformer<Text, TextState>);
-            if (Storyboard.Sprites.ContainsKey(id)) await SpawnObjects<Sprite, SpriteState, SpriteRenderer>(new List<Sprite> {Storyboard.Sprites[id]}, sprite => new SpriteRenderer(this, sprite), Predicate, Transformer<Sprite, SpriteState>);
-            if (Storyboard.Lines.ContainsKey(id)) await SpawnObjects<Line, LineState, LineRenderer>(new List<Line> {Storyboard.Lines[id]}, line => new LineRenderer(this, line), Predicate, Transformer<Line, LineState>);
-            if (Storyboard.Videos.ContainsKey(id)) await SpawnObjects<Video, VideoState, VideoRenderer>(new List<Video> {Storyboard.Videos[id]}, line => new VideoRenderer(this, line), Predicate, Transformer<Video, VideoState>);
-            if (Storyboard.Controllers.ContainsKey(id)) await SpawnObjects<Controller, ControllerState, ControllerRenderer>(new List<Controller> {Storyboard.Controllers[id]}, controller => new ControllerRenderer(this, controller), Predicate, Transformer<Controller, ControllerState>);
-            if (Storyboard.NoteControllers.ContainsKey(id)) await SpawnObjects<NoteController, NoteControllerState, NoteControllerRenderer>(new List<NoteController> {Storyboard.NoteControllers[id]}, noteController => new NoteControllerRenderer(this, noteController), Predicate, Transformer<NoteController, NoteControllerState>);
+            else if (Storyboard.Sprites.ContainsKey(id)) await SpawnObjects<Sprite, SpriteState, SpriteRenderer>(new List<Sprite> {Storyboard.Sprites[id]}, sprite => new SpriteRenderer(this, sprite), Predicate, Transformer<Sprite, SpriteState>);
+            else if (Storyboard.Lines.ContainsKey(id)) await SpawnObjects<Line, LineState, LineRenderer>(new List<Line> {Storyboard.Lines[id]}, line => new LineRenderer(this, line), Predicate, Transformer<Line, LineState>);
+            else if (Storyboard.Videos.ContainsKey(id)) await SpawnObjects<Video, VideoState, VideoRenderer>(new List<Video> {Storyboard.Videos[id]}, line => new VideoRenderer(this, line), Predicate, Transformer<Video, VideoState>);
+            else if (Storyboard.Controllers.ContainsKey(id)) await SpawnObjects<Controller, ControllerState, ControllerRenderer>(new List<Controller> {Storyboard.Controllers[id]}, controller => new ControllerRenderer(this, controller), Predicate, Transformer<Controller, ControllerState>);
+            else if (Storyboard.NoteControllers.ContainsKey(id)) await SpawnObjects<NoteController, NoteControllerState, NoteControllerRenderer>(new List<NoteController> {Storyboard.NoteControllers[id]}, noteController => new NoteControllerRenderer(this, noteController), Predicate, Transformer<NoteController, NoteControllerState>);
         }
 
         public void DestroyObjectsById(string id)
         {
-            if (!ComponentRenderers.ContainsKey(id)) return;
-            ComponentRenderers[id].Let(it =>
+            if (!ComponentRenderers.TryGetValue(id, out var renderer)) return;
+
+            // Cascade children/borrowers first so owner teardown cannot leave dangling shared refs.
+            var children = renderer.Children.ToList();
+            foreach (var child in children)
             {
-                it.Dispose();
-                TypedComponentRenderers[it.GetType()].Remove(it);
-            });
+                if (child?.Component?.Id != null)
+                    DestroyObjectsById(child.Component.Id);
+            }
+
+            if (!ComponentRenderers.TryGetValue(id, out renderer)) return;
+            DestroyObject(id, renderer);
+        }
+
+        public void DestroyObject(string id, StoryboardComponentRenderer renderer)
+        {
+            if (renderer == null) return;
+
+            DetachFromParent(renderer);
+            renderer.Dispose();
+
+            if (TypedComponentRenderers.TryGetValue(renderer.ObjectType, out var list))
+                list.Remove(renderer);
             ComponentRenderers.Remove(id);
+        }
+
+        private static void DetachFromParent(StoryboardComponentRenderer renderer)
+        {
+            if (renderer.Parent == null) return;
+            renderer.Parent.Children.Remove(renderer);
+            renderer.Parent = null;
         }
 
         public void RecalculateTime<TO, TS>(TO obj) where TO : Object<TS> where TS : ObjectState

--- a/engines/unity/Assets/Scripts/Storyboard/StoryboardRenderer.cs
+++ b/engines/unity/Assets/Scripts/Storyboard/StoryboardRenderer.cs
@@ -101,21 +101,33 @@ namespace Cytoid.Storyboard
             {
                 TypedComponentRenderers[type] = new List<StoryboardComponentRenderer>();
             }
-            
-            var timer = new BenchmarkTimer("StoryboardRenderer initialization");
-            bool Predicate<TO>(TO obj) where TO : Object => !obj.IsManuallySpawned(); await SpawnObjects<NoteController, NoteControllerState, NoteControllerRenderer>(Storyboard.NoteControllers.Values.ToList(), noteController => new NoteControllerRenderer(this, noteController), Predicate);
-            timer.Time("NoteController"); // Spawn note placeholder transforms
-            await SpawnObjects<Text, TextState, TextRenderer>(Storyboard.Texts.Values.ToList(), text => new TextRenderer(this, text), Predicate);
-            timer.Time("Text");
-            await SpawnObjects<Sprite, SpriteState, SpriteRenderer>(Storyboard.Sprites.Values.ToList(), sprite => new SpriteRenderer(this, sprite), Predicate);
-            timer.Time("Sprite");
-            await SpawnObjects<Line, LineState, LineRenderer>(Storyboard.Lines.Values.ToList(), line => new LineRenderer(this, line), Predicate);
-            timer.Time("Line");
-            await SpawnObjects<Video, VideoState, VideoRenderer>(Storyboard.Videos.Values.ToList(), line => new VideoRenderer(this, line), Predicate);
-            timer.Time("Video");
-            await SpawnObjects<Controller, ControllerState, ControllerRenderer>(Storyboard.Controllers.Values.ToList(), controller => new ControllerRenderer(this, controller), Predicate);
-            timer.Time("Controller");
-            timer.Time();
+
+            try
+            {
+                var timer = new BenchmarkTimer("StoryboardRenderer initialization");
+                bool Predicate<TO>(TO obj) where TO : Object => !obj.IsManuallySpawned();
+                await SpawnObjects<NoteController, NoteControllerState, NoteControllerRenderer>(Storyboard.NoteControllers.Values.ToList(), noteController => new NoteControllerRenderer(this, noteController), Predicate);
+                timer.Time("NoteController"); // Spawn note placeholder transforms
+                await SpawnObjects<Text, TextState, TextRenderer>(Storyboard.Texts.Values.ToList(), text => new TextRenderer(this, text), Predicate);
+                timer.Time("Text");
+                await SpawnObjects<Sprite, SpriteState, SpriteRenderer>(Storyboard.Sprites.Values.ToList(), sprite => new SpriteRenderer(this, sprite), Predicate);
+                timer.Time("Sprite");
+                await SpawnObjects<Line, LineState, LineRenderer>(Storyboard.Lines.Values.ToList(), line => new LineRenderer(this, line), Predicate);
+                timer.Time("Line");
+                await SpawnObjects<Video, VideoState, VideoRenderer>(Storyboard.Videos.Values.ToList(), line => new VideoRenderer(this, line), Predicate);
+                timer.Time("Video");
+                await SpawnObjects<Controller, ControllerState, ControllerRenderer>(Storyboard.Controllers.Values.ToList(), controller => new ControllerRenderer(this, controller), Predicate);
+                timer.Time("Controller");
+                timer.Time();
+            }
+            catch
+            {
+                // SpawnObjects only rolls back its own batch. Earlier successful type batches would
+                // otherwise remain registered, and Game catches storyboard init failures without
+                // calling Dispose (listeners below are registered only on success).
+                Dispose();
+                throw;
+            }
 
             // Clear on abort/retry/complete
             Game.onGameDisposed.AddListener(_ =>

--- a/engines/unity/Assets/Scripts/Storyboard/StoryboardRenderer.cs
+++ b/engines/unity/Assets/Scripts/Storyboard/StoryboardRenderer.cs
@@ -255,7 +255,7 @@ namespace Cytoid.Storyboard
             {
                 foreach (var id in trigger.Spawn)
                 {
-                    SpawnObjectById(id).Forget();
+                    SpawnObjectByIdLogged(id).Forget();
                 }
             }
 
@@ -269,8 +269,22 @@ namespace Cytoid.Storyboard
             }
         }
 
+        async UniTaskVoid SpawnObjectByIdLogged(string id)
+        {
+            try
+            {
+                await SpawnObjectById(id);
+            }
+            catch (Exception ex)
+            {
+                Debug.LogException(ex);
+            }
+        }
+
         public async UniTask SpawnObjectById(string id)
         {
+            // Storyboard object ids are unique across component kinds; else-if matches that contract
+            // (legacy multi-if could spawn the same id from multiple dictionaries).
             bool Predicate<TO>(TO obj) where TO : Object => obj.Id == id;
             TO Transformer<TO, TS>(TO obj) where TO : Object<TS> where TS : ObjectState
             {

--- a/engines/unity/Assets/Scripts/Storyboard/StoryboardRenderer.cs
+++ b/engines/unity/Assets/Scripts/Storyboard/StoryboardRenderer.cs
@@ -203,7 +203,15 @@ namespace Cytoid.Storyboard
             var updateOrder = new[]
                 {typeof(NoteController), typeof(Text), typeof(Sprite), typeof(Line), typeof(Video), typeof(Controller)};
 
-            var renderersToDestroy = new HashSet<string>();
+            // Insertion order is parent/self then descendants; destroy in reverse so
+            // children run first (same invariant as DestroyObjectsById).
+            var renderersToDestroy = new List<string>();
+            var renderersToDestroySet = new HashSet<string>();
+            void EnqueueDestroy(string id)
+            {
+                if (renderersToDestroySet.Add(id))
+                    renderersToDestroy.Add(id);
+            }
 
             foreach (var type in updateOrder)
             {
@@ -220,10 +228,10 @@ namespace Cytoid.Storyboard
                         // Destroy the target as well
                         if (renderer.Parent != null && renderer.Component.TargetId != null)
                         {
-                            renderersToDestroy.Add(renderer.Parent.Component.Id);
+                            EnqueueDestroy(renderer.Parent.Component.Id);
                             this.ListOf(renderer.Parent).Flatten(it => it.Children).ForEach(it =>
                             {
-                                renderersToDestroy.Add(it.Component.Id);
+                                EnqueueDestroy(it.Component.Id);
                             });
                         }
                         else
@@ -231,7 +239,7 @@ namespace Cytoid.Storyboard
                             renderer.Parent?.Children.Remove(renderer);
                             this.ListOf(renderer).Flatten(it => it.Children).ForEach(it =>
                             {
-                                renderersToDestroy.Add(it.Component.Id);
+                                EnqueueDestroy(it.Component.Id);
                             });
                         }
                         continue;
@@ -241,8 +249,9 @@ namespace Cytoid.Storyboard
                 }
             }
 
-            foreach (var id in renderersToDestroy)
+            for (var i = renderersToDestroy.Count - 1; i >= 0; i--)
             {
+                var id = renderersToDestroy[i];
                 if (!ComponentRenderers.TryGetValue(id, out var renderer)) continue;
                 DestroyObject(id, renderer);
             }

--- a/engines/unity/Assets/Scripts/Storyboard/Texts/TextRenderer.cs
+++ b/engines/unity/Assets/Scripts/Storyboard/Texts/TextRenderer.cs
@@ -7,16 +7,18 @@ namespace Cytoid.Storyboard.Texts
 {
     public class TextRenderer : StoryboardComponentRenderer<Text, TextState>
     {
-
+        
         public UnityEngine.UI.Text Text { get; private set; }
-
+        
         public LetterSpacing LetterSpacing { get; private set; }
-
+        
         public RectTransform RectTransform { get; private set; }
-
+        
         public Canvas Canvas { get; private set; }
-
+        
         public CanvasGroup CanvasGroup { get; private set; }
+
+        private bool ownsResources;
 
         public TextRenderer(StoryboardRenderer mainRenderer, Text component) : base(mainRenderer, component)
         {
@@ -28,9 +30,11 @@ namespace Cytoid.Storyboard.Texts
 
         public override async UniTask Initialize()
         {
+            BeginInitialize();
             var targetRenderer = GetTargetRenderer<TextRenderer>();
             if (targetRenderer != null)
             {
+                ownsResources = false;
                 Text = targetRenderer.Text;
                 LetterSpacing = targetRenderer.LetterSpacing;
                 RectTransform = targetRenderer.RectTransform;
@@ -39,6 +43,7 @@ namespace Cytoid.Storyboard.Texts
             }
             else
             {
+                ownsResources = true;
                 Text = Instantiate(Provider.TextPrefab, GetParentTransform());
                 RectTransform = Text.rectTransform;
                 LetterSpacing = Text.GetComponent<LetterSpacing>();
@@ -53,23 +58,38 @@ namespace Cytoid.Storyboard.Texts
         }
 
         public override StoryboardRendererEaser<TextState> CreateEaser() => new TextEaser(this);
-
+        
         public override void Clear()
         {
-            Text.text = "";
-            Text.fontSize = 20;
-            Text.alignment = TextAnchor.MiddleCenter;
-            Text.color = UnityEngine.Color.white;
-            LetterSpacing.enabled = false;
-            LetterSpacing.Spacing = 0;
-            CanvasGroup.alpha = 0;
+            if (Text != null)
+            {
+                Text.text = "";
+                Text.fontSize = 20;
+                Text.alignment = TextAnchor.MiddleCenter;
+                Text.color = UnityEngine.Color.white;
+            }
+            if (LetterSpacing != null)
+            {
+                LetterSpacing.enabled = false;
+                LetterSpacing.Spacing = 0;
+            }
+            if (CanvasGroup != null)
+                CanvasGroup.alpha = 0;
             IsTransformActive = false;
         }
 
         public override void Dispose()
         {
-            Destroy(Text.gameObject);
+            if (IsDisposed) return;
+            if (ownsResources && Text != null)
+                Destroy(Text.gameObject);
             Text = null;
+            LetterSpacing = null;
+            RectTransform = null;
+            Canvas = null;
+            CanvasGroup = null;
+            ownsResources = false;
+            base.Dispose();
         }
 
     }

--- a/engines/unity/Assets/Scripts/Storyboard/Videos/VideoRenderer.cs
+++ b/engines/unity/Assets/Scripts/Storyboard/Videos/VideoRenderer.cs
@@ -27,6 +27,8 @@ namespace Cytoid.Storyboard.Videos
         private bool ownsResources;
         private bool prepareCompleted;
         private bool hasEnded;
+        /// <summary>Owner of the shared VideoPlayer; borrowers read ended state from here.</summary>
+        private VideoRenderer sharedPlaybackOwner;
         private VideoPlayer.EventHandler prepareCompletedHandler;
         private VideoPlayer.EventHandler loopPointReachedHandler;
 
@@ -45,6 +47,7 @@ namespace Cytoid.Storyboard.Videos
             if (targetRenderer != null)
             {
                 ownsResources = false;
+                sharedPlaybackOwner = targetRenderer;
                 VideoPlayer = targetRenderer.VideoPlayer;
                 RawImage = targetRenderer.RawImage;
                 RenderTexture = targetRenderer.RenderTexture;
@@ -54,6 +57,7 @@ namespace Cytoid.Storyboard.Videos
             else
             {
                 ownsResources = true;
+                sharedPlaybackOwner = this;
                 VideoPlayer = Instantiate(Provider.VideoVideoPlayerPrefab);
                 RawImage = Instantiate(Provider.VideoRawImagePrefab, Provider.Canvas.transform);
                 RenderTexture = new RenderTexture(UnityEngine.Screen.width / 2, UnityEngine.Screen.height / 2, 0, RenderTextureFormat.ARGB32);
@@ -125,9 +129,18 @@ namespace Cytoid.Storyboard.Videos
                 hasEnded = true;
         }
 
+        /// <summary>
+        /// Ended is owned by the resource owner so target_id borrowers honor the same gate.
+        /// </summary>
+        private bool HasSharedPlaybackEnded =>
+            sharedPlaybackOwner != null &&
+            !sharedPlaybackOwner.IsDisposed &&
+            sharedPlaybackOwner.hasEnded;
+
         public override void Clear()
         {
-            hasEnded = false;
+            if (ownsResources)
+                hasEnded = false;
             if (ownsResources && VideoPlayer != null)
                 VideoPlayer.Stop();
             if (RawImage != null)
@@ -157,6 +170,7 @@ namespace Cytoid.Storyboard.Videos
             Canvas = null;
             ownsResources = false;
             hasEnded = false;
+            sharedPlaybackOwner = null;
             base.Dispose();
         }
 
@@ -191,8 +205,9 @@ namespace Cytoid.Storyboard.Videos
             }
             else if (!VideoPlayer.isPlaying)
             {
-                // Non-loop clips must not restart every frame after natural end.
-                if (hasEnded && !VideoPlayer.isLooping) return;
+                // Non-loop clips must not restart every frame after natural end
+                // (owner and target_id borrowers share this gate).
+                if (HasSharedPlaybackEnded && !VideoPlayer.isLooping) return;
                 VideoPlayer.Play();
             }
         }

--- a/engines/unity/Assets/Scripts/Storyboard/Videos/VideoRenderer.cs
+++ b/engines/unity/Assets/Scripts/Storyboard/Videos/VideoRenderer.cs
@@ -26,11 +26,14 @@ namespace Cytoid.Storyboard.Videos
 
         private bool ownsResources;
         private bool prepareCompleted;
+        private bool hasEnded;
         private VideoPlayer.EventHandler prepareCompletedHandler;
+        private VideoPlayer.EventHandler loopPointReachedHandler;
 
         public VideoRenderer(StoryboardRenderer mainRenderer, Video component) : base(mainRenderer, component)
         {
             prepareCompletedHandler = OnPrepareCompleted;
+            loopPointReachedHandler = OnLoopPointReached;
         }
 
         public override StoryboardRendererEaser<VideoState> CreateEaser() => new VideoEaser(this);
@@ -88,6 +91,7 @@ namespace Cytoid.Storyboard.Videos
                 VideoPlayer.renderMode = VideoRenderMode.RenderTexture;
                 VideoPlayer.targetTexture = RenderTexture;
                 RawImage.texture = RenderTexture;
+                VideoPlayer.loopPointReached += loopPointReachedHandler;
 
                 prepareCompleted = false;
                 VideoPlayer.prepareCompleted += prepareCompletedHandler;
@@ -115,8 +119,15 @@ namespace Cytoid.Storyboard.Videos
 
         private void OnPrepareCompleted(VideoPlayer _) => prepareCompleted = true;
 
+        private void OnLoopPointReached(VideoPlayer _)
+        {
+            if (VideoPlayer != null && !VideoPlayer.isLooping)
+                hasEnded = true;
+        }
+
         public override void Clear()
         {
+            hasEnded = false;
             if (ownsResources && VideoPlayer != null)
                 VideoPlayer.Stop();
             if (RawImage != null)
@@ -128,6 +139,7 @@ namespace Cytoid.Storyboard.Videos
         {
             if (IsDisposed) return;
             UnsubscribePrepareCompleted();
+            UnsubscribeLoopPointReached();
             if (ownsResources)
             {
                 if (VideoPlayer != null) Destroy(VideoPlayer.gameObject);
@@ -144,6 +156,7 @@ namespace Cytoid.Storyboard.Videos
             RectTransform = null;
             Canvas = null;
             ownsResources = false;
+            hasEnded = false;
             base.Dispose();
         }
 
@@ -151,6 +164,12 @@ namespace Cytoid.Storyboard.Videos
         {
             if (VideoPlayer != null && prepareCompletedHandler != null)
                 VideoPlayer.prepareCompleted -= prepareCompletedHandler;
+        }
+
+        private void UnsubscribeLoopPointReached()
+        {
+            if (ownsResources && VideoPlayer != null && loopPointReachedHandler != null)
+                VideoPlayer.loopPointReached -= loopPointReachedHandler;
         }
 
         public override void Update(VideoState fromState, VideoState toState)
@@ -172,6 +191,8 @@ namespace Cytoid.Storyboard.Videos
             }
             else if (!VideoPlayer.isPlaying)
             {
+                // Non-loop clips must not restart every frame after natural end.
+                if (hasEnded && !VideoPlayer.isLooping) return;
                 VideoPlayer.Play();
             }
         }

--- a/engines/unity/Assets/Scripts/Storyboard/Videos/VideoRenderer.cs
+++ b/engines/unity/Assets/Scripts/Storyboard/Videos/VideoRenderer.cs
@@ -24,17 +24,24 @@ namespace Cytoid.Storyboard.Videos
 
         public override bool IsOnCanvas => true;
 
+        private bool ownsResources;
+        private bool prepareCompleted;
+        private VideoPlayer.EventHandler prepareCompletedHandler;
+
         public VideoRenderer(StoryboardRenderer mainRenderer, Video component) : base(mainRenderer, component)
         {
+            prepareCompletedHandler = OnPrepareCompleted;
         }
 
         public override StoryboardRendererEaser<VideoState> CreateEaser() => new VideoEaser(this);
 
         public override async UniTask Initialize()
         {
+            var version = BeginInitialize();
             var targetRenderer = GetTargetRenderer<VideoRenderer>();
             if (targetRenderer != null)
             {
+                ownsResources = false;
                 VideoPlayer = targetRenderer.VideoPlayer;
                 RawImage = targetRenderer.RawImage;
                 RenderTexture = targetRenderer.RenderTexture;
@@ -43,6 +50,7 @@ namespace Cytoid.Storyboard.Videos
             }
             else
             {
+                ownsResources = true;
                 VideoPlayer = Instantiate(Provider.VideoVideoPlayerPrefab);
                 RawImage = Instantiate(Provider.VideoRawImagePrefab, Provider.Canvas.transform);
                 RenderTexture = new RenderTexture(UnityEngine.Screen.width / 2, UnityEngine.Screen.height / 2, 0, RenderTextureFormat.ARGB32);
@@ -81,32 +89,68 @@ namespace Cytoid.Storyboard.Videos
                 VideoPlayer.targetTexture = RenderTexture;
                 RawImage.texture = RenderTexture;
 
-                var prepareCompleted = false;
-                VideoPlayer.prepareCompleted += _ => prepareCompleted = true;
-                VideoPlayer.Prepare();
-                var startTime = DateTimeOffset.UtcNow;
-                await UniTask.WaitUntil(() => prepareCompleted || DateTimeOffset.UtcNow - startTime > TimeSpan.FromSeconds(5));
-                if (!prepareCompleted)
+                prepareCompleted = false;
+                VideoPlayer.prepareCompleted += prepareCompletedHandler;
+                try
                 {
-                    Debug.Log($"Android version code: {Context.AndroidVersionCode}");
-                    Debug.Log($"Video path: {path}");
-                    Debug.LogError("Could not load video. Are you using Android Q or above?");
+                    VideoPlayer.Prepare();
+                    var startTime = DateTimeOffset.UtcNow;
+                    await UniTask.WaitUntil(() =>
+                        prepareCompleted || IsInitializeStale(version) ||
+                        DateTimeOffset.UtcNow - startTime > TimeSpan.FromSeconds(5));
+                    if (IsInitializeStale(version)) return;
+                    if (!prepareCompleted)
+                    {
+                        Debug.Log($"Android version code: {Context.AndroidVersionCode}");
+                        Debug.Log($"Video path: {path}");
+                        Debug.LogError("Could not load video. Are you using Android Q or above?");
+                    }
+                }
+                finally
+                {
+                    UnsubscribePrepareCompleted();
                 }
             }
         }
 
+        private void OnPrepareCompleted(VideoPlayer _) => prepareCompleted = true;
+
         public override void Clear()
         {
-            VideoPlayer.Stop();
-            RawImage.color = UnityEngine.Color.white.WithAlpha(0);
+            if (ownsResources && VideoPlayer != null)
+                VideoPlayer.Stop();
+            if (RawImage != null)
+                RawImage.color = UnityEngine.Color.white.WithAlpha(0);
             IsTransformActive = false;
         }
 
         public override void Dispose()
         {
-            Destroy(VideoPlayer.gameObject);
-            Destroy(RawImage.gameObject);
-            Destroy(RenderTexture);
+            if (IsDisposed) return;
+            UnsubscribePrepareCompleted();
+            if (ownsResources)
+            {
+                if (VideoPlayer != null) Destroy(VideoPlayer.gameObject);
+                if (RawImage != null) Destroy(RawImage.gameObject);
+                if (RenderTexture != null)
+                {
+                    RenderTexture.Release();
+                    Destroy(RenderTexture);
+                }
+            }
+            VideoPlayer = null;
+            RawImage = null;
+            RenderTexture = null;
+            RectTransform = null;
+            Canvas = null;
+            ownsResources = false;
+            base.Dispose();
+        }
+
+        private void UnsubscribePrepareCompleted()
+        {
+            if (VideoPlayer != null && prepareCompletedHandler != null)
+                VideoPlayer.prepareCompleted -= prepareCompletedHandler;
         }
 
         public override void Update(VideoState fromState, VideoState toState)
@@ -117,7 +161,7 @@ namespace Cytoid.Storyboard.Videos
 
         public void SyncPlaybackWithGameState()
         {
-            if (VideoPlayer == null || MainRenderer == null) return;
+            if (VideoPlayer == null || MainRenderer == null || IsDisposed) return;
 
             if (!MainRenderer.Game.State.IsPlaying)
             {

--- a/engines/unity/Assets/Scripts/Utils/AssetMemory.cs
+++ b/engines/unity/Assets/Scripts/Utils/AssetMemory.cs
@@ -57,13 +57,14 @@ public class AssetMemory
         {
             await UniTask.WaitUntil(() => !loadingPaths.Contains(path), cancellationToken: cancellationToken);
             var loaded = GetCachedAssetEntry<T>(path);
-            if (loaded == null)
+            if (loaded != null)
             {
-                throw new InvalidOperationException($"Concurrent asset load failed: {path}");
+                loaded.Tags.Add(tag);
+                return loaded.Asset;
             }
 
-            loaded.Tags.Add(tag);
-            return loaded.Asset;
+            // Leader failed or disposed the entry before waiters woke; retry as a fresh load.
+            return await LoadAsset<T>(path, tag, cancellationToken);
         }
 
         EnforceTagLimit(tag);

--- a/engines/unity/Assets/Scripts/Utils/TextureScaler.cs
+++ b/engines/unity/Assets/Scripts/Utils/TextureScaler.cs
@@ -22,13 +22,22 @@ public class TextureScaler
     public static Texture2D Scaled(Texture2D src, int width, int height, FilterMode mode = FilterMode.Trilinear)
     {
         Rect texR = new Rect(0, 0, width, height);
-        _gpu_scale(src, width, height, mode);
+        var previous = RenderTexture.active;
+        RenderTexture rtt = null;
+        try
+        {
+            rtt = _gpu_scale(src, width, height, mode);
 
-        //Get rendered data back to a new texture
-        Texture2D result = new Texture2D(width, height, TextureFormat.ARGB32, true);
-        result.Reinitialize(width, height);
-        result.ReadPixels(texR, 0, 0, true);
-        return result;
+            //Get rendered data back to a new texture
+            Texture2D result = new Texture2D(width, height, TextureFormat.ARGB32, true);
+            result.Reinitialize(width, height);
+            result.ReadPixels(texR, 0, 0, true);
+            return result;
+        }
+        finally
+        {
+            ReleaseTemporary(rtt, previous);
+        }
     }
 
     /// <summary>
@@ -41,12 +50,21 @@ public class TextureScaler
     public static void Scale(Texture2D tex, int width, int height, FilterMode mode = FilterMode.Trilinear)
     {
         Rect texR = new Rect(0, 0, width, height);
-        _gpu_scale(tex, width, height, mode);
+        var previous = RenderTexture.active;
+        RenderTexture rtt = null;
+        try
+        {
+            rtt = _gpu_scale(tex, width, height, mode);
 
-        // Update new texture
-        tex.Reinitialize(width, height);
-        tex.ReadPixels(texR, 0, 0, true);
-        tex.Apply(true); //Remove this if you hate us applying textures for you :)
+            // Update new texture
+            tex.Reinitialize(width, height);
+            tex.ReadPixels(texR, 0, 0, true);
+            tex.Apply(true); //Remove this if you hate us applying textures for you :)
+        }
+        finally
+        {
+            ReleaseTemporary(rtt, previous);
+        }
     }
     
     public static Texture2D FitCrop(Texture2D tex, int width, int height, FilterMode mode = FilterMode.Trilinear)
@@ -57,29 +75,38 @@ public class TextureScaler
         var ratio = tex.width * 1.0f / tex.height;
         // Debug.Log($"Width: {width}, Height: {height}, Texture width: {tex.width}, Texture height: {tex.height}, Target ratio: {targetRatio}, Texture ratio: {ratio}");
         Rect texR;
-        if (targetRatio < ratio)
+        var previous = RenderTexture.active;
+        RenderTexture rtt = null;
+        try
         {
-            var toWidth = tex.width * height * 1.0f / tex.height;
-            texR = new Rect((int) ((toWidth - width) / 2), 0, width, height);
-            _gpu_scale(tex, (int) toWidth, height, mode);
-            // Debug.Log($"To width: {toWidth}, Rect: {texR}");
-            result.ReadPixels(texR, 0, 0, true);
+            if (targetRatio < ratio)
+            {
+                var toWidth = tex.width * height * 1.0f / tex.height;
+                texR = new Rect((int) ((toWidth - width) / 2), 0, width, height);
+                rtt = _gpu_scale(tex, (int) toWidth, height, mode);
+                // Debug.Log($"To width: {toWidth}, Rect: {texR}");
+                result.ReadPixels(texR, 0, 0, true);
+            }
+            else
+            {
+                var toHeight = tex.height * width * 1.0f / tex.width;
+                texR = new Rect(0, (int) ((toHeight - height) / 2), width, height);
+                rtt = _gpu_scale(tex, width, (int) toHeight, mode);
+                // Debug.Log($"To height: {toHeight}, Rect: {texR}");
+                result.ReadPixels(texR, 0, 0, true);
+            }
+            result.Apply();
+            return result;
         }
-        else
+        finally
         {
-            var toHeight = tex.height * width * 1.0f / tex.width;
-            texR = new Rect(0, (int) ((toHeight - height) / 2), width, height);
-            _gpu_scale(tex, width, (int) toHeight, mode);
-            // Debug.Log($"To height: {toHeight}, Rect: {texR}");
-            result.ReadPixels(texR, 0, 0, true);
+            ReleaseTemporary(rtt, previous);
         }
-        result.Apply();
-
-        return result;
     }
 
     // Internal unility that renders the source texture into the RTT - the scaling method itself.
-    static void _gpu_scale(Texture2D src, int width, int height, FilterMode fmode)
+    // Caller must release the returned RenderTexture and restore the previous active RT.
+    static RenderTexture _gpu_scale(Texture2D src, int width, int height, FilterMode fmode)
     {
         //We need the source texture in VRAM because we render with it
         src.filterMode = fmode;
@@ -97,5 +124,14 @@ public class TextureScaler
         //Then clear & draw the texture to fill the entire RTT.
         GL.Clear(true, true, new Color(0, 0, 0, 0));
         Graphics.DrawTexture(new Rect(0, 0, 1, 1), src);
+        return rtt;
+    }
+
+    static void ReleaseTemporary(RenderTexture temporary, RenderTexture previous)
+    {
+        RenderTexture.active = previous;
+        if (temporary == null) return;
+        temporary.Release();
+        Object.Destroy(temporary);
     }
 }


### PR DESCRIPTION
## Summary
- Stop Storyboard trigger `foreach` mutation that throws on Uses/Score remove.
- Destroy by `ObjectType`, cascade children, and only dispose owned `target_id` resources.
- Guard Sprite/Video init against destroy-during-await; release temporary TextureScaler RTs.
- Stop non-loop Storyboard videos from restarting every frame after natural end (`hasEnded` + `loopPointReached`).

## Test plan
- [ ] Trigger Uses/Score destroy no longer throws mid-foreach.
- [ ] Shared `target_id` resources survive child destroy.
- [ ] Destroy during Sprite/Video init does not leave half-initialized state.
- [ ] Non-loop video ends once and stays ended; pause/resume still works; Clear/replay resets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved storyboard trigger handling to prevent missed or incorrectly repeated triggers.
  * Strengthened cleanup and ownership handling for text, sprite, video, line, and controller resources.
  * Improved video initialization, playback synchronization, and timeout handling.
  * Ensured temporary textures are released and previous render targets are restored.
  * Improved recursive object removal and cleanup of spawned storyboard elements.
  * Improved recovery when asset loading is interrupted and prevented stale sprite updates.

* **Tests**
  * Added coverage for trigger lifecycle behavior, renderer disposal, texture cleanup, and shared-resource protection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->