### PR TITLE
fix(notes): aim drag rotation at overridden next-note position

### DIFF
--- a/engines/unity/Assets/Scripts/Game/Notes/Note.cs
+++ b/engines/unity/Assets/Scripts/Game/Notes/Note.cs
@@ -241,7 +241,11 @@ public abstract class Note : MonoBehaviour
             }
 
             var position = transform.localPosition;
-            var nextPosition = hasNextNote ? nextNote.transform.localPosition : NextNoteModel.position;
+            // Unspawned next notes must use CalculatePosition so Storyboard Override applies
+            // (baked .position would aim drag lines/heads at the pre-override chart coord).
+            var nextPosition = hasNextNote
+                ? nextNote.transform.localPosition
+                : NextNoteModel.CalculatePosition(Game.Chart);
 
             if (position == nextPosition)
                 Model.rotation = Vector3.zero;


### PR DESCRIPTION
﻿## Summary
- Unspawned next-note drag rotation now uses `CalculatePosition` so Storyboard Override is respected (was baked `.position`).

## Test plan
- [ ] Override a drag child off chart before it appears; line/head aim at override, not baked coord
- [ ] After child spawns, orientation still tracks live transform


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved positioning for upcoming notes before they appear in the game.
  * Existing spawned notes continue to use their current in-game positions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->