### PR TITLE
fix(gameplay): NaN guards and end-of-play lifecycle cleanup

### DIFF
--- a/engines/unity/Assets/Scripts/Game/Chart/Chart.cs
+++ b/engines/unity/Assets/Scripts/Game/Chart/Chart.cs
@@ -179,6 +179,11 @@ public class Chart
                 speed /= 1.5f;
             }
 
+            // Final speed (mods × AR × experimental) must stay positive/finite for intro/scale.
+            const float minNoteSpeed = 1e-4f;
+            if (float.IsNaN(speed) || float.IsInfinity(speed) || speed <= minNoteSpeed)
+                speed = 1f;
+
             note.start_time = ConvertToTime((float) note.tick);
             note.end_time = ConvertToTime((float) (note.tick + note.hold_tick));
 

--- a/engines/unity/Assets/Scripts/Game/EffectController.cs
+++ b/engines/unity/Assets/Scripts/Game/EffectController.cs
@@ -343,10 +343,11 @@ public class EffectController : MonoBehaviour
     
     private async void AwaitAndCollect(Effect effect, ParticleSystem particle)
     {
+        var generation = game.ObjectPool.Generation;
         var main = particle.main;
         var waitSeconds = main.duration / Mathf.Max(1e-4f, main.simulationSpeed);
         await UniTask.Delay(TimeSpan.FromSeconds(waitSeconds));
-        if (this == null) return;
+        if (this == null || game.ObjectPool == null || game.ObjectPool.Generation != generation) return;
         game.ObjectPool.CollectEffect(effect, particle);
     }
 

--- a/engines/unity/Assets/Scripts/Game/EffectController.cs
+++ b/engines/unity/Assets/Scripts/Game/EffectController.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using Cysharp.Threading.Tasks;
 using UnityEngine;
 
@@ -17,6 +18,7 @@ public class EffectController : MonoBehaviour
     public Transform EffectParentTransform { get; private set; }
     
     private float clearEffectSizeMultiplier;
+    private readonly Dictionary<Effect, float> prefabDurations = new Dictionary<Effect, float>();
 
     /// <summary>Outer diameter at ring spawn; matches legacy FlatFX ripple preset.</summary>
     const float ClearRingStartDiameter = 1f;
@@ -57,7 +59,20 @@ public class EffectController : MonoBehaviour
     public void OnGameLoaded()
     {
         clearEffectSizeMultiplier = Context.Player.Settings.ClearEffectsSize;
+        CachePrefabDurations();
     }
+
+    private void CachePrefabDurations()
+    {
+        prefabDurations.Clear();
+        foreach (Effect effect in Enum.GetValues(typeof(Effect)))
+        {
+            prefabDurations[effect] = GetPrefab(effect).main.duration;
+        }
+    }
+
+    private float PrefabDuration(Effect effect) =>
+        prefabDurations.TryGetValue(effect, out var duration) ? duration : GetPrefab(effect).main.duration;
 
     private void ExpireSoftBudgetIfStale()
     {
@@ -254,11 +269,11 @@ public class EffectController : MonoBehaviour
             fx.Stop();
 
             var mainModule = fx.main;
+            mainModule.duration = PrefabDuration(Effect.Miss);
             mainModule.simulationSpeed = 0.3f;
-            mainModule.duration /= 0.3f;
             mainModule.startColor = game.Config.NoteGradeEffectColors[grade];
 
-            if (isDragType) fx.transform.localScale = new Vector3(2, 2, 2);
+            fx.transform.localScale = isDragType ? new Vector3(2, 2, 2) : Vector3.one;
 
             fx.Play();
             AwaitAndCollect(Effect.Miss, fx);
@@ -303,11 +318,11 @@ public class EffectController : MonoBehaviour
             }
 
             var mainModule = fx.main;
+            mainModule.duration = PrefabDuration(clearEffect);
             mainModule.simulationSpeed = speed;
-            mainModule.duration /= speed;
             mainModule.startColor = color.WithAlpha(1);
 
-            if (isDragType) fx.transform.localScale = new Vector3(3f, 3f, 3f);
+            fx.transform.localScale = isDragType ? new Vector3(3f, 3f, 3f) : Vector3.one;
 
             fx.Play();
             AwaitAndCollect(clearEffect, fx);
@@ -328,7 +343,9 @@ public class EffectController : MonoBehaviour
     
     private async void AwaitAndCollect(Effect effect, ParticleSystem particle)
     {
-        await UniTask.Delay(TimeSpan.FromSeconds(particle.main.duration));
+        var main = particle.main;
+        var waitSeconds = main.duration / Mathf.Max(1e-4f, main.simulationSpeed);
+        await UniTask.Delay(TimeSpan.FromSeconds(waitSeconds));
         if (this == null) return;
         game.ObjectPool.CollectEffect(effect, particle);
     }

--- a/engines/unity/Assets/Scripts/Game/InputController.cs
+++ b/engines/unity/Assets/Scripts/Game/InputController.cs
@@ -78,6 +78,26 @@ public class InputController : MonoBehaviour
         GameTouchInput.FingerDown -= OnFingerDown;
         GameTouchInput.FingerUpdate -= OnFingerUpdate;
         GameTouchInput.FingerUp -= OnFingerUp;
+        ResetBindingsWithoutJudgment();
+    }
+
+    /// <summary>
+    /// Release Hold/Flick finger ownership without producing new judgments.
+    /// Used by pause, Fail/Complete/Dispose via <see cref="DisableInput"/>.
+    /// </summary>
+    public void ResetBindingsWithoutJudgment()
+    {
+        HoldingNotes.Values.ForEach(note =>
+        {
+            note.HoldingFingers.Clear();
+        });
+        HoldingNotes.Clear();
+
+        FlickingNotes.Values.ForEach(note =>
+        {
+            if (!note.IsCleared) note.StopFlicking();
+        });
+        FlickingNotes.Clear();
     }
 
     public void OnNoteCollected(Note note)
@@ -96,17 +116,7 @@ public class InputController : MonoBehaviour
 
     public void OnGamePaused(Game game)
     {
-        HoldingNotes.Values.ForEach(note =>
-        {
-            note.HoldingFingers.Clear();
-        });
-        HoldingNotes.Clear();
-
-        FlickingNotes.Values.ForEach(note =>
-        {
-            if (!note.IsCleared) note.StopFlicking();
-        });
-        FlickingNotes.Clear();
+        ResetBindingsWithoutJudgment();
     }
 
     public void OnGameUpdate(Game game)

--- a/engines/unity/Assets/Scripts/Game/Notes/DragHeadNote.cs
+++ b/engines/unity/Assets/Scripts/Game/Notes/DragHeadNote.cs
@@ -89,7 +89,10 @@ public class DragHeadNote : Note
         if (Game.Time >= Model.start_time)
         {
             // Consume zero-span edges in the same frame so same-tick chains do not linger on NaN/u=Inf.
-            while (true)
+            // Cap iterations against malformed charts with cyclic next_id and non-increasing start_time.
+            var maxEdgeSteps = Chart.note_map.Count + 1;
+            var edgeSteps = 0;
+            while (edgeSteps++ < maxEdgeSteps)
             {
                 var fromPos = (hasFromNote && fromNote != this)
                     ? fromNote.transform.localPosition

--- a/engines/unity/Assets/Scripts/Game/Notes/DragHeadNote.cs
+++ b/engines/unity/Assets/Scripts/Game/Notes/DragHeadNote.cs
@@ -88,41 +88,45 @@ public class DragHeadNote : Note
 
         if (Game.Time >= Model.start_time)
         {
-            // Move drag head
-            if (FromNoteModel.id == 523)
+            // Consume zero-span edges in the same frame so same-tick chains do not linger on NaN/u=Inf.
+            while (true)
             {
-                if (hasFromNote && fromNote != this)
-                {
-                    print(fromNote.transform.localPosition);
-                }
-                else
-                {
-                    print(FromNoteModel.CalculatePosition(Game.Chart));
-                }
-            }
-            
-            transform.localPosition = Vector3.Lerp(
-                (hasFromNote && fromNote != this) ? fromNote.transform.localPosition : FromNoteModel.CalculatePosition(Game.Chart), 
-                hasToNote ? toNote.transform.localPosition : ToNoteModel.CalculatePosition(Game.Chart),
-                (Game.Time - FromNoteModel.start_time) / (ToNoteModel.start_time - FromNoteModel.start_time));
+                var fromPos = (hasFromNote && fromNote != this)
+                    ? fromNote.transform.localPosition
+                    : FromNoteModel.CalculatePosition(Game.Chart);
+                var toPos = hasToNote
+                    ? toNote.transform.localPosition
+                    : ToNoteModel.CalculatePosition(Game.Chart);
 
-            // Moved to next note?
-            if (Game.Time >= ToNoteModel.start_time)
-            {
-                if (ToNoteModel == EndNoteModel) // Last note
-                {
-                    transform.localPosition = hasToNote ? toNote.transform.localPosition : ToNoteModel.CalculatePosition(Game.Chart);
-                }
+                var span = ToNoteModel.start_time - FromNoteModel.start_time;
+                float u;
+                if (span > 0f)
+                    u = Mathf.Clamp01((Game.Time - FromNoteModel.start_time) / span);
                 else
+                    u = Game.Time >= ToNoteModel.start_time ? 1f : 0f;
+
+                transform.localPosition = Vector3.Lerp(fromPos, toPos, u);
+
+                if (Game.Time < ToNoteModel.start_time)
+                    break;
+
+                if (ToNoteModel == EndNoteModel)
                 {
-                    FromNoteModel = ToNoteModel;
-                    ToNoteModel = Chart.note_map[FromNoteModel.next_id];
-                    
-                    hasFromNote = false;
-                    hasToNote = false;
-                    fromNote = null;
-                    toNote = null;
+                    transform.localPosition = toPos;
+                    break;
                 }
+
+                FromNoteModel = ToNoteModel;
+                ToNoteModel = Chart.note_map[FromNoteModel.next_id];
+                hasFromNote = false;
+                hasToNote = false;
+                fromNote = null;
+                toNote = null;
+
+                if (Game.SpawnedNotes.TryGetValue(FromNoteModel.id, out fromNote))
+                    hasFromNote = true;
+                if (Game.SpawnedNotes.TryGetValue(ToNoteModel.id, out toNote))
+                    hasToNote = true;
             }
 
             // Moving to or already at last note

--- a/engines/unity/Assets/Scripts/Game/Notes/DragLineElement.cs
+++ b/engines/unity/Assets/Scripts/Game/Notes/DragLineElement.cs
@@ -143,7 +143,11 @@ public class DragLineElement : MonoBehaviour
             introRatio = time < FromNoteModel.nextdraglinestarttime ? 1.0f : 0.0f;
         }
 
-        outroRatio = (time - FromNoteModel.start_time) / (ToNoteModel.start_time - FromNoteModel.start_time);
+        var outroSpan = ToNoteModel.start_time - FromNoteModel.start_time;
+        if (outroSpan > 0f)
+            outroRatio = (time - FromNoteModel.start_time) / outroSpan;
+        else
+            outroRatio = time < FromNoteModel.start_time ? 0f : 1f;
 
         if (introRatio > 0 && introRatio < 1)
         {

--- a/engines/unity/Assets/Scripts/Game/Notes/HoldNote.cs
+++ b/engines/unity/Assets/Scripts/Game/Notes/HoldNote.cs
@@ -45,7 +45,9 @@ public class HoldNote : Note
             {
                 HeldDuration = 0;
             }
-            HoldProgress = (Game.Time - (Model.start_time + JudgmentOffset)) / Model.Duration;
+            HoldProgress = Model.Duration > 1e-4f
+                ? (Game.Time - (Model.start_time + JudgmentOffset)) / Model.Duration
+                : (Game.Time >= Model.start_time + JudgmentOffset ? 1f : 0f);
             
             if (!playedHitSoundAtBegin && HoldProgress >= 0 && Context.Player.Settings.HoldHitSoundTiming.Let(it => it == HoldHitSoundTiming.Begin || it == HoldHitSoundTiming.Both))
             {

--- a/engines/unity/Assets/Scripts/Game/ObjectPool.cs
+++ b/engines/unity/Assets/Scripts/Game/ObjectPool.cs
@@ -29,6 +29,11 @@ public class ObjectPool
     private readonly DragLinePoolItem dragLinePoolItem = new DragLinePoolItem();
     private readonly Dictionary<EffectController.Effect, PrefabPoolItem> effectPoolItems = new Dictionary<EffectController.Effect, PrefabPoolItem>();
 
+    /// <summary>
+    /// Bumped on <see cref="Dispose"/> so delayed FX collect callbacks can no-op.
+    /// </summary>
+    public int Generation { get; private set; }
+
     public Game Game { get; }
 
     public ObjectPool(Game game)
@@ -110,9 +115,19 @@ public class ObjectPool
 
     public void Dispose()
     {
+        Generation++;
+
         SpawnedNotes.Values.ForEach(it => it.Dispose());
+        SpawnedNotes.Clear();
         notePoolItems.Values.ForEach(it => it.Dispose());
+
+        // Active drag lines are not in the pool queue.
+        foreach (var line in SpawnedDragLines.Values.ToList())
+            line.Dispose();
+        SpawnedDragLines.Clear();
         dragLinePoolItem.Dispose();
+
+        effectPoolItems.Values.ForEach(it => it.Dispose());
     }
 
     public Note SpawnNote(ChartModel.Note model)
@@ -333,14 +348,19 @@ public class ObjectPool
 
     public class PrefabPoolItem : PoolItem<ParticleSystem, ParticleSystemInstantiateProvider, ParticleSystemSpawnProvider>
     {
+        private readonly List<ParticleSystem> allItems = new List<ParticleSystem>();
+
         public override ParticleSystem OnInstantiate(Game game, ParticleSystemInstantiateProvider arguments)
         {
-            return Object.Instantiate(arguments.Prefab, arguments.Parent, true);
+            var particle = Object.Instantiate(arguments.Prefab, arguments.Parent, true);
+            allItems.Add(particle);
+            return particle;
         }
 
         public override void OnSpawn(Game game, ParticleSystem particle, ParticleSystemSpawnProvider arguments)
         {
             particle.gameObject.SetActive(true);
+            particle.transform.localScale = Vector3.one;
             if (arguments.Parent != default)
             {
                 var transform = particle.transform;
@@ -358,12 +378,15 @@ public class ObjectPool
         {
             if (particle == null || particle.gameObject == null) return;
             particle.Stop();
+            particle.transform.localScale = Vector3.one;
             particle.gameObject.SetActive(false);
         }
 
         public override void Dispose()
         {
-            PooledItems.ForEach(Object.Destroy);
+            allItems.ForEach(Object.Destroy);
+            allItems.Clear();
+            PooledItems.Clear();
         }
     }
 


### PR DESCRIPTION
## Summary
- Guard zero-span DragHead/DragLine and zero-duration Hold so ratios stay finite.
- Restore pooled Clear FX duration/scale; dispose active DragLines/effects on teardown.
- Reset Hold/Flick bindings without judgment on pause/Fail/Complete/Dispose.
- Sanitize non-finite note speed before intro bake.

## Test plan
- [ ] Same-tick drag chain settles to a finite position; line outro completes.
- [ ] Zero-duration hold completes without NaN visuals.
- [ ] Long session Clear/Miss FX keep expected duration/scale; exit cleans pools.
- [ ] Pause/fail/complete then re-reserve Flick works.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of extremely short, invalid, or zero-duration notes and transitions.
  * Fixed drag notes advancing through multiple segments correctly within a single frame.
  * Improved pause and input shutdown behavior by releasing active flick and hold interactions cleanly.
  * Prevented visual effects from retaining incorrect scale or continuing after their pool is reset.
  * Improved cleanup of active drag lines and particle effects when gameplay objects are disposed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->